### PR TITLE
feat: make eBPF default on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,12 +95,8 @@ jobs:
         run: |
           mkdir -p "$RUSTNET_ASSET_DIR"
           # build.rs will handle Npcap SDK download on Windows
-          # Use linux-default feature for all Linux targets to enable eBPF
-          if [[ "${{ matrix.target }}" == *"linux"* ]]; then
-            ${{ matrix.cargo }} build --verbose --release --target ${{ matrix.target }} --features "linux-default"
-          else
-            ${{ matrix.cargo }} build --verbose --release --target ${{ matrix.target }}
-          fi
+          # eBPF is now enabled by default on Linux, no need for explicit feature flag
+          ${{ matrix.cargo }} build --verbose --release --target ${{ matrix.target }}
 
       - name: Create release archive
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,11 @@ windows = { version = "0.61", features = [
 libbpf-cargo = "0.25"
 
 [features]
-default = []
-linux-default = ["ebpf"]
+# eBPF is enabled by default for enhanced performance on Linux.
+# On non-Linux platforms, this feature has no effect as all eBPF code
+# and dependencies are Linux-specific (guarded by target_os checks).
+default = ["ebpf"]
+linux-default = ["ebpf"]  # Deprecated: kept for backwards compatibility
 ebpf = ["libbpf-rs", "bytes", "libc"]
 
 # Minimal cross configuration to override dependency conflicts
@@ -105,7 +108,7 @@ Features:
 - Process identification and service name resolution
 - Advanced filtering with vim/fzf-style search
 - Multi-threaded processing for optimal performance
-- Optional eBPF support for enhanced Linux performance
+- eBPF-enhanced process detection on Linux (with automatic fallback)
 """
 depends = "libpcap0.8, libelf1"
 section = "net"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ COPY resources/ebpf/vmlinux ./resources/ebpf/vmlinux
 COPY src ./src
 COPY assets/services ./assets/services
 
-# Build the application in release mode with eBPF support
-RUN cargo build --release --features "linux-default"
+# Build the application in release mode (eBPF is enabled by default on Linux)
+RUN cargo build --release
 
 # Runtime stage - use trixie-slim to match GLIBC version from builder
 FROM debian:trixie-slim

--- a/EBPF_BUILD.md
+++ b/EBPF_BUILD.md
@@ -2,6 +2,8 @@
 
 This document explains how to work with eBPF kernel headers in this project.
 
+**Note:** eBPF is now enabled by default on Linux builds. This guide provides detailed information about the eBPF implementation and how to customize the build.
+
 ## Current Setup
 
 The project bundles **architecture-specific vmlinux.h files** from the [libbpf/vmlinux.h](https://github.com/libbpf/vmlinux.h) repository. This eliminates network dependencies during builds and ensures reproducible builds.
@@ -58,27 +60,34 @@ After updating, commit the changes to the repository.
 
 ## Building with eBPF Support
 
-To build rustnet with eBPF support on Linux:
+eBPF is enabled by default on Linux. To build rustnet:
 
 ```bash
 # Install build dependencies
 sudo apt-get install libelf-dev clang llvm  # Debian/Ubuntu
 sudo yum install elfutils-libelf-devel clang llvm  # RedHat/CentOS/Fedora
 
-# Build with eBPF feature
-cargo build --release --features ebpf
+# Build in release mode (eBPF is enabled by default)
+cargo build --release
 
 # The bundled vmlinux.h files will be used automatically
 # No network access required!
 ```
 
+To build **without** eBPF support (procfs-only mode):
+
+```bash
+# Build without eBPF
+cargo build --release --no-default-features
+```
+
 ## Testing eBPF Functionality
 
-After building with eBPF support, test that it works correctly:
+After building (eBPF is enabled by default), test that it works correctly:
 
 ```bash
 # Option 1: Run with sudo (always works)
-sudo cargo run --features ebpf
+sudo cargo run --release
 
 # Option 2: Set capabilities (Linux only, see INSTALL.md Permissions section)
 sudo setcap 'cap_net_raw,cap_net_admin,cap_sys_admin,cap_bpf,cap_perfmon+eip' ./target/release/rustnet

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -180,10 +180,11 @@ After installation, see the [Permissions Setup](#permissions-setup) section to c
   - **Linux**: `sudo apt-get install libpcap-dev` (Debian/Ubuntu) or `sudo yum install libpcap-devel` (RedHat/CentOS)
   - **macOS**: Included by default
   - **Windows**: Install Npcap and Npcap SDK (see [Windows Build Setup](#windows-build-setup) below)
-- **For eBPF support (optional, experimental - Linux only)**:
+- **For eBPF support (enabled by default on Linux)**:
   - `sudo apt-get install libelf-dev clang llvm` (Debian/Ubuntu)
   - `sudo yum install elfutils-libelf-devel clang llvm` (RedHat/CentOS)
   - Linux kernel 4.19+ with BTF support recommended
+  - Note: eBPF automatically falls back to procfs if unavailable
 
 ### Basic Build
 
@@ -192,16 +193,16 @@ After installation, see the [Permissions Setup](#permissions-setup) section to c
 git clone https://github.com/domcyrus/rustnet.git
 cd rustnet
 
-# Build in release mode (basic functionality)
+# Build in release mode (eBPF is enabled by default on Linux)
 cargo build --release
 
-# Build with experimental eBPF support for enhanced Linux performance (Linux only)
-cargo build --release --features ebpf
+# To build WITHOUT eBPF support (procfs-only mode on Linux)
+cargo build --release --no-default-features
 
 # The executable will be in target/release/rustnet
 ```
 
-See [EBPF_BUILD.md](EBPF_BUILD.md) for detailed eBPF build instructions.
+See [EBPF_BUILD.md](EBPF_BUILD.md) for detailed eBPF information.
 
 ### Windows Build Setup
 
@@ -388,13 +389,13 @@ sudo setcap cap_net_raw,cap_net_admin=eip ~/.cargo/bin/rustnet
 rustnet
 ```
 
-**For experimental eBPF-enabled builds (enhanced Linux performance):**
+**For eBPF-enabled builds (enhanced Linux performance - enabled by default):**
 
-eBPF is an experimental feature that provides lower-overhead process identification using kernel probes:
+eBPF is enabled by default on Linux and provides lower-overhead process identification using kernel probes:
 
 ```bash
-# Build with eBPF support
-cargo build --release --features ebpf
+# Build in release mode (eBPF is enabled by default)
+cargo build --release
 
 # Try modern capabilities first (Linux 5.8+)
 sudo setcap 'cap_net_raw,cap_net_admin,cap_bpf,cap_perfmon+eip' ./target/release/rustnet
@@ -423,7 +424,7 @@ Additional capability (may be required):
 - `Process Detection: eBPF + procfs` - eBPF successfully loaded
 - `Process Detection: procfs` - Using procfs fallback
 
-**Note:** eBPF support is experimental and may have limitations with process name display. See [ARCHITECTURE.md](ARCHITECTURE.md) for details on eBPF implementation.
+**Note:** eBPF is enabled by default on Linux builds and may have limitations with process name display. See [ARCHITECTURE.md](ARCHITECTURE.md) for details on eBPF implementation. To build without eBPF, use `cargo build --release --no-default-features`.
 
 **For system-wide installation:**
 

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -14,7 +14,7 @@ cargo install flamegraph
 
 # 2. Build a release binary with debug symbols
 # IMPORTANT: Debug symbols are required for meaningful flamegraphs!
-CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release --features linux-default
+CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release
 
 # Or add this to Cargo.toml temporarily:
 # [profile.release]
@@ -41,7 +41,7 @@ If you prefer to use `perf` directly:
 
 ```bash
 # Build with debug symbols
-cargo build --release --features linux-default
+cargo build --release
 
 # Record performance data (run for 30-60 seconds, then Ctrl+C to stop)
 sudo perf record -F 99 -g ./target/release/rustnet -i eth0
@@ -131,7 +131,7 @@ If your flamegraph only shows "rustnet (100%)" with no details:
 **Solution**:
 ```bash
 # Rebuild with debug symbols
-CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release --features linux-default
+CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release
 
 # Or add to Cargo.toml:
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ A cross-platform network monitoring tool built with Rust. RustNet provides real-
 - **Optional Logging**: Detailed logging with configurable log levels (disabled by default)
 
 <details>
-<summary><b>eBPF Enhanced Process Identification (Experimental - Linux)</b></summary>
+<summary><b>eBPF Enhanced Process Identification (Linux Default)</b></summary>
 
-When built with the `ebpf` feature on Linux, RustNet uses kernel eBPF programs for enhanced performance and lower overhead process identification. However, this comes with important limitations:
+RustNet uses kernel eBPF programs by default on Linux for enhanced performance and lower overhead process identification. However, this comes with important limitations:
 
 **Process Name Limitations:**
 - eBPF uses the kernel's `comm` field, which is limited to 16 characters
@@ -44,8 +44,14 @@ When built with the `ebpf` feature on Linux, RustNet uses kernel eBPF programs f
 **Fallback Behavior:**
 - When eBPF fails to load or lacks sufficient permissions, RustNet automatically falls back to standard procfs-based process identification
 - Standard mode provides full process names but with higher CPU overhead
+- eBPF is enabled by default; no special build flags needed
 
-See [EBPF_BUILD.md](EBPF_BUILD.md) for build instructions and [ARCHITECTURE.md](ARCHITECTURE.md) for technical details.
+To disable eBPF and use procfs-only mode, build with:
+```bash
+cargo build --release --no-default-features
+```
+
+See [EBPF_BUILD.md](EBPF_BUILD.md) for more details and [ARCHITECTURE.md](ARCHITECTURE.md) for technical information.
 
 </details>
 

--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -32,14 +32,15 @@ Features include:
 - Process identification and service name resolution
 - Cross-platform support (Linux, macOS, Windows, BSD)
 - Advanced filtering with vim/fzf-style search
-- Optional eBPF support for enhanced Linux performance
+- eBPF-enhanced process detection (enabled by default with automatic fallback)
 
 %prep
 %autosetup -n %{name}-%{version}
 
 %build
 export RUSTFLAGS="%{build_rustflags}"
-cargo build --release --features "linux-default"
+# eBPF is now enabled by default, no need for explicit feature flag
+cargo build --release
 
 %install
 install -Dpm 0755 target/release/rustnet -t %{buildroot}%{_bindir}/


### PR DESCRIPTION
Makes eBPF the default build configuration on Linux for better performance and lower overhead process identification.

eBPF automatically falls back to procfs when unavailable. To build without eBPF, use `--no-default-features`.

Closes #32