### PR TITLE
chore(Cargo.lock): change package version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "rustnet-monitor"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "aes",
  "anyhow",


### PR DESCRIPTION
I just uploaded the package to the Arch Linux AUR repository ([1](https://aur.archlinux.org/packages/rustnet-git)). According to the [Arch Linux wiki](https://wiki.archlinux.org/title/Rust_package_guidelines#Prepare), I should use `cargo fetch --locked` to download the required libraries for the build, as `--locked` is used for reproducible builds. However, since the package version in `Cargo.lock` is still 0.8.0, adding `--locked` will result in an error. Therefore, I want to correct the version number so that I can add `--locked`.