### PR TITLE
enabling udp_lite 

### DIFF
--- a/src/network/parser.rs
+++ b/src/network/parser.rs
@@ -335,6 +335,7 @@ impl PacketParser {
             2 => protocol::igmp::parse(transport_data, params, &self.local_ips),
             6 => protocol::tcp::parse(transport_data, params, &self.config, &self.local_ips),
             17 => protocol::udp::parse(transport_data, params, &self.config, &self.local_ips),
+            136 => protocol::udp_lite::parse(transport_data, params, &self.config, &self.local_ips),
             _ => None,
         }
     }
@@ -402,6 +403,7 @@ impl PacketParser {
             58 => protocol::icmp::parse_v6(final_transport_data, params, &self.local_ips),
             6 => protocol::tcp::parse(final_transport_data, params, &self.config, &self.local_ips),
             17 => protocol::udp::parse(final_transport_data, params, &self.config, &self.local_ips),
+            136 => protocol::udp_lite::parse(final_transport_data, params, &self.config, &self.local_ips),
             _ => None,
         }
     }
@@ -540,6 +542,7 @@ impl PacketParser {
             2 => protocol::igmp::parse(transport_data, params, &self.local_ips),
             6 => protocol::tcp::parse(transport_data, params, &self.config, &self.local_ips),
             17 => protocol::udp::parse(transport_data, params, &self.config, &self.local_ips),
+            136 => protocol::udp_lite::parse(transport_data, params, &self.config, &self.local_ips),
             _ => None,
         }
     }
@@ -605,6 +608,7 @@ impl PacketParser {
             58 => protocol::icmp::parse_v6(final_transport_data, params, &self.local_ips),
             6 => protocol::tcp::parse(final_transport_data, params, &self.config, &self.local_ips),
             17 => protocol::udp::parse(final_transport_data, params, &self.config, &self.local_ips),
+            136 => protocol::udp_lite::parse(final_transport_data, params, &self.config, &self.local_ips),
             _ => None,
         }
     }

--- a/src/network/platform/linux/enhanced.rs
+++ b/src/network/platform/linux/enhanced.rs
@@ -113,7 +113,7 @@ mod ebpf_enhanced {
         fn lookup_process_enhanced(&self, conn: &Connection) -> Option<(u32, String)> {
             // Try eBPF first for TCP/UDP/ICMP connections
             match conn.protocol {
-                Protocol::Tcp | Protocol::Udp => {
+                Protocol::Tcp | Protocol::Udp | Protocol::UdpLite => {
                     debug!(
                         "Enhanced lookup: Trying eBPF for {}:{} -> {}:{} ({})",
                         conn.local_addr.ip(),
@@ -123,6 +123,7 @@ mod ebpf_enhanced {
                         match conn.protocol {
                             Protocol::Tcp => "TCP",
                             Protocol::Udp => "UDP",
+                            Protocol::UdpLite => "UDP-Lite",
                             _ => "Unknown",
                         }
                     );

--- a/src/network/platform/linux/process.rs
+++ b/src/network/platform/linux/process.rs
@@ -85,6 +85,18 @@ impl LinuxProcessLookup {
             &inode_to_process,
             &mut process_map,
         )?;
+        Self::parse_and_map(
+            "/proc/net/udplite",
+            Protocol::UdpLite,
+            &inode_to_process,
+            &mut process_map,
+        )?;
+        Self::parse_and_map(
+            "/proc/net/udplite6",
+            Protocol::UdpLite,
+            &inode_to_process,
+            &mut process_map,
+        )?;
 
         Ok((process_map, pid_names))
     }

--- a/src/network/protocol/mod.rs
+++ b/src/network/protocol/mod.rs
@@ -11,6 +11,7 @@ pub mod icmp;
 pub mod igmp;
 pub mod tcp;
 pub mod udp;
+pub mod udp_lite;
 
 use std::net::IpAddr;
 

--- a/src/network/protocol/udp_lite.rs
+++ b/src/network/protocol/udp_lite.rs
@@ -1,0 +1,249 @@
+//! UDP-Lite (Lightweight User Datagram Protocol) parsing
+//!
+//! UDP-Lite (RFC 3828) uses IP protocol number 136. Its header is identical
+//! to UDP except bytes 4-5 carry a checksum coverage field instead of length.
+//! Port extraction is the same as UDP.
+
+use crate::network::parser::{ParsedPacket, ParserConfig};
+use crate::network::protocol::TransportParams;
+use crate::network::types::{Protocol, ProtocolState};
+use std::net::SocketAddr;
+
+/// Parse a UDP-Lite packet
+pub fn parse(
+    transport_data: &[u8],
+    params: TransportParams,
+    _config: &ParserConfig,
+    local_ips: &std::collections::HashSet<std::net::IpAddr>,
+) -> Option<ParsedPacket> {
+    if transport_data.len() < 8 {
+        return None;
+    }
+
+    let src_port = u16::from_be_bytes([transport_data[0], transport_data[1]]);
+    let dst_port = u16::from_be_bytes([transport_data[2], transport_data[3]]);
+
+    let is_outgoing = local_ips.contains(&params.src_ip);
+
+    let (local_addr, remote_addr) = if is_outgoing {
+        (
+            SocketAddr::new(params.src_ip, src_port),
+            SocketAddr::new(params.dst_ip, dst_port),
+        )
+    } else {
+        (
+            SocketAddr::new(params.dst_ip, dst_port),
+            SocketAddr::new(params.src_ip, src_port),
+        )
+    };
+
+    Some(ParsedPacket {
+        connection_key: format!("UDPLite:{}-UDPLite:{}", local_addr, remote_addr),
+        protocol: Protocol::UdpLite,
+        local_addr,
+        remote_addr,
+        tcp_header: None,
+        protocol_state: ProtocolState::UdpLite,
+        is_outgoing,
+        packet_len: params.packet_len,
+        dpi_result: None,
+        process_name: params.process_name,
+        process_id: params.process_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::parser::ParserConfig;
+    use std::collections::HashSet;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    fn local_ips(ip: impl Into<IpAddr>) -> HashSet<IpAddr> {
+        let mut set = HashSet::new();
+        set.insert(ip.into());
+        set
+    }
+
+    fn params_v4(src: Ipv4Addr, dst: Ipv4Addr) -> TransportParams {
+        TransportParams::new(IpAddr::V4(src), IpAddr::V4(dst), 20, None, None)
+    }
+
+    fn params_v6(src: Ipv6Addr, dst: Ipv6Addr) -> TransportParams {
+        TransportParams::new(IpAddr::V6(src), IpAddr::V6(dst), 28, None, None)
+    }
+
+    /// Minimal valid UDP-Lite header: src_port=5000, dst_port=6000,
+    /// checksum_coverage=8 (header only), checksum=0x0000, no payload.
+    fn header(src_port: u16, dst_port: u16) -> Vec<u8> {
+        let mut h = Vec::with_capacity(8);
+        h.extend_from_slice(&src_port.to_be_bytes()); // bytes 0-1: source port
+        h.extend_from_slice(&dst_port.to_be_bytes()); // bytes 2-3: dest port
+        h.extend_from_slice(&8u16.to_be_bytes()); // bytes 4-5: checksum coverage
+        h.extend_from_slice(&0u16.to_be_bytes()); // bytes 6-7: checksum
+        h
+    }
+
+    // --- parse rejects undersized input ---
+
+    #[test]
+    fn test_too_short_returns_none() {
+        let src = Ipv4Addr::new(10, 0, 0, 1);
+        let dst = Ipv4Addr::new(10, 0, 0, 2);
+        let local = local_ips(src);
+        let config = ParserConfig::default();
+
+        assert!(parse(&[], params_v4(src, dst), &config, &local).is_none());
+        assert!(parse(&[0u8; 7], params_v4(src, dst), &config, &local).is_none());
+    }
+
+    // --- outgoing packet: local is src ---
+
+    #[test]
+    fn test_outgoing_packet() {
+        let src = Ipv4Addr::new(192, 168, 1, 10);
+        let dst = Ipv4Addr::new(203, 0, 113, 5);
+        let data = header(5000, 6000);
+        let config = ParserConfig::default();
+
+        let pkt = parse(&data, params_v4(src, dst), &config, &local_ips(src)).unwrap();
+
+        assert_eq!(pkt.protocol, Protocol::UdpLite);
+        assert!(pkt.is_outgoing);
+        assert_eq!(pkt.local_addr, "192.168.1.10:5000".parse().unwrap());
+        assert_eq!(pkt.remote_addr, "203.0.113.5:6000".parse().unwrap());
+        assert!(matches!(pkt.protocol_state, ProtocolState::UdpLite));
+        assert!(pkt.tcp_header.is_none());
+        assert!(pkt.dpi_result.is_none());
+    }
+
+    // --- incoming packet: local is dst ---
+
+    #[test]
+    fn test_incoming_packet() {
+        let src = Ipv4Addr::new(203, 0, 113, 5);
+        let dst = Ipv4Addr::new(192, 168, 1, 10);
+        let data = header(6000, 5000);
+        let config = ParserConfig::default();
+
+        let pkt = parse(&data, params_v4(src, dst), &config, &local_ips(dst)).unwrap();
+
+        assert!(!pkt.is_outgoing);
+        // local_addr should flip to dst
+        assert_eq!(pkt.local_addr, "192.168.1.10:5000".parse().unwrap());
+        assert_eq!(pkt.remote_addr, "203.0.113.5:6000".parse().unwrap());
+    }
+
+    // --- connection_key format ---
+
+    #[test]
+    fn test_connection_key_format() {
+        let src = Ipv4Addr::new(10, 1, 1, 1);
+        let dst = Ipv4Addr::new(10, 1, 1, 2);
+        let data = header(1111, 2222);
+        let config = ParserConfig::default();
+
+        let pkt = parse(&data, params_v4(src, dst), &config, &local_ips(src)).unwrap();
+
+        assert_eq!(pkt.connection_key, "UDPLite:10.1.1.1:1111-UDPLite:10.1.1.2:2222");
+    }
+
+    // --- packet_len is forwarded from TransportParams ---
+
+    #[test]
+    fn test_packet_len_forwarded() {
+        let src = Ipv4Addr::new(10, 0, 0, 1);
+        let dst = Ipv4Addr::new(10, 0, 0, 2);
+        let data = header(100, 200);
+        let params = TransportParams::new(IpAddr::V4(src), IpAddr::V4(dst), 1234, None, None);
+        let config = ParserConfig::default();
+
+        let pkt = parse(&data, params, &config, &local_ips(src)).unwrap();
+
+        assert_eq!(pkt.packet_len, 1234);
+    }
+
+    // --- process info is forwarded from TransportParams ---
+
+    #[test]
+    fn test_process_info_forwarded() {
+        let src = Ipv4Addr::new(10, 0, 0, 1);
+        let dst = Ipv4Addr::new(10, 0, 0, 2);
+        let data = header(100, 200);
+        let params = TransportParams::new(
+            IpAddr::V4(src),
+            IpAddr::V4(dst),
+            20,
+            Some("myapp".to_string()),
+            Some(42),
+        );
+        let config = ParserConfig::default();
+
+        let pkt = parse(&data, params, &config, &local_ips(src)).unwrap();
+
+        assert_eq!(pkt.process_name.as_deref(), Some("myapp"));
+        assert_eq!(pkt.process_id, Some(42));
+    }
+
+    // --- exactly 8 bytes (header only, no payload) is accepted ---
+
+    #[test]
+    fn test_exact_minimum_length_accepted() {
+        let src = Ipv4Addr::new(10, 0, 0, 1);
+        let dst = Ipv4Addr::new(10, 0, 0, 2);
+        let config = ParserConfig::default();
+
+        assert!(parse(&[0u8; 8], params_v4(src, dst), &config, &local_ips(src)).is_some());
+    }
+
+    // --- payload bytes beyond the 8-byte header are ignored (no DPI) ---
+
+    #[test]
+    fn test_payload_ignored() {
+        let src = Ipv4Addr::new(10, 0, 0, 1);
+        let dst = Ipv4Addr::new(10, 0, 0, 2);
+        let mut data = header(7777, 8888);
+        data.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]); // payload
+        let config = ParserConfig::default();
+
+        let pkt = parse(&data, params_v4(src, dst), &config, &local_ips(src)).unwrap();
+
+        assert!(pkt.dpi_result.is_none());
+        assert_eq!(pkt.local_addr.port(), 7777);
+        assert_eq!(pkt.remote_addr.port(), 8888);
+    }
+
+    // --- IPv6 outgoing ---
+
+    #[test]
+    fn test_ipv6_outgoing() {
+        let src: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let dst: Ipv6Addr = "2001:db8::2".parse().unwrap();
+        let data = header(9000, 9001);
+        let config = ParserConfig::default();
+
+        let pkt = parse(&data, params_v6(src, dst), &config, &local_ips(src)).unwrap();
+
+        assert_eq!(pkt.protocol, Protocol::UdpLite);
+        assert!(pkt.is_outgoing);
+        assert_eq!(pkt.local_addr.port(), 9000);
+        assert_eq!(pkt.remote_addr.port(), 9001);
+        assert!(matches!(pkt.local_addr.ip(), IpAddr::V6(_)));
+    }
+
+    // --- IPv6 incoming ---
+
+    #[test]
+    fn test_ipv6_incoming() {
+        let src: Ipv6Addr = "2001:db8::2".parse().unwrap();
+        let dst: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let data = header(9001, 9000);
+        let config = ParserConfig::default();
+
+        let pkt = parse(&data, params_v6(src, dst), &config, &local_ips(dst)).unwrap();
+
+        assert!(!pkt.is_outgoing);
+        assert_eq!(pkt.local_addr.port(), 9000);
+        assert_eq!(pkt.remote_addr.port(), 9001);
+    }
+}

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant, SystemTime};
 pub enum Protocol {
     Tcp,
     Udp,
+    UdpLite,
     Icmp,
     Igmp,
     Arp,
@@ -17,6 +18,7 @@ impl std::fmt::Display for Protocol {
         match self {
             Protocol::Tcp => write!(f, "TCP"),
             Protocol::Udp => write!(f, "UDP"),
+            Protocol::UdpLite => write!(f, "UDP-Lite"),
             Protocol::Icmp => write!(f, "ICMP"),
             Protocol::Igmp => write!(f, "IGMP"),
             Protocol::Arp => write!(f, "ARP"),
@@ -200,6 +202,7 @@ impl fmt::Display for TcpState {
 pub enum ProtocolState {
     Tcp(TcpState),
     Udp,
+    UdpLite,
     Icmp {
         icmp_type: u8,
         icmp_id: Option<u16>,
@@ -1942,6 +1945,16 @@ impl Connection {
                     }
                 }
             }
+            ProtocolState::UdpLite => {
+                let idle_time = self.idle_time();
+                if idle_time > Duration::from_secs(60) {
+                    "UDPLITE_STALE".to_string()
+                } else if idle_time > Duration::from_secs(30) {
+                    "UDPLITE_IDLE".to_string()
+                } else {
+                    "UDPLITE_ACTIVE".to_string()
+                }
+            }
             ProtocolState::Icmp { icmp_type, icmp_id } => match icmp_type {
                 8 => match icmp_id {
                     Some(id) => format!("ECHO_REQ({})", id),
@@ -2042,6 +2055,7 @@ impl Connection {
                     Duration::from_secs(60)
                 }
             }
+            ProtocolState::UdpLite => Duration::from_secs(60),
             ProtocolState::Icmp { .. } => Duration::from_secs(10),
             ProtocolState::Igmp { .. } => Duration::from_secs(10),
             ProtocolState::Arp(_) => Duration::from_secs(30),


### PR DESCRIPTION
-udp_lite is a linux kernel supported protocol(protocol number: 136) which supports checksum for selective fields. 
-Its a low hanging item for rustnet. 
-Validated the fix.
 