### PR TITLE
docs: accurate Windows sandbox terminology + roadmap entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 - **Per-process attribution**: Every TCP, UDP, and QUIC connection mapped to its owning process, via eBPF on Linux, PKTAP on macOS, native APIs on Windows and FreeBSD. Wireshark and tcpdump can't do this; `netstat` / `ss` can't show live state.
 - **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, QUIC, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS, without external dissectors.
-- **Security sandboxing**: Landlock (Linux 5.13+), Seatbelt (macOS), restricted token + job objects (Windows). Drops privileges immediately after libpcap initializes. See [SECURITY.md](SECURITY.md).
+- **Security sandboxing**: Landlock (Linux 5.13+), Seatbelt (macOS), token privilege drop + job-object child-process block (Windows). Drops privileges immediately after libpcap initializes. See [SECURITY.md](SECURITY.md).
 - **TCP network analytics**: Real-time retransmissions, out-of-order packets, and fast-retransmit detection, per-connection and aggregate.
 - **Smart connection lifecycle**: Protocol-aware timeouts with white → yellow → red staleness indicators. Toggle `t` to keep historic (closed) connections visible for forensics.
 - **Vim/fzf-style filtering**: `port:`, `src:`, `dst:`, `sni:`, `process:`, `state:`, `proto:`, plus regex via `/(?i)pattern/`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,7 @@ This document outlines the planned features and improvements for RustNet.
   - Architecture: pre-fork a Casper service before `cap_enter()`, communicate over socket pair at runtime
   - Write FFI bindings for `libprocstat` and `libcasper` (no Rust crate exists)
   - Link against `-lprocstat -lcasper -lcap_sysctl` (system libraries on FreeBSD 10+)
+- [ ] **Windows Sandbox Hardening**: Strengthen the current privilege-drop + Job Object setup with process mitigation policies (`SetProcessMitigationPolicy`), low-integrity execution, and evaluation of `CreateRestrictedToken` / AppContainer.
 - [ ] **OpenBSD and NetBSD Support**: Future platforms to support
 - [x] **Linux Process Identification**: **Experimental eBPF Support Implemented** - Basic eBPF-based process identification now available with `--features ebpf`. Provides efficient kernel-level process-to-connection mapping with lower overhead than procfs. Currently has limitations (see eBPF Improvements section below).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ RustNet processes untrusted network data, making defense-in-depth security criti
 - [Landlock Sandboxing (Linux)](#landlock-sandboxing-linux)
 - [Seatbelt Sandboxing (macOS)](#seatbelt-sandboxing-macos)
 - [FreeBSD Sandboxing](#freebsd-sandboxing)
-- [Restricted Token Sandboxing (Windows)](#restricted-token-sandboxing-windows)
+- [Privilege Drop and Job Object Sandboxing (Windows)](#privilege-drop-and-job-object-sandboxing-windows)
 - [Privilege Requirements](#privilege-requirements)
 - [Read-Only Operation](#read-only-operation)
 - [No External Communication](#no-external-communication)
@@ -122,7 +122,7 @@ On Linux, clipboard requires access to Wayland sockets (`/run/user/UID/wayland-0
 
 FreeBSD does not currently have sandboxing enabled. A full Capsicum sandbox using `cap_enter()` with `libcasper` for privileged process lookup is planned — see [ROADMAP.md](ROADMAP.md) for details.
 
-## Restricted Token Sandboxing (Windows)
+## Privilege Drop and Job Object Sandboxing (Windows)
 
 On Windows, RustNet removes dangerous privileges from the process token and applies a Job Object to prevent child process creation after initialization.
 


### PR DESCRIPTION
"Restricted token" in Win32 means `CreateRestrictedToken`, which RustNet doesn't call. The actual mechanism is `AdjustTokenPrivileges` + a Job Object. Tightens README + SECURITY.md, and adds a ROADMAP item for further hardening (mitigation policies, low integrity, real restricted token, AppContainer).