### PR TITLE
feat: remove CAP_NET_ADMIN and CAP_SYS_ADMIN, use read-only packet capture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,9 @@ LABEL org.opencontainers.image.description="A cross-platform network monitoring 
 LABEL org.opencontainers.image.source="https://github.com/domcyrus/rustnet"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"
 
-# Important: RustNet requires elevated privileges for packet capture functionality
-# Run with: docker run --cap-add=NET_RAW --cap-add=NET_ADMIN rustnet
-# Or with:  docker run --privileged rustnet
+# Important: RustNet requires elevated privileges for packet capture and eBPF functionality
+# Modern kernels (5.8+): docker run --cap-add=NET_RAW --cap-add=BPF --cap-add=PERFMON rustnet
+# Legacy kernels: docker run --cap-add=NET_RAW --cap-add=SYS_ADMIN rustnet
+# Or with: docker run --privileged rustnet
+# Note: CAP_NET_ADMIN is NOT required (uses read-only, non-promiscuous packet capture)
 ENTRYPOINT ["rustnet"]

--- a/EBPF_BUILD.md
+++ b/EBPF_BUILD.md
@@ -90,13 +90,18 @@ After building (eBPF is enabled by default), test that it works correctly:
 sudo cargo run --release
 
 # Option 2: Set capabilities (Linux only, see INSTALL.md Permissions section)
-sudo setcap 'cap_net_raw,cap_net_admin,cap_sys_admin,cap_bpf,cap_perfmon+eip' ./target/release/rustnet
+# Modern Linux (5.8+):
+sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon=eip' ./target/release/rustnet
+./target/release/rustnet
+
+# Legacy Linux (older kernels):
+sudo setcap 'cap_net_raw,cap_sys_admin=eip' ./target/release/rustnet
 ./target/release/rustnet
 
 # Check the TUI Statistics panel to verify it shows "Process Detection: eBPF + procfs"
 ```
 
-**Note**: eBPF kprobe programs require specific Linux capabilities. See [INSTALL.md - Permissions Setup](INSTALL.md#permissions-setup) for detailed capability requirements. The required capabilities may vary by kernel version.
+**Note**: eBPF kprobe programs require specific Linux capabilities. RustNet uses read-only packet capture (CAP_NET_RAW) without promiscuous mode, so CAP_NET_ADMIN is not required. Modern kernels (5.8+) need CAP_BPF and CAP_PERFMON for eBPF, while older kernels require CAP_SYS_ADMIN. See [INSTALL.md - Permissions Setup](INSTALL.md#permissions-setup) for detailed capability requirements.
 
 ## Generating vmlinux.h from Your Local Kernel (Optional)
 
@@ -141,8 +146,9 @@ This is typically not needed since the bundled headers work across kernel versio
 
 **"Permission denied" when loading eBPF**:
 - See [INSTALL.md - Permissions Setup](INSTALL.md#permissions-setup) for capability setup
-- Required capabilities: `CAP_NET_RAW`, `CAP_NET_ADMIN`, `CAP_BPF`, `CAP_PERFMON`
-- Some kernels may also require `CAP_SYS_ADMIN`
+- Required capabilities (modern kernel 5.8+): `CAP_NET_RAW`, `CAP_BPF`, `CAP_PERFMON`
+- Required capabilities (legacy kernel): `CAP_NET_RAW`, `CAP_SYS_ADMIN`
+- Note: CAP_NET_ADMIN is NOT required (RustNet uses read-only packet capture)
 
 **eBPF fails to load, falls back to procfs**:
 - This is expected behavior when eBPF can't load

--- a/MUSL_BUILD.md
+++ b/MUSL_BUILD.md
@@ -37,7 +37,7 @@ We initially attempted to include eBPF support, which required vendoring libelf 
 For users on older distributions, the `cargo install` workaround is documented:
 ```bash
 cargo install rustnet-monitor
-sudo setcap cap_net_raw,cap_net_admin=eip ~/.cargo/bin/rustnet
+sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon=eip' ~/.cargo/bin/rustnet
 ```
 
 ## Potential Future Approaches

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cargo build --release
 **Via Docker:**
 ```bash
 docker pull ghcr.io/domcyrus/rustnet:latest
-docker run --rm -it --cap-add=NET_RAW --cap-add=NET_ADMIN --net=host \
+docker run --rm -it --cap-add=NET_RAW --cap-add=BPF --cap-add=PERFMON --net=host \
   ghcr.io/domcyrus/rustnet:latest
 ```
 
@@ -98,13 +98,19 @@ docker run --rm -it --cap-add=NET_RAW --cap-add=NET_ADMIN --net=host \
 
 Packet capture requires elevated privileges. See [INSTALL.md](INSTALL.md) for detailed permission setup.
 
+> **Security Note (Linux):** RustNet uses **read-only packet capture** without promiscuous mode, requiring only `CAP_NET_RAW` (not full root or `CAP_NET_ADMIN`). This follows the principle of least privilege for enhanced security.
+
 ```bash
-# Quick start with sudo
+# Quick start with sudo (all platforms)
 sudo rustnet
 
-# Or grant capabilities to run without sudo (Linux)
-sudo setcap cap_net_raw,cap_net_admin=eip /path/to/rustnet
+# Linux: Grant minimal capabilities (recommended - no root required!)
+# Read-only packet capture + eBPF process tracking
+sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon=eip' /path/to/rustnet
 rustnet
+
+# macOS: PKTAP requires root for process metadata
+sudo rustnet  # or use 'lsof' fallback without sudo
 ```
 
 **Common options:**

--- a/USAGE.md
+++ b/USAGE.md
@@ -23,8 +23,8 @@ Packet capture requires elevated privileges on most systems. See [INSTALL.md](IN
 sudo rustnet
 
 # Or grant capabilities to run without sudo (see INSTALL.md for details)
-# Linux example:
-sudo setcap cap_net_raw,cap_net_admin=eip /path/to/rustnet
+# Linux example (modern kernel 5.8+):
+sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon=eip' /path/to/rustnet
 rustnet
 ```
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -9,12 +9,11 @@ case "$1" in
         # This allows rustnet to run as a normal user with enhanced eBPF process detection
         if command -v setcap >/dev/null 2>&1; then
             # Try modern capabilities first (Linux 5.8+)
-            # CAP_NET_RAW, CAP_NET_ADMIN: packet capture
-            # CAP_BPF, CAP_PERFMON: eBPF support
-            # CAP_SYS_ADMIN: may be required for kprobe attachment on some kernel versions
-            setcap 'cap_net_raw,cap_net_admin,cap_sys_admin,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet 2>/dev/null || \
+            # CAP_NET_RAW: read-only packet capture (non-promiscuous mode)
+            # CAP_BPF, CAP_PERFMON: eBPF support for enhanced process tracking
+            setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet 2>/dev/null || \
                 # Fallback for older kernels without CAP_BPF/CAP_PERFMON
-                setcap 'cap_net_raw,cap_net_admin,cap_sys_admin+eip' /usr/bin/rustnet || true
+                setcap 'cap_net_raw,cap_sys_admin+eip' /usr/bin/rustnet || true
         fi
 
         cat <<EOF
@@ -29,18 +28,21 @@ NETWORK PACKET CAPTURE PERMISSIONS:
   To verify permissions are set correctly:
     getcap /usr/bin/rustnet
 
-  Expected output (Linux 5.8+):
-    /usr/bin/rustnet cap_net_raw,cap_net_admin,cap_sys_admin,cap_bpf,cap_perfmon=eip
+  Expected output (modern Linux 5.8+):
+    /usr/bin/rustnet cap_net_raw,cap_bpf,cap_perfmon=eip
 
-  Or for older kernels:
-    /usr/bin/rustnet cap_net_raw,cap_net_admin,cap_sys_admin=eip
+  Or for legacy kernels (pre-5.8):
+    /usr/bin/rustnet cap_net_raw,cap_sys_admin=eip
 
   If capabilities are not set, you can manually set them:
-    # For Linux 5.8+ with eBPF support
-    sudo setcap 'cap_net_raw,cap_net_admin,cap_sys_admin,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet
+    # For modern Linux 5.8+ with eBPF support
+    sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet
 
-    # Or for older kernels
-    sudo setcap 'cap_net_raw,cap_net_admin,cap_sys_admin+eip' /usr/bin/rustnet
+    # Or for legacy kernels without CAP_BPF support
+    sudo setcap 'cap_net_raw,cap_sys_admin+eip' /usr/bin/rustnet
+
+  Note: RustNet uses read-only packet capture (no promiscuous mode).
+        CAP_NET_ADMIN is NOT required.
 
   Alternatively, run rustnet with sudo:
     sudo rustnet


### PR DESCRIPTION
## Summary

This PR removes the `CAP_NET_ADMIN` requirement and eliminates the need for `CAP_SYS_ADMIN` on modern kernels by using non-promiscuous mode for packet capture. This significantly reduces the security surface by following the principle of least privilege.

- Remove promiscuous mode - hardcoded to false for read-only capture
- Remove `CAP_NET_ADMIN` from all capability checks
- Use `CAP_BPF` + `CAP_PERFMON` instead of `CAP_SYS_ADMIN` on modern kernels (5.8+)
- Updated capability checking logic in `loader.rs` and `privileges.rs`
- Removed promiscuous mode configuration from `capture.rs`

### Updated Docs
- Added prominent security notes in README and INSTALL docs
- Updated all capability examples across documentation files
- Clarified platform-specific requirements (Linux vs macOS)