### PR TITLE
feat: add JSON logging for SIEM integration (#9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,6 +1785,8 @@ dependencies = [
  "procfs",
  "ratatui",
  "ring",
+ "serde",
+ "serde_json",
  "simple-logging",
  "simplelog",
  "windows",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ chrono = "0.4"
 ratatui = { version = "0.29", features = ["all-widgets"] }
 ring = "0.17"
 aes = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,4 +49,11 @@ pub fn build_cli() -> Command {
                 .help("Set the log level (if not provided, no logging will be enabled)")
                 .required(false),
         )
+        .arg(
+            Arg::new("json-log")
+                .long("json-log")
+                .value_name("FILE")
+                .help("Enable JSON logging of connection events to specified file")
+                .required(false),
+        )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,11 @@ fn main() -> Result<()> {
         info!("Deep packet inspection disabled");
     }
 
+    if let Some(json_log_path) = matches.get_one::<String>("json-log") {
+        config.json_log_file = Some(json_log_path.to_string());
+        info!("JSON logging enabled: {}", json_log_path);
+    }
+
     // Set up terminal
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = ui::setup_terminal(backend)?;


### PR DESCRIPTION
## Summary

Adds optional JSON logging of connection events for SIEM tools and log processors.

Implements a lightweight, focused solution as requested in #9.

## Changes

- New `--json-log <FILE>` CLI flag to specify output file  
- Logs two event types: `new_connection` and `connection_closed`
- Includes connection details (IPs, ports, protocol)
- Includes DPI information when available (domains, SNI, etc.)
- Includes traffic statistics on connection close (bytes, duration)
- Clean JSON lines format (one event per line)

## Implementation

Events are logged at two connection lifecycle points:
1. When connection is first detected
2. When connection is cleaned up/closed

## Example Output

```json
{"timestamp":"2025-10-11T12:49:41.846363643+00:00","event":"new_connection","protocol":"UDP","source_ip":"192.168.1.10","source_port":50124,"destination_ip":"8.8.8.8","destination_port":53,"dpi_protocol":"DNS (porcini.us-east.host.bsky.network)","dpi_domain":"porcini.us-east.host.bsky.network"}
{"timestamp":"2025-10-11T12:49:42.622658316+00:00","event":"new_connection","protocol":"UDP","source_ip":"192.168.1.10","source_port":52545,"destination_ip":"142.250.178.234","destination_port":443,"dpi_protocol":"QUIC (naler-pa.clients6.google.com)","dpi_domain":"naler-pa.clients6.google.com"}
```

## Usage

```bash
sudo rustnet --json-log /var/log/rustnet_events.json
```

Users can forward logs to SIEM using existing tools like rsyslog or filebeat.

Thanks to @Conor0Callaghan for #29 which helped creating this implementation.

Closes #9