### PR TITLE
docs: add Ubuntu PPA and Fedora COPR installation instructions

### DIFF
--- a/.github/workflows/copr-update-spec.yml
+++ b/.github/workflows/copr-update-spec.yml
@@ -1,0 +1,73 @@
+name: Update COPR Spec Version
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  update-spec:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          # Extract version by removing 'v' prefix
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Update RPM spec file
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SPEC_FILE="rpm/rustnet.spec"
+
+          # Update the Version: line in the spec file
+          sed -i "s/^Version:.*/Version: $VERSION/" "$SPEC_FILE"
+
+          echo "Updated $SPEC_FILE to version $VERSION"
+          echo ""
+          echo "Version line:"
+          grep "^Version:" "$SPEC_FILE"
+
+      - name: Commit and push changes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Check if there are changes to commit
+          if git diff --quiet rpm/rustnet.spec; then
+            echo "No changes to rpm/rustnet.spec (already at version $VERSION)"
+            exit 0
+          fi
+
+          # Commit and push
+          git add rpm/rustnet.spec
+          git commit -m "chore: update RPM spec to version $VERSION"
+          git push origin HEAD:main
+
+          echo "Pushed changes to main branch"
+
+      - name: Summary
+        run: |
+          echo "## 🎉 RPM Spec Updated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **File**: rpm/rustnet.spec" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "COPR will automatically rebuild the package via webhook." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View COPR Builds →](https://copr.fedorainfracloud.org/coprs/domcyrus/rustnet/builds/)" >> $GITHUB_STEP_SUMMARY

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,33 @@ Pre-built packages are available for each release on the [GitHub Releases](https
 
 ### Linux Package Installation
 
+#### Ubuntu PPA (Recommended for Ubuntu 25.10+)
+
+The easiest way to install RustNet on Ubuntu is via the official PPA.
+
+```bash
+# Add the RustNet PPA
+sudo add-apt-repository ppa:domcyrus/rustnet
+
+# Update package list
+sudo apt update
+
+# Install rustnet
+sudo apt install rustnet
+
+# Run with sudo
+sudo rustnet
+
+# Optional: Grant capabilities to run without sudo (see Permissions section)
+sudo setcap cap_net_raw,cap_net_admin=eip /usr/bin/rustnet
+rustnet
+```
+
+**Important:** The PPA only supports Ubuntu 25.10+ due to the Rust 1.88+ requirement. Earlier Ubuntu versions don't have a recent enough Rust compiler in their repositories. For older Ubuntu versions, use the [.deb packages](#debianubuntu-deb-packages) from GitHub releases or [build from source](#building-from-source).
+
 #### Debian/Ubuntu (.deb packages)
+
+For manual installation or non-Ubuntu Debian-based distributions:
 
 ```bash
 # Download the appropriate package for your architecture:
@@ -82,39 +108,43 @@ Pre-built packages are available for each release on the [GitHub Releases](https
 # - Rustnet_LinuxDEB_arm64.deb (ARM64)
 # - Rustnet_LinuxDEB_armhf.deb (ARMv7)
 
-# Install the package
+# Install the package (capabilities are automatically configured)
 sudo dpkg -i Rustnet_LinuxDEB_amd64.deb
 
 # Install dependencies if needed
 sudo apt-get install -f
 
-# Run with sudo
-sudo rustnet
-
-# Optional: Grant capabilities to run without sudo (see Permissions section)
-sudo setcap cap_net_raw,cap_net_admin=eip /usr/bin/rustnet
+# Run without sudo (capabilities were set by post-install script)
 rustnet
+
+# Verify capabilities
+getcap /usr/bin/rustnet
 ```
 
+**Note:** The .deb package automatically sets Linux capabilities via post-install script, so you can run RustNet without sudo.
+
 #### RedHat/Fedora/CentOS (.rpm packages)
+
+For manual installation or distributions not using COPR:
 
 ```bash
 # Download the appropriate package for your architecture:
 # - Rustnet_LinuxRPM_x86_64.rpm
 # - Rustnet_LinuxRPM_aarch64.rpm
 
-# Install the package
+# Install the package (capabilities are automatically configured)
 sudo rpm -i Rustnet_LinuxRPM_x86_64.rpm
 # Or with dnf/yum:
 sudo dnf install Rustnet_LinuxRPM_x86_64.rpm
 
-# Run with sudo
-sudo rustnet
-
-# Optional: Grant capabilities to run without sudo (see Permissions section)
-sudo setcap cap_net_raw,cap_net_admin=eip /usr/bin/rustnet
+# Run without sudo (capabilities were set by post-install script)
 rustnet
+
+# Verify capabilities
+getcap /usr/bin/rustnet
 ```
+
+**Note:** The .rpm package automatically sets Linux capabilities via post-install script, so you can run RustNet without sudo.
 
 #### Arch Linux (AUR)
 
@@ -131,12 +161,26 @@ yay -S rustnet
 yay -S rustnet-bin
 ```
 
-#### Fedora/RHEL/CentOS (COPR)
+#### Fedora (COPR - Recommended for Fedora 42+)
+
+The easiest way to install RustNet on Fedora is via the official COPR repository.
 
 ```bash
+# Enable the COPR repository
 sudo dnf copr enable domcyrus/rustnet
+
+# Install rustnet
 sudo dnf install rustnet
+
+# Run with sudo
+sudo rustnet
+
+# Optional: Grant capabilities to run without sudo (see Permissions section)
+sudo setcap cap_net_raw,cap_net_admin=eip /usr/bin/rustnet
+rustnet
 ```
+
+**Important:** The COPR only supports Fedora 42 and 43 due to the Rust 1.88+ requirement. CentOS and RHEL don't have recent enough Rust compilers in their repositories. For those distributions, use the [.rpm packages](#redhatfedoracentos-rpm-packages) from GitHub releases or [build from source](#building-from-source).
 
 #### Homebrew Installation
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,19 @@ See [EBPF_BUILD.md](EBPF_BUILD.md) for more details and [ARCHITECTURE.md](ARCHIT
 
 ### Installation
 
-**From crates.io (Recommended):**
+**Ubuntu PPA (Recommended for Ubuntu 25.10+ users):**
+```bash
+sudo add-apt-repository ppa:domcyrus/rustnet
+sudo apt update && sudo apt install rustnet
+```
+
+**Fedora COPR (Recommended for Fedora 42+ users):**
+```bash
+sudo dnf copr enable domcyrus/rustnet
+sudo dnf install rustnet
+```
+
+**From crates.io:**
 ```bash
 cargo install rustnet-monitor
 ```


### PR DESCRIPTION
- Add Ubuntu PPA section to INSTALL.md (requires Ubuntu 25.10+)
- Add Fedora COPR section to INSTALL.md (requires Fedora 42+)
- Update README.md Quick Start with PPA/COPR as recommended methods
- Add GitHub Actions workflow to auto-update RPM spec version on tag push