### PR TITLE
fix(ui): scope / search to Overview and tidy status bars (#229)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -864,40 +864,18 @@ where
                                     return Ok(());
                                 }
 
-                                // Handle navigation keys (j/k) and text input
-                                match c {
-                                    'k' => {
-                                        // Vim-style up navigation while filtering
-                                        // Use the SAME sorted connections list from the main loop
-                                        debug!(
-                                            "Filter mode navigation UP (k): {} connections available",
-                                            connections.len()
-                                        );
-                                        ui_state.move_selection_up(&connections);
-                                    }
-                                    'j' => {
-                                        // Vim-style down navigation while filtering
-                                        // Use the SAME sorted connections list from the main loop
-                                        debug!(
-                                            "Filter mode navigation DOWN (j): {} connections available",
-                                            connections.len()
-                                        );
-                                        ui_state.move_selection_down(&connections);
-                                    }
-                                    _ => {
-                                        // Regular character input for filter
-                                        ui_state.filter_add_char(c);
-                                        needs_data_refresh = true;
-                                    }
-                                }
+                                // All other characters (including j/k) are text input.
+                                // Use arrow keys to navigate while typing.
+                                ui_state.filter_add_char(c);
+                                needs_data_refresh = true;
                             }
                             _ => {}
                         }
                     } else {
                         // Handle input in normal mode
                         match (key.code, key.modifiers) {
-                            // Enter filter mode with '/'
-                            (KeyCode::Char('/'), _) => {
+                            // Enter filter mode with '/' (only on Overview tab)
+                            (KeyCode::Char('/'), _) if ui_state.selected_tab == 0 => {
                                 ui_state.quit_confirmation = false;
                                 debug!("Entering filter mode");
                                 ui_state.enter_filter_mode();
@@ -1256,10 +1234,9 @@ where
                                     // Clear filter if one is active
                                     ui_state.clear_filter();
                                     needs_data_refresh = true;
-                                } else if ui_state.selected_tab == 1 {
-                                    ui_state.selected_tab = 0; // Back to overview
-                                } else if ui_state.selected_tab == 2 {
-                                    ui_state.selected_tab = 0; // Back to overview from help
+                                } else if ui_state.selected_tab != 0 {
+                                    // Back to overview from any other tab
+                                    ui_state.selected_tab = 0;
                                 }
                             }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3916,7 +3916,9 @@ fn draw_help(f: &mut Frame, area: Rect) -> Result<()> {
         ]),
         Line::from(vec![
             Span::styled("/ ", theme::fg(theme::key())),
-            Span::raw("Enter filter mode (navigate while typing!)"),
+            Span::raw(
+                "Enter filter mode on Overview (use \u{2191}/\u{2193} to navigate while typing)",
+            ),
         ]),
         Line::from(""),
         Line::from(vec![Span::styled("Tabs:", theme::bold_fg(theme::accent()))]),
@@ -4186,6 +4188,21 @@ fn draw_filter_input(f: &mut Frame, ui_state: &UIState, area: Rect) {
     f.render_widget(filter_input, area);
 }
 
+/// Status bar text per tab. Only Overview exposes connection-list shortcuts
+/// (/, a, t, c); other tabs show just what actually works there.
+fn default_status_line(selected_tab: usize) -> &'static str {
+    match selected_tab {
+        // Overview
+        0 => {
+            " 'h' help | Tab/Shift+Tab switch tabs | '/' filter | 'a' group | 't' history | 'c' copy"
+        }
+        // Details
+        1 => " 'h' help | Tab/Shift+Tab switch tabs | 'c' copy remote addr | Esc back to Overview",
+        // Interfaces / Graph / Help
+        _ => " 'h' help | Tab/Shift+Tab switch tabs | Esc back to Overview",
+    }
+}
+
 /// Draw status bar
 fn draw_status_bar(f: &mut Frame, ui_state: &UIState, connection_count: usize, area: Rect) {
     let status = if ui_state.quit_confirmation {
@@ -4197,18 +4214,15 @@ fn draw_status_bar(f: &mut Frame, ui_state: &UIState, connection_count: usize, a
         if time.elapsed().as_secs() < 3 {
             format!(" {} ", msg)
         } else {
-            " 'h' help | Tab/Shift+Tab switch tabs | '/' filter | 'a' group | 't' history | 'c' copy".to_string()
+            default_status_line(ui_state.selected_tab).to_string()
         }
     } else if !ui_state.filter_query.is_empty() {
         format!(
             " 'h' help | Tab/Shift+Tab switch tabs | Showing {} filtered connections (Esc to clear) ",
             connection_count
         )
-    } else if ui_state.selected_tab == 1 {
-        " Click any field to copy | 'c' copy remote addr | Tab switch tabs | Esc back ".to_string()
     } else {
-        " 'h' help | Tab/Shift+Tab switch tabs | '/' filter | 'a' group | 't' history | 'c' copy"
-            .to_string()
+        default_status_line(ui_state.selected_tab).to_string()
     };
 
     let style = if ui_state.quit_confirmation || ui_state.clear_confirmation {


### PR DESCRIPTION
- Only enter filter mode with '/' on the Overview tab
- Treat j/k as text input in filter mode; use arrow keys to navigate
- Per-tab status bar text with consistent phrasing
- Esc returns to Overview from any non-Overview tab