### PR TITLE
fix(build): skip cross-compile lib paths on native builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,14 @@ include!("src/cli.rs");
 
 fn setup_cross_compilation_libs() {
     let target = env::var("TARGET").unwrap_or_default();
+    let host = env::var("HOST").unwrap_or_default();
+
+    // Only apply hard-coded multiarch lib paths when actually cross-compiling.
+    // On native builds (e.g. Homebrew on Linux arm64) these paths would shadow
+    // package-manager-provided libraries and break linkage.
+    if host == target {
+        return;
+    }
 
     match target.as_str() {
         "aarch64-unknown-linux-gnu" => {


### PR DESCRIPTION
The hard-coded multiarch search paths in build.rs are only valid inside cross-rs docker images. On native builds (e.g. Homebrew on Linux arm64) they shadow package-manager-provided libelf/libz and break linkage. Skip the setup entirely when HOST == TARGET.