### PR TITLE
feat(dpi): add SIP protocol detection and metadata extraction

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -417,7 +417,7 @@ Wireshark operates at the packet capture layer (libpcap) - it sees raw network t
 |------------|---------|-----------|
 | Process identification | Yes (eBPF, procfs, platform APIs) | No |
 | Connection state tracking | Native (TCP FSM, QUIC states) | Via dissectors |
-| Protocol dissectors | ~15 common protocols | 3000+ protocols |
+| Protocol dissectors | ~16 common protocols | 3000+ protocols |
 | Packet-level inspection | Metadata only | Full payload |
 | Interface | TUI (terminal) | GUI |
 | Capture to file | Yes (`--pcap-export`) | Yes (native) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The headline of this release is a major TUI refresh. The tabs, stats panel, and 
 ### Added
 - **TUI Revamp**: Redesigned tabs, stats panel, and details view (#239)
 - **Per-field Colors and Status Dot**: New per-field colors, status dot, and magenta panel borders for at-a-glance readability (#241)
+- **SIP Protocol Detection**: Deep packet inspection for SIP (Session Initiation Protocol) traffic over UDP/TCP port 5060, with method/URI/response code display and compact header support
 - **Address Scope Labels**: Remote addresses are tagged PUBLIC, PRIVATE, etc. in the connection list (#251)
 - **Reverse DNS Resolution by Default**: Reverse DNS resolution is now enabled by default. Use the new `--no-resolve-dns` flag to opt out (#245)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Features
 
 - **Per-process attribution**: Every TCP, UDP, and QUIC connection mapped to its owning process, via eBPF on Linux, PKTAP on macOS, native APIs on Windows and FreeBSD. Wireshark and tcpdump can't do this; `netstat` / `ss` can't show live state.
-- **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, QUIC, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS, without external dissectors.
+- **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, QUIC, SIP, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS, without external dissectors.
 - **Security sandboxing**: Landlock (Linux 5.13+), Seatbelt (macOS), token privilege drop + job-object child-process block (Windows). Drops privileges immediately after libpcap initializes. See [SECURITY.md](SECURITY.md).
 - **TCP network analytics**: Real-time retransmissions, out-of-order packets, and fast-retransmit detection, per-connection and aggregate.
 - **Smart connection lifecycle**: Protocol-aware timeouts with white → yellow → red staleness indicators. Toggle `t` to keep historic (closed) connections visible for forensics.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -466,6 +466,11 @@ impl ConnectionFilter {
                 {
                     return true;
                 }
+                if let Some(ref cseq_method) = info.cseq_method
+                    && match_text(cseq_method, fv)
+                {
+                    return true;
+                }
                 if let Some(ref user_agent) = info.user_agent
                     && match_text(user_agent, fv)
                 {
@@ -474,6 +479,14 @@ impl ConnectionFilter {
                 if let Some(ref server) = info.server
                     && match_text(server, fv)
                 {
+                    return true;
+                }
+                if let Some(ref content_type) = info.content_type
+                    && match_text(content_type, fv)
+                {
+                    return true;
+                }
+                if info.has_sdp && match_text("sdp", fv) {
                     return true;
                 }
             }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -437,6 +437,46 @@ impl ConnectionFilter {
                     return true;
                 }
             }
+            ApplicationProtocol::Sip(info) => {
+                if match_text("sip", fv) {
+                    return true;
+                }
+                if let Some(ref method) = info.method
+                    && match_text(method, fv)
+                {
+                    return true;
+                }
+                if let Some(ref request_uri) = info.request_uri
+                    && match_text(request_uri, fv)
+                {
+                    return true;
+                }
+                if let Some(ref from) = info.from
+                    && match_text(from, fv)
+                {
+                    return true;
+                }
+                if let Some(ref to) = info.to
+                    && match_text(to, fv)
+                {
+                    return true;
+                }
+                if let Some(ref call_id) = info.call_id
+                    && match_text(call_id, fv)
+                {
+                    return true;
+                }
+                if let Some(ref user_agent) = info.user_agent
+                    && match_text(user_agent, fv)
+                {
+                    return true;
+                }
+                if let Some(ref server) = info.server
+                    && match_text(server, fv)
+                {
+                    return true;
+                }
+            }
             ApplicationProtocol::NetBios(info) => {
                 if let Some(ref name) = info.name
                     && match_text(name, fv)

--- a/src/network/dpi/http.rs
+++ b/src/network/dpi/http.rs
@@ -32,7 +32,7 @@ pub fn analyze_http(payload: &[u8]) -> Option<HttpInfo> {
             // Response line: HTTP/1.1 200 OK
             info.version = parse_http_version(parts[0]);
             info.status_code = parts[1].parse::<u16>().ok();
-        } else if is_http_method(parts[0]) {
+        } else if is_http_method(parts[0]) && parts[2].starts_with("HTTP/") {
             // Request line: GET /path HTTP/1.1
             info.method = Some(parts[0].to_string());
             info.path = Some(parts[1].to_string());
@@ -126,5 +126,11 @@ mod tests {
 
         assert_eq!(info.status_code, Some(200));
         assert!(info.method.is_none());
+    }
+
+    #[test]
+    fn test_sip_options_not_http() {
+        let payload = b"OPTIONS sip:bob@example.com SIP/2.0\r\nVia: SIP/2.0/UDP host\r\n\r\n";
+        assert!(analyze_http(payload).is_none());
     }
 }

--- a/src/network/dpi/mod.rs
+++ b/src/network/dpi/mod.rs
@@ -13,6 +13,7 @@ mod mqtt;
 mod netbios;
 mod ntp;
 mod quic;
+mod sip;
 mod snmp;
 mod ssdp;
 mod ssh;
@@ -32,6 +33,7 @@ const PORT_NETBIOS_DGM: u16 = 138;
 const PORT_SNMP: u16 = 161;
 const PORT_SNMP_TRAP: u16 = 162;
 const PORT_HTTPS: u16 = 443;
+const PORT_SIP: u16 = 5060;
 const PORT_MQTT: u16 = 1883;
 const PORT_SSDP: u16 = 1900;
 const PORT_MDNS: u16 = 5353;
@@ -58,14 +60,23 @@ pub fn analyze_tcp_packet(
 
     // Try protocols in order of likelihood/speed
 
-    // 1. Check for HTTP (fast string matching)
+    // 1. Check for SIP (port 5060 or SIP start-line)
+    if (local_port == PORT_SIP || remote_port == PORT_SIP || sip::is_likely_sip(payload))
+        && let Some(sip_result) = sip::analyze_sip(payload)
+    {
+        return Some(DpiResult {
+            application: ApplicationProtocol::Sip(sip_result),
+        });
+    }
+
+    // 2. Check for HTTP (fast string matching)
     if let Some(http_result) = http::analyze_http(payload) {
         return Some(DpiResult {
             application: ApplicationProtocol::Http(http_result),
         });
     }
 
-    // 2. Check for TLS/HTTPS (port 443 or TLS handshake)
+    // 3. Check for TLS/HTTPS (port 443 or TLS handshake)
     if (local_port == PORT_HTTPS || remote_port == PORT_HTTPS || https::is_tls_handshake(payload))
         && let Some(tls_result) = https::analyze_https(payload)
     {
@@ -74,7 +85,7 @@ pub fn analyze_tcp_packet(
         });
     }
 
-    // 3. Check for BitTorrent (handshake signature \x13BitTorrent protocol)
+    // 4. Check for BitTorrent (handshake signature \x13BitTorrent protocol)
     if bittorrent::is_bittorrent_handshake(payload)
         && let Some(bt_result) = bittorrent::analyze_bittorrent(payload)
     {
@@ -83,7 +94,7 @@ pub fn analyze_tcp_packet(
         });
     }
 
-    // 4. Check for MQTT (port 1883 or MQTT signature)
+    // 5. Check for MQTT (port 1883 or MQTT signature)
     if (local_port == PORT_MQTT || remote_port == PORT_MQTT || mqtt::is_mqtt_packet(payload))
         && let Some(mqtt_result) = mqtt::analyze_mqtt(payload)
     {
@@ -92,7 +103,7 @@ pub fn analyze_tcp_packet(
         });
     }
 
-    // 5. Check for SSH (port 22 or SSH banner)
+    // 6. Check for SSH (port 22 or SSH banner)
     if (local_port == PORT_SSH || remote_port == PORT_SSH || ssh::is_likely_ssh(payload))
         && let Some(ssh_result) = ssh::analyze_ssh(payload, _is_outgoing)
     {
@@ -126,7 +137,16 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 2. QUIC/HTTP3 (port 443)
+    // 2. SIP (port 5060 or SIP start-line)
+    if (local_port == PORT_SIP || remote_port == PORT_SIP || sip::is_likely_sip(payload))
+        && let Some(sip_result) = sip::analyze_sip(payload)
+    {
+        return Some(DpiResult {
+            application: ApplicationProtocol::Sip(sip_result),
+        });
+    }
+
+    // 3. QUIC/HTTP3 (port 443)
     if (local_port == PORT_HTTPS || remote_port == PORT_HTTPS) && quic::is_quic_packet(payload) {
         let quic_info = quic::parse_quic_packet(payload);
         if let Some(quic_info) = quic_info {
@@ -144,7 +164,7 @@ pub fn analyze_udp_packet(
         }
     }
 
-    // 3. mDNS (port 5353)
+    // 4. mDNS (port 5353)
     if (local_port == PORT_MDNS || remote_port == PORT_MDNS)
         && let Some(mdns_result) = mdns::analyze_mdns(payload)
     {
@@ -153,7 +173,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 4. DHCP (ports 67-68)
+    // 5. DHCP (ports 67-68)
     if matches!(
         (local_port, remote_port),
         (PORT_DHCP_SERVER, _)
@@ -167,7 +187,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 5. NTP (port 123)
+    // 6. NTP (port 123)
     if (local_port == PORT_NTP || remote_port == PORT_NTP)
         && let Some(ntp_result) = ntp::analyze_ntp(payload)
     {
@@ -176,7 +196,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 6. LLMNR (port 5355)
+    // 7. LLMNR (port 5355)
     if (local_port == PORT_LLMNR || remote_port == PORT_LLMNR)
         && let Some(llmnr_result) = llmnr::analyze_llmnr(payload)
     {
@@ -185,7 +205,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 7. SSDP (port 1900)
+    // 8. SSDP (port 1900)
     if (local_port == PORT_SSDP || remote_port == PORT_SSDP)
         && let Some(ssdp_result) = ssdp::analyze_ssdp(payload)
     {
@@ -194,7 +214,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 8. NetBIOS-NS (port 137)
+    // 9. NetBIOS-NS (port 137)
     if (local_port == PORT_NETBIOS_NS || remote_port == PORT_NETBIOS_NS)
         && let Some(netbios_result) = netbios::analyze_netbios_ns(payload)
     {
@@ -203,7 +223,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 9. NetBIOS-DGM (port 138)
+    // 10. NetBIOS-DGM (port 138)
     if (local_port == PORT_NETBIOS_DGM || remote_port == PORT_NETBIOS_DGM)
         && let Some(netbios_result) = netbios::analyze_netbios_dgm(payload)
     {
@@ -212,7 +232,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 10. SNMP (ports 161-162)
+    // 11. SNMP (ports 161-162)
     if matches!(
         (local_port, remote_port),
         (PORT_SNMP, _) | (PORT_SNMP_TRAP, _) | (_, PORT_SNMP) | (_, PORT_SNMP_TRAP)
@@ -223,7 +243,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 11. STUN (port 3478/5349 or magic cookie detection for non-standard ports)
+    // 12. STUN (port 3478/5349 or magic cookie detection for non-standard ports)
     if (local_port == PORT_STUN
         || remote_port == PORT_STUN
         || local_port == PORT_STUN_TLS
@@ -236,7 +256,7 @@ pub fn analyze_udp_packet(
         });
     }
 
-    // 12. BitTorrent DHT / uTP (no port gating — signature-based)
+    // 13. BitTorrent DHT / uTP (no port gating — signature-based)
     if let Some(bt_result) = bittorrent::analyze_udp_bittorrent(payload) {
         return Some(DpiResult {
             application: ApplicationProtocol::BitTorrent(bt_result),

--- a/src/network/dpi/sip.rs
+++ b/src/network/dpi/sip.rs
@@ -56,11 +56,15 @@ pub fn analyze_sip(payload: &[u8]) -> Option<SipInfo> {
         request_uri: start_line.request_uri,
         status_code: start_line.status_code,
         reason_phrase: start_line.reason_phrase,
+        cseq_number: None,
+        cseq_method: None,
         from: None,
         to: None,
         call_id: None,
         user_agent: None,
         server: None,
+        content_type: None,
+        has_sdp: false,
     };
 
     for line in text.lines().skip(1) {
@@ -93,6 +97,16 @@ pub fn analyze_sip(payload: &[u8]) -> Option<SipInfo> {
                     info.call_id = Some(value.to_string());
                 }
             }
+            "cseq" => {
+                if let Some((number, method)) = parse_cseq(value) {
+                    if info.cseq_number.is_none() {
+                        info.cseq_number = Some(number);
+                    }
+                    if info.cseq_method.is_none() {
+                        info.cseq_method = Some(method);
+                    }
+                }
+            }
             "user-agent" => {
                 if info.user_agent.is_none() {
                     info.user_agent = Some(value.to_string());
@@ -101,6 +115,14 @@ pub fn analyze_sip(payload: &[u8]) -> Option<SipInfo> {
             "server" => {
                 if info.server.is_none() {
                     info.server = Some(value.to_string());
+                }
+            }
+            "content-type" | "c" => {
+                if info.content_type.is_none() {
+                    info.content_type = Some(value.to_string());
+                }
+                if value.eq_ignore_ascii_case("application/sdp") {
+                    info.has_sdp = true;
                 }
             }
             _ => {}
@@ -164,6 +186,14 @@ fn is_known_sip_method(method: &str) -> bool {
     )
 }
 
+fn parse_cseq(value: &str) -> Option<(u32, String)> {
+    let mut parts = value.split_whitespace();
+    let number = parts.next()?.parse::<u32>().ok()?;
+    let method = parts.next()?;
+
+    Some((number, method.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,18 +205,24 @@ Via: SIP/2.0/UDP pc33.example.com;branch=z9hG4bK776asdhds\r\n\
 From: Alice <sip:alice@example.com>;tag=1928301774\r\n\
 To: Bob <sip:bob@example.com>\r\n\
 Call-ID: a84b4c76e66710@pc33.example.com\r\n\
+CSeq: 314159 INVITE\r\n\
 User-Agent: Softphone/1.0\r\n\
+Content-Type: application/sdp\r\n\
 \r\n";
 
         let info = analyze_sip(packet).expect("should parse");
         assert!(!info.is_response);
         assert_eq!(info.method.as_deref(), Some("INVITE"));
         assert_eq!(info.request_uri.as_deref(), Some("sip:bob@example.com"));
+        assert_eq!(info.cseq_number, Some(314159));
+        assert_eq!(info.cseq_method.as_deref(), Some("INVITE"));
         assert_eq!(
             info.call_id.as_deref(),
             Some("a84b4c76e66710@pc33.example.com")
         );
         assert_eq!(info.user_agent.as_deref(), Some("Softphone/1.0"));
+        assert_eq!(info.content_type.as_deref(), Some("application/sdp"));
+        assert!(info.has_sdp);
     }
 
     #[test]
@@ -197,12 +233,15 @@ From: Alice <sip:alice@example.com>;tag=9fxced76sl\r\n\
 To: Bob <sip:bob@example.com>;tag=8321234356\r\n\
 Call-ID: 3848276298220188511@atlanta.example.com\r\n\
 Server: PBX/2.1\r\n\
+CSeq: 1 INVITE\r\n\
 \r\n";
 
         let info = analyze_sip(packet).expect("should parse");
         assert!(info.is_response);
         assert_eq!(info.status_code, Some(200));
         assert_eq!(info.reason_phrase.as_deref(), Some("OK"));
+        assert_eq!(info.cseq_number, Some(1));
+        assert_eq!(info.cseq_method.as_deref(), Some("INVITE"));
         assert_eq!(info.server.as_deref(), Some("PBX/2.1"));
     }
 
@@ -212,6 +251,7 @@ Server: PBX/2.1\r\n\
 f: <sip:alice@example.com>\r\n\
 t: <sip:alice@example.com>\r\n\
 i: 12345@client.example.com\r\n\
+c: application/sdp\r\n\
 \r\n";
 
         let info = analyze_sip(packet).expect("should parse");
@@ -219,6 +259,19 @@ i: 12345@client.example.com\r\n\
         assert_eq!(info.from.as_deref(), Some("<sip:alice@example.com>"));
         assert_eq!(info.to.as_deref(), Some("<sip:alice@example.com>"));
         assert_eq!(info.call_id.as_deref(), Some("12345@client.example.com"));
+        assert_eq!(info.content_type.as_deref(), Some("application/sdp"));
+        assert!(info.has_sdp);
+    }
+
+    #[test]
+    fn test_sip_non_sdp_content_type() {
+        let packet = b"INFO sip:bob@example.com SIP/2.0\r\n\
+Content-Type: application/dtmf-relay\r\n\
+\r\n";
+
+        let info = analyze_sip(packet).expect("should parse");
+        assert_eq!(info.content_type.as_deref(), Some("application/dtmf-relay"));
+        assert!(!info.has_sdp);
     }
 
     #[test]

--- a/src/network/dpi/sip.rs
+++ b/src/network/dpi/sip.rs
@@ -1,0 +1,243 @@
+//! SIP (Session Initiation Protocol) Deep Packet Inspection
+//!
+//! Parses plaintext SIP requests and responses over UDP/TCP.
+//! This intentionally focuses on high-value start-line and header fields.
+
+use crate::network::types::SipInfo;
+
+const MIN_SIP_SIZE: usize = 12;
+const SIP_VERSION: &str = "SIP/2.0";
+
+struct SipStartLine {
+    is_response: bool,
+    method: Option<String>,
+    request_uri: Option<String>,
+    status_code: Option<u16>,
+    reason_phrase: Option<String>,
+}
+
+/// Quick check if payload looks like a SIP message.
+pub fn is_likely_sip(payload: &[u8]) -> bool {
+    if payload.len() < MIN_SIP_SIZE {
+        return false;
+    }
+
+    if !payload
+        .iter()
+        .take(32)
+        .all(|&b| b.is_ascii_graphic() || matches!(b, b' ' | b'\r' | b'\n' | b'\t'))
+    {
+        return false;
+    }
+
+    let Ok(text) = std::str::from_utf8(payload) else {
+        return false;
+    };
+    let Some(first_line) = text.lines().next() else {
+        return false;
+    };
+
+    parse_start_line(first_line.trim()).is_some()
+}
+
+/// Analyze a SIP request/response and extract key fields.
+pub fn analyze_sip(payload: &[u8]) -> Option<SipInfo> {
+    if !is_likely_sip(payload) {
+        return None;
+    }
+
+    let text = std::str::from_utf8(payload).ok()?;
+    let first_line = text.lines().next()?.trim();
+    let start_line = parse_start_line(first_line)?;
+
+    let mut info = SipInfo {
+        is_response: start_line.is_response,
+        method: start_line.method,
+        request_uri: start_line.request_uri,
+        status_code: start_line.status_code,
+        reason_phrase: start_line.reason_phrase,
+        from: None,
+        to: None,
+        call_id: None,
+        user_agent: None,
+        server: None,
+    };
+
+    for line in text.lines().skip(1) {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+
+        match name.trim().to_ascii_lowercase().as_str() {
+            "from" | "f" => {
+                if info.from.is_none() {
+                    info.from = Some(value.to_string());
+                }
+            }
+            "to" | "t" => {
+                if info.to.is_none() {
+                    info.to = Some(value.to_string());
+                }
+            }
+            "call-id" | "i" => {
+                if info.call_id.is_none() {
+                    info.call_id = Some(value.to_string());
+                }
+            }
+            "user-agent" => {
+                if info.user_agent.is_none() {
+                    info.user_agent = Some(value.to_string());
+                }
+            }
+            "server" => {
+                if info.server.is_none() {
+                    info.server = Some(value.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Some(info)
+}
+
+fn parse_start_line(first_line: &str) -> Option<SipStartLine> {
+    if let Some(rest) = first_line.strip_prefix("SIP/2.0 ") {
+        let mut parts = rest.split_whitespace();
+        let status_code = parts.next()?.parse::<u16>().ok()?;
+        let reason_phrase = rest
+            .split_once(' ')
+            .and_then(|(_, reason)| (!reason.trim().is_empty()).then(|| reason.trim().to_string()));
+        return Some(SipStartLine {
+            is_response: true,
+            method: None,
+            request_uri: None,
+            status_code: Some(status_code),
+            reason_phrase,
+        });
+    }
+
+    let mut parts = first_line.split_whitespace();
+    let method = parts.next()?;
+    let request_uri = parts.next()?;
+    let version = parts.next()?;
+
+    if !is_known_sip_method(method) || version != SIP_VERSION {
+        return None;
+    }
+
+    Some(SipStartLine {
+        is_response: false,
+        method: Some(method.to_string()),
+        request_uri: Some(request_uri.to_string()),
+        status_code: None,
+        reason_phrase: None,
+    })
+}
+
+fn is_known_sip_method(method: &str) -> bool {
+    matches!(
+        method,
+        "INVITE"
+            | "ACK"
+            | "BYE"
+            | "CANCEL"
+            | "REGISTER"
+            | "OPTIONS"
+            | "PRACK"
+            | "SUBSCRIBE"
+            | "NOTIFY"
+            | "PUBLISH"
+            | "INFO"
+            | "REFER"
+            | "MESSAGE"
+            | "UPDATE"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sip_invite_request() {
+        let packet = b"INVITE sip:bob@example.com SIP/2.0\r\n\
+Via: SIP/2.0/UDP pc33.example.com;branch=z9hG4bK776asdhds\r\n\
+From: Alice <sip:alice@example.com>;tag=1928301774\r\n\
+To: Bob <sip:bob@example.com>\r\n\
+Call-ID: a84b4c76e66710@pc33.example.com\r\n\
+User-Agent: Softphone/1.0\r\n\
+\r\n";
+
+        let info = analyze_sip(packet).expect("should parse");
+        assert!(!info.is_response);
+        assert_eq!(info.method.as_deref(), Some("INVITE"));
+        assert_eq!(info.request_uri.as_deref(), Some("sip:bob@example.com"));
+        assert_eq!(
+            info.call_id.as_deref(),
+            Some("a84b4c76e66710@pc33.example.com")
+        );
+        assert_eq!(info.user_agent.as_deref(), Some("Softphone/1.0"));
+    }
+
+    #[test]
+    fn test_sip_response() {
+        let packet = b"SIP/2.0 200 OK\r\n\
+Via: SIP/2.0/UDP server.example.com;branch=z9hG4bK74bf9\r\n\
+From: Alice <sip:alice@example.com>;tag=9fxced76sl\r\n\
+To: Bob <sip:bob@example.com>;tag=8321234356\r\n\
+Call-ID: 3848276298220188511@atlanta.example.com\r\n\
+Server: PBX/2.1\r\n\
+\r\n";
+
+        let info = analyze_sip(packet).expect("should parse");
+        assert!(info.is_response);
+        assert_eq!(info.status_code, Some(200));
+        assert_eq!(info.reason_phrase.as_deref(), Some("OK"));
+        assert_eq!(info.server.as_deref(), Some("PBX/2.1"));
+    }
+
+    #[test]
+    fn test_sip_compact_headers() {
+        let packet = b"REGISTER sip:registrar.example.com SIP/2.0\r\n\
+f: <sip:alice@example.com>\r\n\
+t: <sip:alice@example.com>\r\n\
+i: 12345@client.example.com\r\n\
+\r\n";
+
+        let info = analyze_sip(packet).expect("should parse");
+        assert_eq!(info.method.as_deref(), Some("REGISTER"));
+        assert_eq!(info.from.as_deref(), Some("<sip:alice@example.com>"));
+        assert_eq!(info.to.as_deref(), Some("<sip:alice@example.com>"));
+        assert_eq!(info.call_id.as_deref(), Some("12345@client.example.com"));
+    }
+
+    #[test]
+    fn test_http_not_sip() {
+        let packet = b"OPTIONS / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        assert!(!is_likely_sip(packet));
+        assert!(analyze_sip(packet).is_none());
+    }
+
+    #[test]
+    fn test_binary_not_sip() {
+        let packet = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03];
+        assert!(!is_likely_sip(&packet));
+    }
+
+    #[test]
+    fn test_invalid_start_line() {
+        let packet = b"HELLO sip:bob@example.com SIP/2.0\r\n\r\n";
+        assert!(!is_likely_sip(packet));
+        assert!(analyze_sip(packet).is_none());
+    }
+}

--- a/src/network/merge.rs
+++ b/src/network/merge.rs
@@ -897,6 +897,12 @@ fn merge_sip_info(old_info: &mut SipInfo, new_info: &SipInfo) {
     if new_info.reason_phrase.is_some() {
         old_info.reason_phrase.clone_from(&new_info.reason_phrase);
     }
+    if old_info.cseq_number.is_none() && new_info.cseq_number.is_some() {
+        old_info.cseq_number = new_info.cseq_number;
+    }
+    if old_info.cseq_method.is_none() && new_info.cseq_method.is_some() {
+        old_info.cseq_method.clone_from(&new_info.cseq_method);
+    }
     if old_info.from.is_none() && new_info.from.is_some() {
         old_info.from.clone_from(&new_info.from);
     }
@@ -912,6 +918,10 @@ fn merge_sip_info(old_info: &mut SipInfo, new_info: &SipInfo) {
     if old_info.server.is_none() && new_info.server.is_some() {
         old_info.server.clone_from(&new_info.server);
     }
+    if old_info.content_type.is_none() && new_info.content_type.is_some() {
+        old_info.content_type.clone_from(&new_info.content_type);
+    }
+    old_info.has_sdp |= new_info.has_sdp;
 }
 
 /// Update connection rate calculations using sliding window

--- a/src/network/merge.rs
+++ b/src/network/merge.rs
@@ -7,7 +7,7 @@ use crate::network::dpi::{DpiResult, is_partial_sni, try_extract_tls_from_reasse
 use crate::network::parser::{ParsedPacket, TcpFlags};
 use crate::network::types::{
     ApplicationProtocol, Connection, DnsInfo, DpiInfo, HttpInfo, HttpsInfo, MqttInfo,
-    ProtocolState, QuicConnectionState, QuicInfo, SshInfo, TcpState,
+    ProtocolState, QuicConnectionState, QuicInfo, SipInfo, SshInfo, TcpState,
 };
 
 /// Get the priority of a QUIC connection state for proper state progression
@@ -494,6 +494,11 @@ fn merge_dpi_info(conn: &mut Connection, dpi_result: &DpiResult) {
                     merge_mqtt_info(old_info, new_info);
                 }
 
+                // SIP - merge dialog identifiers and latest request/response summary
+                (ApplicationProtocol::Sip(old_info), ApplicationProtocol::Sip(new_info)) => {
+                    merge_sip_info(old_info, new_info);
+                }
+
                 _ => {
                     // Keep existing protocol
                 }
@@ -874,6 +879,39 @@ fn merge_mqtt_info(old_info: &mut MqttInfo, new_info: &MqttInfo) {
     }
     // Always update packet_type to show the latest activity
     old_info.packet_type = new_info.packet_type;
+}
+
+/// Merge SIP information
+fn merge_sip_info(old_info: &mut SipInfo, new_info: &SipInfo) {
+    old_info.is_response = new_info.is_response;
+
+    if new_info.method.is_some() {
+        old_info.method.clone_from(&new_info.method);
+    }
+    if new_info.request_uri.is_some() {
+        old_info.request_uri.clone_from(&new_info.request_uri);
+    }
+    if new_info.status_code.is_some() {
+        old_info.status_code = new_info.status_code;
+    }
+    if new_info.reason_phrase.is_some() {
+        old_info.reason_phrase.clone_from(&new_info.reason_phrase);
+    }
+    if old_info.from.is_none() && new_info.from.is_some() {
+        old_info.from.clone_from(&new_info.from);
+    }
+    if old_info.to.is_none() && new_info.to.is_some() {
+        old_info.to.clone_from(&new_info.to);
+    }
+    if old_info.call_id.is_none() && new_info.call_id.is_some() {
+        old_info.call_id.clone_from(&new_info.call_id);
+    }
+    if old_info.user_agent.is_none() && new_info.user_agent.is_some() {
+        old_info.user_agent.clone_from(&new_info.user_agent);
+    }
+    if old_info.server.is_none() && new_info.server.is_some() {
+        old_info.server.clone_from(&new_info.server);
+    }
 }
 
 /// Update connection rate calculations using sliding window

--- a/src/network/services.rs
+++ b/src/network/services.rs
@@ -87,6 +87,7 @@ impl ServiceLookup {
         lookup.add_service(143, Protocol::Tcp, "imap");
         lookup.add_service(443, Protocol::Tcp, "https");
         lookup.add_service(445, Protocol::Tcp, "microsoft-ds");
+        lookup.add_service(5060, Protocol::Tcp, "sip");
         lookup.add_service(587, Protocol::Tcp, "submission");
         lookup.add_service(993, Protocol::Tcp, "imaps");
         lookup.add_service(995, Protocol::Tcp, "pop3s");

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -118,10 +118,20 @@ impl std::fmt::Display for ApplicationProtocol {
             }
             ApplicationProtocol::Sip(info) => {
                 if let Some(status_code) = info.status_code {
-                    write!(f, "SIP {}", status_code)
+                    if info.has_sdp {
+                        write!(f, "SIP {} (SDP)", status_code)
+                    } else {
+                        write!(f, "SIP {}", status_code)
+                    }
                 } else if let Some(method) = &info.method {
                     if let Some(uri) = &info.request_uri {
-                        write!(f, "SIP {} ({})", method, uri)
+                        if info.has_sdp {
+                            write!(f, "SIP {} ({} SDP)", method, uri)
+                        } else {
+                            write!(f, "SIP {} ({})", method, uri)
+                        }
+                    } else if info.has_sdp {
+                        write!(f, "SIP {} (SDP)", method)
                     } else {
                         write!(f, "SIP {}", method)
                     }
@@ -740,11 +750,15 @@ pub struct SipInfo {
     pub request_uri: Option<String>,
     pub status_code: Option<u16>,
     pub reason_phrase: Option<String>,
+    pub cseq_number: Option<u32>,
+    pub cseq_method: Option<String>,
     pub from: Option<String>,
     pub to: Option<String>,
     pub call_id: Option<String>,
     pub user_agent: Option<String>,
     pub server: Option<String>,
+    pub content_type: Option<String>,
+    pub has_sdp: bool,
 }
 
 // NetBIOS-specific types

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -116,6 +116,19 @@ impl std::fmt::Display for ApplicationProtocol {
                     write!(f, "SSDP {}", info.method)
                 }
             }
+            ApplicationProtocol::Sip(info) => {
+                if let Some(status_code) = info.status_code {
+                    write!(f, "SIP {}", status_code)
+                } else if let Some(method) = &info.method {
+                    if let Some(uri) = &info.request_uri {
+                        write!(f, "SIP {} ({})", method, uri)
+                    } else {
+                        write!(f, "SIP {}", method)
+                    }
+                } else {
+                    write!(f, "SIP")
+                }
+            }
             ApplicationProtocol::NetBios(info) => {
                 if let Some(name) = &info.name {
                     write!(f, "NetBIOS {} ({})", info.service, name)
@@ -354,6 +367,7 @@ pub enum ApplicationProtocol {
     Dhcp(DhcpInfo),
     Snmp(SnmpInfo),
     Ssdp(SsdpInfo),
+    Sip(SipInfo),
     NetBios(NetBiosInfo),
     BitTorrent(BitTorrentInfo),
     Stun(StunInfo),
@@ -375,6 +389,7 @@ impl ApplicationProtocol {
             ApplicationProtocol::NetBios(_) => "NetBIOS",
             ApplicationProtocol::Ntp(_) => "NTP",
             ApplicationProtocol::Quic(_) => "QUIC",
+            ApplicationProtocol::Sip(_) => "SIP",
             ApplicationProtocol::Snmp(_) => "SNMP",
             ApplicationProtocol::Ssh(_) => "SSH",
             ApplicationProtocol::Ssdp(_) => "SSDP",
@@ -715,6 +730,21 @@ impl std::fmt::Display for SsdpMethod {
             SsdpMethod::Response => write!(f, "RESPONSE"),
         }
     }
+}
+
+// SIP-specific types
+#[derive(Debug, Clone)]
+pub struct SipInfo {
+    pub is_response: bool,
+    pub method: Option<String>,
+    pub request_uri: Option<String>,
+    pub status_code: Option<u16>,
+    pub reason_phrase: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub call_id: Option<String>,
+    pub user_agent: Option<String>,
+    pub server: Option<String>,
 }
 
 // NetBIOS-specific types
@@ -1475,6 +1505,7 @@ impl AppProtocolDistribution {
                     | ApplicationProtocol::Dhcp(_)
                     | ApplicationProtocol::Snmp(_)
                     | ApplicationProtocol::Ssdp(_)
+                    | ApplicationProtocol::Sip(_)
                     | ApplicationProtocol::NetBios(_)
                     | ApplicationProtocol::BitTorrent(_)
                     | ApplicationProtocol::Stun(_)
@@ -1987,6 +2018,15 @@ impl Connection {
                         ApplicationProtocol::Ssdp(info) => {
                             Cow::Owned(format!("SSDP_{}", info.method))
                         }
+                        ApplicationProtocol::Sip(info) => {
+                            if let Some(status_code) = info.status_code {
+                                Cow::Owned(format!("SIP_{}", status_code))
+                            } else if let Some(method) = &info.method {
+                                Cow::Owned(format!("SIP_{}", method))
+                            } else {
+                                Cow::Borrowed("SIP")
+                            }
+                        }
                         ApplicationProtocol::NetBios(info) => {
                             Cow::Owned(format!("NETBIOS_{}", info.service))
                         }
@@ -2109,6 +2149,7 @@ impl Connection {
                         ApplicationProtocol::Dhcp(_) => Duration::from_secs(60),
                         ApplicationProtocol::Snmp(_) => Duration::from_secs(60),
                         ApplicationProtocol::Ssdp(_) => Duration::from_secs(30),
+                        ApplicationProtocol::Sip(_) => Duration::from_secs(120),
                         ApplicationProtocol::NetBios(_) => Duration::from_secs(60),
                         ApplicationProtocol::BitTorrent(_) => Duration::from_secs(60),
                         ApplicationProtocol::Stun(_) => Duration::from_secs(30),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3805,6 +3805,96 @@ fn draw_connection_details(
                     );
                 }
             }
+            crate::network::types::ApplicationProtocol::Sip(info) => {
+                push_detail_field(
+                    &mut details_text,
+                    &mut detail_fields,
+                    "Type",
+                    if info.is_response {
+                        "Response"
+                    } else {
+                        "Request"
+                    }
+                    .to_string(),
+                    label_style,
+                );
+                if let Some(method) = &info.method {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Method",
+                        method.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(status_code) = info.status_code {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Status",
+                        if let Some(reason) = &info.reason_phrase {
+                            format!("{} {}", status_code, reason)
+                        } else {
+                            status_code.to_string()
+                        },
+                        label_style,
+                    );
+                }
+                if let Some(request_uri) = &info.request_uri {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Request URI",
+                        request_uri.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(from) = &info.from {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "From",
+                        from.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(to) = &info.to {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "To",
+                        to.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(call_id) = &info.call_id {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Call-ID",
+                        call_id.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(user_agent) = &info.user_agent {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "User-Agent",
+                        user_agent.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(server) = &info.server {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Server",
+                        server.clone(),
+                        label_style,
+                    );
+                }
+            }
             crate::network::types::ApplicationProtocol::NetBios(info) => {
                 push_detail_field(
                     &mut details_text,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3849,6 +3849,19 @@ fn draw_connection_details(
                         label_style,
                     );
                 }
+                if let Some(cseq_number) = info.cseq_number {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "CSeq",
+                        if let Some(method) = &info.cseq_method {
+                            format!("{} {}", cseq_number, method)
+                        } else {
+                            cseq_number.to_string()
+                        },
+                        label_style,
+                    );
+                }
                 if let Some(from) = &info.from {
                     push_detail_field(
                         &mut details_text,
@@ -3891,6 +3904,24 @@ fn draw_connection_details(
                         &mut detail_fields,
                         "Server",
                         server.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(content_type) = &info.content_type {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Content-Type",
+                        content_type.clone(),
+                        label_style,
+                    );
+                }
+                if info.has_sdp {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Body",
+                        "SDP".to_string(),
                         label_style,
                     );
                 }


### PR DESCRIPTION
## Summary
- add DPI detection and parsing for plaintext SIP over TCP/UDP
- extract SIP metadata including `From`, `To`, `Call-ID`, `User-Agent`, `Server`, `CSeq`, and `Content-Type`
- derive `has_sdp`, surface SIP metadata in filtering/merge/UI, and document the new protocol support
- tighten HTTP request parsing so `SIP/2.0` traffic is not misclassified as HTTP

## Verification
- `cargo fmt --all`
- full `cargo test` / `clippy` were not completed locally because the environment stalled on the configured cargo mirror index update

Closes #260