### PR TITLE
Sort bandwidth by combined up+down total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Bandwidth Sorting**: Changed bandwidth sorting to use combined up+down total instead of separate up/down sorting
+  - Simpler sorting behavior: press `s` once to sort by total bandwidth
+  - Display still shows "Down/Up" with individual values
+  - Arrow indicator shows when sorting by combined bandwidth total
+
 ## [0.14.0] - 2025-10-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See [USAGE.md](USAGE.md) for detailed keyboard controls and navigation tips.
 **Sorting:**
 - Press `s` to cycle through sortable columns (Protocol, Address, State, Service, Bandwidth, Process)
 - Press `S` (Shift+s) to toggle sort direction
-- Find bandwidth hogs: Press `s` until "Down↓/Up" appears
+- Find bandwidth hogs: Press `s` until "Down/Up ↓" appears (sorts by combined up+down speed)
 
 See [USAGE.md](USAGE.md) for complete filtering syntax and sorting guide.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ The experimental eBPF support provides efficient process identification but has 
   - Direction toggle with `S` (Shift+s) for ascending/descending
   - Visual indicators: cyan/underlined active column, arrows showing direction
   - Smart defaults: bandwidth descending (show hogs), text ascending (alphabetical)
-  - Special bandwidth handling: arrows attach to specific metric (Down↓/Up or Down/Up↓)
+  - Bandwidth sorting: sorts by combined up+down bandwidth total
   - Seamless integration with filtering
 
 ### Performance & Architecture

--- a/USAGE.md
+++ b/USAGE.md
@@ -293,16 +293,10 @@ RustNet provides powerful table sorting to help you analyze network connections.
 
 ### Quick Start
 
-**Find bandwidth hogs:**
+**Find bandwidth hogs (combined up+down traffic):**
 ```
-Press 's' repeatedly until you see: Down↓/Up
-The connections with highest download bandwidth appear at the top
-```
-
-**Find top uploaders:**
-```
-Press 's' repeatedly until you see: Down/Up↓
-The connections with highest upload bandwidth appear at the top
+Press 's' repeatedly until you see: Down/Up ↓
+The connections with highest total bandwidth appear at the top
 ```
 
 **Sort by process name:**
@@ -323,8 +317,7 @@ Press `s` to cycle through columns in left-to-right order:
 | **State** | ↑ Ascending | Sort by connection state (ESTABLISHED, etc.) |
 | **Service** | ↑ Ascending | Sort by service name or port number |
 | **Application** | ↑ Ascending | Sort by detected application protocol (HTTP, DNS, etc.) |
-| **Bandwidth ↓** | ↓ Descending | Sort by **download** bandwidth (highest first by default) |
-| **Bandwidth ↑** | ↓ Descending | Sort by **upload** bandwidth (highest first by default) |
+| **Bandwidth (Down/Up)** | ↓ Descending | Sort by **combined up+down** bandwidth (highest first by default) |
 | **Process** | ↑ Ascending | Sort by process name alphabetically |
 
 ### Sort Indicators
@@ -345,30 +338,12 @@ Table title shows current sort:
 ┌─ Active Connections (Sort: Remote Addr ↑) ──┐
 ```
 
-### Bandwidth Column Special Behavior
-
-The bandwidth column shows **both download and upload** metrics. The arrow attaches to the specific metric being sorted:
-
-| Display | Sorting By | Direction | Meaning |
-|---------|------------|-----------|---------|
-| `Down↓/Up` | Download | Descending (↓) | **Highest downloads first** (bandwidth hogs) |
-| `Down↑/Up` | Download | Ascending (↑) | Lowest downloads first |
-| `Down/Up↓` | Upload | Descending (↓) | **Highest uploads first** (top uploaders) |
-| `Down/Up↑` | Upload | Ascending (↑) | Lowest uploads first |
-
-**Key points:**
-- The arrow (↑/↓) indicates **sort direction**, not bandwidth direction
-- `↓` = Descending = Highest values at top (10MB → 5MB → 1MB)
-- `↑` = Ascending = Lowest values at top (1MB → 5MB → 10MB)
-- Press `s` once on bandwidth to sort by downloads, press `s` again for uploads
-- Press `S` (Shift+s) to flip between high-to-low and low-to-high
-
 ### Sort Behavior
 
 **Press `s` (lowercase) - Cycle Columns:**
 - Moves to the next column in left-to-right visual order
 - **Resets to default direction** for that column
-- Bandwidth columns default to descending (↓) to show highest values first
+- Bandwidth column defaults to descending (↓) to show highest values first
 - Text columns default to ascending (↑) for alphabetical order
 
 **Press `S` (Shift+s) - Toggle Direction:**
@@ -390,16 +365,16 @@ Sorting works seamlessly with filtering:
 Example workflow:
 ```
 1. Press '/' and type 'firefox' to filter Firefox connections
-2. Press 's' until you see "Down↓/Up"
-3. Now viewing Firefox connections sorted by download bandwidth
+2. Press 's' until you see "Down/Up ↓"
+3. Now viewing Firefox connections sorted by total bandwidth (up+down combined)
 ```
 
 ### Examples
 
-**Find which process is downloading the most:**
+**Find which process is using the most bandwidth:**
 ```
-1. Press 's' until "Down↓/Up" appears
-2. Top connection shows the highest download rate
+1. Press 's' until "Down/Up ↓" appears
+2. Top connection shows the highest total bandwidth (up+down combined)
 3. Look at the "Process" column to see which application
 ```
 
@@ -412,9 +387,9 @@ Example workflow:
 
 **Find idle connections (lowest bandwidth):**
 ```
-1. Press 's' to cycle to "Down↓/Up"
-2. Press 'S' to toggle to "Down↑/Up" (ascending)
-3. Connections with lowest download bandwidth appear first
+1. Press 's' to cycle to "Down/Up ↓"
+2. Press 'S' to toggle to "Down/Up ↑" (ascending)
+3. Connections with lowest total bandwidth appear first
 ```
 
 **Sort by application protocol:**

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,16 +123,12 @@ fn sort_connections(
         let ordering = match sort_column {
             SortColumn::CreatedAt => a.created_at.cmp(&b.created_at),
 
-            SortColumn::BandwidthDown => {
-                // Compare as f64, handle NaN cases
-                a.current_incoming_rate_bps
-                    .partial_cmp(&b.current_incoming_rate_bps)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            }
-
-            SortColumn::BandwidthUp => {
-                a.current_outgoing_rate_bps
-                    .partial_cmp(&b.current_outgoing_rate_bps)
+            SortColumn::BandwidthTotal => {
+                // Compare combined up+down bandwidth, handle NaN cases
+                let a_total = a.current_incoming_rate_bps + a.current_outgoing_rate_bps;
+                let b_total = b.current_incoming_rate_bps + b.current_outgoing_rate_bps;
+                a_total
+                    .partial_cmp(&b_total)
                     .unwrap_or(std::cmp::Ordering::Equal)
             }
 


### PR DESCRIPTION
Changed bandwidth sorting to use the sum of upload and download speeds instead of separate sorting for each direction. This provides a simpler way to identify connections with the highest total bandwidth usage.

- Replace BandwidthDown/BandwidthUp with single BandwidthTotal enum
- Update sort logic to calculate combined rates
- Simplify UI to show "Down/Up ↓/↑" indicator
- Update documentation and tests