### PR TITLE
docs: README hero polish, metadata tune-up, accuracy fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -124,11 +124,11 @@ Removes inactive connections using smart, protocol-aware timeouts. This prevents
 - **Regular UDP**: **60 seconds** - standard timeout
 
 #### QUIC Connections (Detected State)
-- **Connected (active)** (< 1 min idle): **10 minutes**
-- **Connected (idle)** (> 1 min idle): **5 minutes**
+- **Connected**: 3 minutes default, or the peer's `max_idle_timeout` transport parameter when present
 - **With CONNECTION_CLOSE frame**: 1-10 seconds (based on close type)
 - **Initial/Handshaking**: 60 seconds - allow connection establishment
 - **Draining**: 10 seconds - RFC 9000 draining period
+- **Closed**: 1 second - immediate cleanup
 
 **Visual Staleness Indicators:**
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <h1 align="center">RustNet</h1>
   <p align="center">
-    <strong>Per-process network monitoring for your terminal — live TCP, UDP, and QUIC connections with deep packet inspection, sandboxed by default.</strong>
+    <strong>Per-process network monitoring for your terminal: live TCP, UDP, and QUIC connections with deep packet inspection, sandboxed by default.</strong>
   </p>
   <p align="center">
     <a href="https://ratatui.rs/"><img src="https://ratatui.rs/built-with-ratatui/badge.svg" alt="Built With Ratatui"></a>
@@ -19,18 +19,18 @@
 </p>
 
 <p align="center">
-  <em>Real-time visibility into every connection your machine makes, who owns it, and what protocol it's speaking — without tcpdump, X11 forwarding, or root piping.</em>
+  <em>Real-time visibility into every connection your machine makes, who owns it, and what protocol it's speaking. No tcpdump, X11 forwarding, or root piping.</em>
 </p>
 
 ## Features
 
-- **Per-process attribution**: Every TCP, UDP, and QUIC connection mapped to its owning process — via eBPF on Linux, PKTAP on macOS, native APIs on Windows and FreeBSD. Wireshark and tcpdump can't do this; `netstat` / `ss` can't show live state.
-- **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, QUIC, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS — without external dissectors.
+- **Per-process attribution**: Every TCP, UDP, and QUIC connection mapped to its owning process, via eBPF on Linux, PKTAP on macOS, native APIs on Windows and FreeBSD. Wireshark and tcpdump can't do this; `netstat` / `ss` can't show live state.
+- **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, QUIC, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS, without external dissectors.
 - **Security sandboxing**: Landlock (Linux 5.13+), Seatbelt (macOS), restricted token + job objects (Windows). Drops privileges immediately after libpcap initializes. See [SECURITY.md](SECURITY.md).
-- **TCP network analytics**: Real-time retransmissions, out-of-order packets, and fast-retransmit detection — per-connection and aggregate.
+- **TCP network analytics**: Real-time retransmissions, out-of-order packets, and fast-retransmit detection, per-connection and aggregate.
 - **Smart connection lifecycle**: Protocol-aware timeouts with white → yellow → red staleness indicators. Toggle `t` to keep historic (closed) connections visible for forensics.
 - **Vim/fzf-style filtering**: `port:`, `src:`, `dst:`, `sni:`, `process:`, `state:`, `proto:`, plus regex via `/(?i)pattern/`.
-- **GeoIP enrichment**: Country lookups via local MaxMind GeoLite2 — no network calls.
+- **GeoIP enrichment**: Country lookups via local MaxMind GeoLite2. No network calls.
 - **Cross-platform**: Linux, macOS, Windows, FreeBSD.
 
 ## Why RustNet?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
 [![Build Status](https://github.com/domcyrus/rustnet/workflows/Rust/badge.svg)](https://github.com/domcyrus/rustnet/actions)
 [![Crates.io](https://img.shields.io/crates/v/rustnet-monitor.svg)](https://crates.io/crates/rustnet-monitor)
-[![Crates.io Downloads](https://img.shields.io/crates/d/rustnet-monitor.svg)](https://crates.io/crates/rustnet-monitor)
+[![GitHub Stars](https://img.shields.io/github/stars/domcyrus/rustnet?style=flat&logo=github)](https://github.com/domcyrus/rustnet/stargazers)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/domcyrus/rustnet.svg)](https://github.com/domcyrus/rustnet/releases)
 [![Docker Image](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker)](https://github.com/domcyrus/rustnet/pkgs/container/rustnet)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
-[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
-[![Build Status](https://github.com/domcyrus/rustnet/workflows/Rust/badge.svg)](https://github.com/domcyrus/rustnet/actions)
-[![Crates.io](https://img.shields.io/crates/v/rustnet-monitor.svg)](https://crates.io/crates/rustnet-monitor)
-[![GitHub Stars](https://img.shields.io/github/stars/domcyrus/rustnet?style=flat&logo=github)](https://github.com/domcyrus/rustnet/stargazers)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![GitHub release](https://img.shields.io/github/v/release/domcyrus/rustnet.svg)](https://github.com/domcyrus/rustnet/releases)
-[![Docker Image](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker)](https://github.com/domcyrus/rustnet/pkgs/container/rustnet)
+<p align="center">
+  <h1 align="center">RustNet</h1>
+  <p align="center">
+    <strong>Per-process network monitoring for your terminal — live TCP, UDP, and QUIC connections with deep packet inspection, sandboxed by default.</strong>
+  </p>
+  <p align="center">
+    <a href="https://ratatui.rs/"><img src="https://ratatui.rs/built-with-ratatui/badge.svg" alt="Built With Ratatui"></a>
+    <a href="https://github.com/domcyrus/rustnet/actions"><img src="https://github.com/domcyrus/rustnet/workflows/Rust/badge.svg" alt="Build Status"></a>
+    <a href="https://crates.io/crates/rustnet-monitor"><img src="https://img.shields.io/crates/v/rustnet-monitor.svg" alt="Crates.io"></a>
+    <a href="https://github.com/domcyrus/rustnet/stargazers"><img src="https://img.shields.io/github/stars/domcyrus/rustnet?style=flat&logo=github" alt="GitHub Stars"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License"></a>
+    <a href="https://github.com/domcyrus/rustnet/releases"><img src="https://img.shields.io/github/v/release/domcyrus/rustnet.svg" alt="GitHub release"></a>
+    <a href="https://github.com/domcyrus/rustnet/pkgs/container/rustnet"><img src="https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker" alt="Docker Image"></a>
+  </p>
+</p>
 
-# RustNet
+<p align="center">
+  <img src="./assets/rustnet.gif" alt="RustNet demo" width="800">
+</p>
 
-A cross-platform network monitoring tool built with Rust. RustNet provides real-time visibility into network connections with detailed state information, connection lifecycle management, deep packet inspection, and a terminal user interface.
-
-![RustNet Demo](./assets/rustnet.gif)
+<p align="center">
+  <em>Real-time visibility into every connection your machine makes, who owns it, and what protocol it's speaking — without tcpdump, X11 forwarding, or root piping.</em>
+</p>
 
 ## Features
 
 - **Real-time Network Monitoring**: Monitor active TCP, UDP, ICMP, and ARP connections with detailed state information
-- **Connection States**: Track TCP states (`ESTABLISHED`, `SYN_SENT`, `TIME_WAIT`), QUIC states (`QUIC_INITIAL`, `QUIC_HANDSHAKE`, `QUIC_CONNECTED`), DNS states, SSH states, and activity-based UDP states
+- **Connection States**: Track TCP states (`ESTABLISHED`, `SYN_SENT`, `TIME_WAIT`, `FIN_WAIT*`, `CLOSE_WAIT`, …), QUIC handshake states (`Initial`, `Handshaking`, `Connected`, `Draining`), and SSH session states (`Banner`, `KeyExchange`, `Authentication`, `Established`)
 - **Interface Statistics**: Real-time monitoring of network interface metrics including bytes/packets transferred, errors, drops, and collisions
 - **Deep Packet Inspection (DPI)**: Detect application protocols including HTTP, HTTPS/TLS with SNI, DNS, SSH, QUIC, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS
 - **TCP Network Analytics**: Real-time detection of TCP retransmissions, out-of-order packets, and fast retransmits with per-connection and aggregate statistics
@@ -250,7 +260,7 @@ RustNet uses smart timeouts and visual warnings before removing connections:
 - **HTTP/HTTPS**: 10 minutes (supports keep-alive)
 - **SSH**: 30 minutes (long sessions)
 - **TCP active**: 10 minutes, idle: 5 minutes
-- **QUIC active**: 10 minutes, idle: 5 minutes
+- **QUIC connected**: 3 minutes (or peer's transport-param idle timeout, when present); `Initial`/`Handshaking`: 60 seconds
 - **DNS**: 30 seconds
 - **TCP CLOSED**: 5 seconds
 

--- a/README.md
+++ b/README.md
@@ -24,22 +24,14 @@
 
 ## Features
 
-- **Real-time Network Monitoring**: Monitor active TCP, UDP, ICMP, and ARP connections with detailed state information
-- **Connection States**: Track TCP states (`ESTABLISHED`, `SYN_SENT`, `TIME_WAIT`, `FIN_WAIT*`, `CLOSE_WAIT`, …), QUIC handshake states (`Initial`, `Handshaking`, `Connected`, `Draining`), and SSH session states (`Banner`, `KeyExchange`, `Authentication`, `Established`)
-- **Interface Statistics**: Real-time monitoring of network interface metrics including bytes/packets transferred, errors, drops, and collisions
-- **Deep Packet Inspection (DPI)**: Detect application protocols including HTTP, HTTPS/TLS with SNI, DNS, SSH, QUIC, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS
-- **TCP Network Analytics**: Real-time detection of TCP retransmissions, out-of-order packets, and fast retransmits with per-connection and aggregate statistics
-- **Smart Connection Lifecycle**: Protocol-aware timeouts with visual staleness indicators (white → yellow → red) before cleanup
-- **Process Identification**: Associate network connections with running processes
-- **Service Name Resolution**: Identify well-known services using port numbers
-- **GeoIP Location**: Show country codes for remote IPs using GeoLite2 databases (auto-discovered or manually specified)
-- **Reverse DNS Lookups**: Resolve IP addresses to hostnames with background async resolution and caching
-- **Cross-platform Support**: Works on Linux, macOS, Windows, and FreeBSD
-- **Advanced Filtering**: Real-time vim/fzf-style filtering with keyword support (`port:`, `src:`, `dst:`, `sni:`, `process:`, `state:`)
-- **Terminal User Interface**: Beautiful TUI built with ratatui with adjustable column widths
-- **Multi-threaded Processing**: Concurrent packet processing for high performance
-- **Optional Logging**: Detailed logging with configurable log levels (disabled by default)
-- **Security Sandboxing**: Landlock-based filesystem/network restrictions on Linux 5.13+ (see [SECURITY.md](SECURITY.md))
+- **Per-process attribution**: Every TCP, UDP, and QUIC connection mapped to its owning process — via eBPF on Linux, PKTAP on macOS, native APIs on Windows and FreeBSD. Wireshark and tcpdump can't do this; `netstat` / `ss` can't show live state.
+- **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, QUIC, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS — without external dissectors.
+- **Security sandboxing**: Landlock (Linux 5.13+), Seatbelt (macOS), restricted token + job objects (Windows). Drops privileges immediately after libpcap initializes. See [SECURITY.md](SECURITY.md).
+- **TCP network analytics**: Real-time retransmissions, out-of-order packets, and fast-retransmit detection — per-connection and aggregate.
+- **Smart connection lifecycle**: Protocol-aware timeouts with white → yellow → red staleness indicators. Toggle `t` to keep historic (closed) connections visible for forensics.
+- **Vim/fzf-style filtering**: `port:`, `src:`, `dst:`, `sni:`, `process:`, `state:`, `proto:`, plus regex via `/(?i)pattern/`.
+- **GeoIP enrichment**: Country lookups via local MaxMind GeoLite2 — no network calls.
+- **Cross-platform**: Linux, macOS, Windows, FreeBSD.
 
 ## Why RustNet?
 


### PR DESCRIPTION
## Summary

Bundle of README/docs polish targeting recognition + discoverability:

- **Cargo.toml**: keyword swap `terminal` → `ebpf` (lower-competition canonical term); MSRV unchanged.
- **lib.rs / modules**: expanded crate-level `//!` docs and added `//!` headers to `app`, `config`, `filter`, `network`, `ui` (helps lib.rs heuristics and docs.rs rendering).
- **README hero**: centered layout (sniffnet-style), benefit-led bold tagline, italic elevator pitch under the demo GIF.
- **README features**: trimmed from 16 generic bullets to 8 differentiator-focused bullets (per-process attribution, DPI, sandboxing, TCP analytics, smart lifecycle, filtering, GeoIP, cross-platform). Added historic-connections mention.
- **Badges**: replaced low-number crates.io downloads badge with GitHub stars badge.
- **Accuracy fixes**: dropped non-existent DNS/UDP "states" from the Connection States bullet, fixed QUIC enum casing (`Initial / Handshaking / Connected`, not `QUIC_INITIAL`...), and corrected QUIC timeout claim in README + ARCHITECTURE.md (3 min default, not 10).
- **rustdoc**: fixed two pre-existing warnings (NO_COLOR autolink, PARTIAL intra-doc link).

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (317 tests pass)
- [x] `cargo doc --no-deps` produces zero warnings
- [ ] Visual check of README on GitHub (centered hero, badges, GIF render correctly)
- [ ] After merge: confirm lib.rs picks up the new keyword and crate docs on next `cargo publish`