### PR TITLE
feat(dpi): add SIP protocol detection and metadata extraction

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -479,6 +479,41 @@ impl ConnectionFilter {
                     return true;
                 }
             }
+            ApplicationProtocol::Sip(info) => {
+                if match_text("sip", fv) {
+                    return true;
+                }
+                if let Some(ref m) = info.method
+                    && match_text(m, fv)
+                {
+                    return true;
+                }
+                if let Some(ref call_id) = info.call_id
+                    && match_text(call_id, fv)
+                {
+                    return true;
+                }
+                if let Some(ref from) = info.from
+                    && match_text(from, fv)
+                {
+                    return true;
+                }
+                if let Some(ref to) = info.to
+                    && match_text(to, fv)
+                {
+                    return true;
+                }
+                if let Some(ref ua) = info.user_agent
+                    && match_text(ua, fv)
+                {
+                    return true;
+                }
+                if let Some(ref server) = info.server
+                    && match_text(server, fv)
+                {
+                    return true;
+                }
+            }
         }
 
         false

--- a/src/network/dpi/mod.rs
+++ b/src/network/dpi/mod.rs
@@ -13,6 +13,7 @@ mod mqtt;
 mod netbios;
 mod ntp;
 mod quic;
+mod sip;
 mod snmp;
 mod ssdp;
 mod ssh;
@@ -38,6 +39,10 @@ const PORT_MDNS: u16 = 5353;
 const PORT_STUN: u16 = 3478;
 const PORT_STUN_TLS: u16 = 5349;
 const PORT_LLMNR: u16 = 5355;
+// SIP signaling: RFC 3261 reserves 5060 (plain) and 5061 (TLS). 5061 is
+// included only as a port hint; encrypted bodies are not parsed.
+const PORT_SIP: u16 = 5060;
+const PORT_SIP_TLS: u16 = 5061;
 
 /// Result of DPI analysis
 #[derive(Debug, Clone)]
@@ -57,6 +62,23 @@ pub fn analyze_tcp_packet(
     }
 
     // Try protocols in order of likelihood/speed
+
+    // 0. SIP — checked before HTTP because the two share a request-line
+    // grammar (`METHOD <uri> <version>`). Disambiguation hinges on the
+    // trailing version token (`SIP/2.0` vs `HTTP/x.y`); without this
+    // pre-flight check SIP `INVITE`/`OPTIONS`/`MESSAGE` could be
+    // misclassified as HTTP. The signature check is O(line length).
+    if (local_port == PORT_SIP
+        || remote_port == PORT_SIP
+        || local_port == PORT_SIP_TLS
+        || remote_port == PORT_SIP_TLS
+        || sip::is_sip(payload))
+        && let Some(sip_result) = sip::analyze_sip(payload)
+    {
+        return Some(DpiResult {
+            application: ApplicationProtocol::Sip(sip_result),
+        });
+    }
 
     // 1. Check for HTTP (fast string matching)
     if let Some(http_result) = http::analyze_http(payload) {
@@ -240,6 +262,18 @@ pub fn analyze_udp_packet(
     if let Some(bt_result) = bittorrent::analyze_udp_bittorrent(payload) {
         return Some(DpiResult {
             application: ApplicationProtocol::BitTorrent(bt_result),
+        });
+    }
+
+    // 13. SIP over UDP (port 5060 or start-line signature). Placed after
+    // structured binary protocols above so it never shadows them; the
+    // signature check is line-oriented and rejects non-text payloads
+    // quickly.
+    if (local_port == PORT_SIP || remote_port == PORT_SIP || sip::is_sip(payload))
+        && let Some(sip_result) = sip::analyze_sip(payload)
+    {
+        return Some(DpiResult {
+            application: ApplicationProtocol::Sip(sip_result),
         });
     }
 

--- a/src/network/dpi/sip.rs
+++ b/src/network/dpi/sip.rs
@@ -1,0 +1,338 @@
+//! SIP (Session Initiation Protocol) Deep Packet Inspection
+//!
+//! Best-effort detection and metadata extraction for plaintext SIP over
+//! TCP/UDP per RFC 3261. SIP shares its message grammar with HTTP (start
+//! line plus headers separated by CRLF, terminated by an empty line), so
+//! detection runs *before* HTTP analysis to avoid misclassifying messages
+//! whose protocol version reads `SIP/2.0`.
+//!
+//! Extracted headers: `From`, `To`, `Call-ID`, `CSeq`, `User-Agent`,
+//! `Server`, `Content-Type`. The `has_sdp` flag is derived from
+//! `Content-Type: application/sdp`.
+
+use crate::network::types::{SipInfo, SipMessageType};
+
+const SIP_VERSION: &str = "SIP/2.0";
+const SIP_VERSION_PREFIX: &[u8] = b"SIP/2.0";
+
+/// Quick signature check: a SIP message starts either with a known
+/// request method followed by space, or with `SIP/2.0` (response).
+pub fn is_sip(payload: &[u8]) -> bool {
+    if payload.len() < 8 {
+        return false;
+    }
+
+    // Responses: "SIP/2.0 200 OK\r\n"
+    if payload.starts_with(SIP_VERSION_PREFIX) {
+        // Must be followed by a space and a 3-digit status code.
+        return payload
+            .get(SIP_VERSION_PREFIX.len())
+            .is_some_and(|&b| b == b' ');
+    }
+
+    // Requests: "METHOD <uri> SIP/2.0\r\n". The fastest discriminator
+    // from HTTP is the trailing protocol token, but scanning the whole
+    // line is cheap; do that.
+    let line_end = payload
+        .iter()
+        .take(1024)
+        .position(|&b| b == b'\r' || b == b'\n')
+        .unwrap_or(payload.len().min(1024));
+    let first_line = &payload[..line_end];
+
+    if !is_likely_sip_method_prefix(first_line) {
+        return false;
+    }
+
+    // Must terminate with "SIP/2.0".
+    first_line
+        .windows(SIP_VERSION_PREFIX.len())
+        .any(|w| w == SIP_VERSION_PREFIX)
+}
+
+/// SIP request methods per RFC 3261 + common extensions (RFC 3262/3265/3311/3428/3515/3903/6086).
+const SIP_METHODS: &[&[u8]] = &[
+    b"INVITE ",
+    b"ACK ",
+    b"BYE ",
+    b"CANCEL ",
+    b"REGISTER ",
+    b"OPTIONS ",
+    b"PRACK ",
+    b"SUBSCRIBE ",
+    b"NOTIFY ",
+    b"PUBLISH ",
+    b"INFO ",
+    b"REFER ",
+    b"MESSAGE ",
+    b"UPDATE ",
+];
+
+fn is_likely_sip_method_prefix(line: &[u8]) -> bool {
+    SIP_METHODS.iter().any(|m| line.starts_with(m))
+}
+
+/// Parse a plaintext SIP message and extract a `SipInfo`. Returns `None`
+/// if the start line does not match the SIP grammar.
+pub fn analyze_sip(payload: &[u8]) -> Option<SipInfo> {
+    if !is_sip(payload) {
+        return None;
+    }
+
+    // SIP is line-oriented ASCII; tolerate lone LF in the wild.
+    let text = match std::str::from_utf8(payload) {
+        Ok(s) => s,
+        Err(_) => return None,
+    };
+
+    let mut lines = text.split('\n');
+    let start_line_raw = lines.next()?.trim_end_matches('\r');
+
+    let mut info = SipInfo::default();
+    parse_start_line(start_line_raw, &mut info)?;
+
+    for line in lines {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break; // end of headers
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim();
+        let value = value.trim();
+
+        // First-wins for stable identity headers; match guards keep the
+        // declaration flat and satisfy clippy's collapsible_match lint.
+        match canonical_header_name(name).as_str() {
+            "from" | "f" if info.from.is_none() => {
+                info.from = Some(value.to_string());
+            }
+            "to" | "t" if info.to.is_none() => {
+                info.to = Some(value.to_string());
+            }
+            "call-id" | "i" if info.call_id.is_none() => {
+                info.call_id = Some(value.to_string());
+            }
+            "user-agent" if info.user_agent.is_none() => {
+                info.user_agent = Some(value.to_string());
+            }
+            "server" if info.server.is_none() => {
+                info.server = Some(value.to_string());
+            }
+            "cseq" => {
+                parse_cseq(value, &mut info);
+            }
+            "content-type" | "c" if info.content_type.is_none() => {
+                let ct = value.to_string();
+                info.has_sdp = ct
+                    .split(';')
+                    .next()
+                    .map(|t| t.trim().eq_ignore_ascii_case("application/sdp"))
+                    .unwrap_or(false);
+                info.content_type = Some(ct);
+            }
+            _ => {}
+        }
+    }
+
+    Some(info)
+}
+
+fn parse_start_line(line: &str, info: &mut SipInfo) -> Option<()> {
+    if let Some(rest) = line.strip_prefix(SIP_VERSION) {
+        // Response: "SIP/2.0 200 OK"
+        let rest = rest.trim_start();
+        let mut parts = rest.splitn(2, ' ');
+        let code = parts.next()?.parse::<u16>().ok()?;
+        info.message_type = SipMessageType::Response;
+        info.status_code = Some(code);
+        info.reason_phrase = parts
+            .next()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        Some(())
+    } else {
+        // Request: "METHOD <uri> SIP/2.0"
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 3 {
+            return None;
+        }
+        if parts[parts.len() - 1] != SIP_VERSION {
+            return None;
+        }
+        info.message_type = SipMessageType::Request;
+        info.method = Some(parts[0].to_string());
+        Some(())
+    }
+}
+
+fn parse_cseq(value: &str, info: &mut SipInfo) {
+    // "CSeq: <number> <method>"
+    let mut parts = value.split_whitespace();
+    if let Some(num) = parts.next().and_then(|n| n.parse::<u32>().ok()) {
+        info.cseq_number = Some(num);
+    }
+    if let Some(method) = parts.next() {
+        if info.cseq_method.is_none() {
+            info.cseq_method = Some(method.to_string());
+        }
+        // For requests, prefer CSeq method if the start-line method was
+        // missing (some implementations split the request line oddly).
+        if info.method.is_none()
+            && matches!(
+                info.message_type,
+                SipMessageType::Request | SipMessageType::Unknown
+            )
+        {
+            info.method = Some(method.to_string());
+        }
+    }
+}
+
+/// RFC 3261 §7.3.1 — header names are case-insensitive and several have
+/// single-letter compact forms (e.g. `f` for `From`). Normalize to
+/// lowercase long form where it matters; otherwise return lowercase.
+fn canonical_header_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const INVITE: &[u8] = b"INVITE sip:bob@biloxi.example.com SIP/2.0\r\n\
+        Via: SIP/2.0/UDP pc33.atlanta.example.com;branch=z9hG4bK776asdhds\r\n\
+        Max-Forwards: 70\r\n\
+        To: Bob <sip:bob@biloxi.example.com>\r\n\
+        From: Alice <sip:alice@atlanta.example.com>;tag=1928301774\r\n\
+        Call-ID: a84b4c76e66710@pc33.atlanta.example.com\r\n\
+        CSeq: 314159 INVITE\r\n\
+        Contact: <sip:alice@pc33.atlanta.example.com>\r\n\
+        User-Agent: ExampleUA/1.0\r\n\
+        Content-Type: application/sdp\r\n\
+        Content-Length: 142\r\n\
+        \r\n\
+        v=0\r\n";
+
+    const RESPONSE_200: &[u8] = b"SIP/2.0 200 OK\r\n\
+        Via: SIP/2.0/UDP pc33.atlanta.example.com;branch=z9hG4bK776asdhds\r\n\
+        From: Alice <sip:alice@atlanta.example.com>;tag=1928301774\r\n\
+        To: Bob <sip:bob@biloxi.example.com>;tag=a6c85cf\r\n\
+        Call-ID: a84b4c76e66710@pc33.atlanta.example.com\r\n\
+        CSeq: 314159 INVITE\r\n\
+        Server: SomeServer/2.3\r\n\
+        Content-Length: 0\r\n\r\n";
+
+    const REGISTER: &[u8] = b"REGISTER sip:registrar.example.com SIP/2.0\r\n\
+        Via: SIP/2.0/UDP bobspc.example.com:5060;branch=z9hG4bKnashds7\r\n\
+        Max-Forwards: 70\r\n\
+        To: Bob <sip:bob@biloxi.example.com>\r\n\
+        From: Bob <sip:bob@biloxi.example.com>;tag=456248\r\n\
+        Call-ID: 843817637684230@998sdasdh09\r\n\
+        CSeq: 1826 REGISTER\r\n\
+        Content-Length: 0\r\n\r\n";
+
+    #[test]
+    fn detects_request() {
+        assert!(is_sip(INVITE));
+    }
+
+    #[test]
+    fn detects_response() {
+        assert!(is_sip(RESPONSE_200));
+    }
+
+    #[test]
+    fn rejects_http_request() {
+        let http = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        assert!(!is_sip(http));
+    }
+
+    #[test]
+    fn rejects_http_options_with_http_version() {
+        // The OPTIONS method also exists in SIP. Make sure HTTP-bound
+        // OPTIONS requests are not detected as SIP.
+        let http = b"OPTIONS / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        assert!(!is_sip(http));
+    }
+
+    #[test]
+    fn accepts_sip_options() {
+        let sip = b"OPTIONS sip:carol@chicago.example.com SIP/2.0\r\nVia: SIP/2.0/UDP h\r\n\r\n";
+        assert!(is_sip(sip));
+    }
+
+    #[test]
+    fn parses_invite_metadata() {
+        let info = analyze_sip(INVITE).expect("should parse INVITE");
+        assert_eq!(info.message_type, SipMessageType::Request);
+        assert_eq!(info.method.as_deref(), Some("INVITE"));
+        assert_eq!(info.status_code, None);
+        assert_eq!(
+            info.call_id.as_deref(),
+            Some("a84b4c76e66710@pc33.atlanta.example.com")
+        );
+        assert_eq!(info.cseq_number, Some(314159));
+        assert_eq!(info.cseq_method.as_deref(), Some("INVITE"));
+        assert_eq!(info.user_agent.as_deref(), Some("ExampleUA/1.0"));
+        assert_eq!(info.content_type.as_deref(), Some("application/sdp"));
+        assert!(info.has_sdp);
+        assert!(info.from.as_deref().unwrap().contains("alice"));
+        assert!(info.to.as_deref().unwrap().contains("bob"));
+    }
+
+    #[test]
+    fn parses_response_metadata() {
+        let info = analyze_sip(RESPONSE_200).expect("should parse 200");
+        assert_eq!(info.message_type, SipMessageType::Response);
+        assert_eq!(info.status_code, Some(200));
+        assert_eq!(info.reason_phrase.as_deref(), Some("OK"));
+        assert_eq!(info.cseq_method.as_deref(), Some("INVITE"));
+        assert_eq!(info.server.as_deref(), Some("SomeServer/2.3"));
+        assert!(!info.has_sdp);
+    }
+
+    #[test]
+    fn parses_register_without_body() {
+        let info = analyze_sip(REGISTER).expect("should parse REGISTER");
+        assert_eq!(info.method.as_deref(), Some("REGISTER"));
+        assert_eq!(info.cseq_number, Some(1826));
+        assert_eq!(info.cseq_method.as_deref(), Some("REGISTER"));
+        assert!(!info.has_sdp);
+    }
+
+    #[test]
+    fn handles_compact_headers() {
+        let payload = b"INVITE sip:b@x SIP/2.0\r\n\
+            f: Alice <sip:a@x>\r\n\
+            t: Bob <sip:b@x>\r\n\
+            i: callid-1@host\r\n\
+            CSeq: 1 INVITE\r\n\
+            c: application/sdp;charset=utf-8\r\n\r\n";
+        let info = analyze_sip(payload).expect("should parse compact headers");
+        assert!(info.from.as_deref().unwrap().contains("Alice"));
+        assert!(info.to.as_deref().unwrap().contains("Bob"));
+        assert_eq!(info.call_id.as_deref(), Some("callid-1@host"));
+        assert!(info.has_sdp);
+        assert!(
+            info.content_type
+                .as_deref()
+                .unwrap()
+                .contains("application/sdp")
+        );
+    }
+
+    #[test]
+    fn rejects_truncated() {
+        assert!(analyze_sip(b"INV").is_none());
+        assert!(analyze_sip(b"").is_none());
+    }
+
+    #[test]
+    fn rejects_lookalike_with_wrong_version() {
+        let bad = b"INVITE sip:b@x HTTP/1.1\r\n\r\n";
+        assert!(!is_sip(bad));
+        assert!(analyze_sip(bad).is_none());
+    }
+}

--- a/src/network/merge.rs
+++ b/src/network/merge.rs
@@ -7,7 +7,7 @@ use crate::network::dpi::{DpiResult, is_partial_sni, try_extract_tls_from_reasse
 use crate::network::parser::{ParsedPacket, TcpFlags};
 use crate::network::types::{
     ApplicationProtocol, Connection, DnsInfo, DpiInfo, HttpInfo, HttpsInfo, MqttInfo,
-    ProtocolState, QuicConnectionState, QuicInfo, SshInfo, TcpState,
+    ProtocolState, QuicConnectionState, QuicInfo, SipInfo, SipMessageType, SshInfo, TcpState,
 };
 
 /// Get the priority of a QUIC connection state for proper state progression
@@ -494,6 +494,13 @@ fn merge_dpi_info(conn: &mut Connection, dpi_result: &DpiResult) {
                     merge_mqtt_info(old_info, new_info);
                 }
 
+                // SIP — accumulate metadata across requests/responses in
+                // the same dialog (Call-ID is the join key in real life,
+                // but here we operate on a single connection at a time).
+                (ApplicationProtocol::Sip(old_info), ApplicationProtocol::Sip(new_info)) => {
+                    merge_sip_info(old_info, new_info);
+                }
+
                 _ => {
                     // Keep existing protocol
                 }
@@ -874,6 +881,53 @@ fn merge_mqtt_info(old_info: &mut MqttInfo, new_info: &MqttInfo) {
     }
     // Always update packet_type to show the latest activity
     old_info.packet_type = new_info.packet_type;
+}
+
+/// Merge SIP metadata across observed messages in the same connection.
+/// Stable identity fields (`Call-ID`, `From`, `To`, `User-Agent`,
+/// `Server`, `Content-Type`/`has_sdp`) are filled in only if missing.
+/// Volatile fields (`message_type`, `method`, `status_code`,
+/// `reason_phrase`, `CSeq`) are overwritten with whatever the most
+/// recent message carries so the TUI reflects the latest activity in a
+/// dialog.
+fn merge_sip_info(old_info: &mut SipInfo, new_info: &SipInfo) {
+    if old_info.call_id.is_none() && new_info.call_id.is_some() {
+        old_info.call_id.clone_from(&new_info.call_id);
+    }
+    if old_info.from.is_none() && new_info.from.is_some() {
+        old_info.from.clone_from(&new_info.from);
+    }
+    if old_info.to.is_none() && new_info.to.is_some() {
+        old_info.to.clone_from(&new_info.to);
+    }
+    if old_info.user_agent.is_none() && new_info.user_agent.is_some() {
+        old_info.user_agent.clone_from(&new_info.user_agent);
+    }
+    if old_info.server.is_none() && new_info.server.is_some() {
+        old_info.server.clone_from(&new_info.server);
+    }
+    if old_info.content_type.is_none() && new_info.content_type.is_some() {
+        old_info.content_type.clone_from(&new_info.content_type);
+        old_info.has_sdp |= new_info.has_sdp;
+    }
+
+    // Latest-wins for what the dialog is doing right now.
+    if new_info.message_type != SipMessageType::Unknown {
+        old_info.message_type = new_info.message_type.clone();
+    }
+    if new_info.method.is_some() {
+        old_info.method.clone_from(&new_info.method);
+    }
+    if new_info.status_code.is_some() {
+        old_info.status_code = new_info.status_code;
+        old_info.reason_phrase.clone_from(&new_info.reason_phrase);
+    }
+    if new_info.cseq_number.is_some() {
+        old_info.cseq_number = new_info.cseq_number;
+    }
+    if new_info.cseq_method.is_some() {
+        old_info.cseq_method.clone_from(&new_info.cseq_method);
+    }
 }
 
 /// Update connection rate calculations using sliding window

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -160,6 +160,27 @@ impl std::fmt::Display for ApplicationProtocol {
                     write!(f, "MQTT {}", info.packet_type)
                 }
             }
+            ApplicationProtocol::Sip(info) => match info.message_type {
+                SipMessageType::Request => {
+                    let method = info.method.as_deref().unwrap_or("REQ");
+                    if let Some(call_id) = &info.call_id {
+                        write!(f, "SIP {} ({})", method, call_id)
+                    } else {
+                        write!(f, "SIP {}", method)
+                    }
+                }
+                SipMessageType::Response => {
+                    let code = info.status_code.unwrap_or(0);
+                    let cseq = info.cseq_method.as_deref();
+                    match (cseq, &info.reason_phrase) {
+                        (Some(m), Some(reason)) => write!(f, "SIP {} {} ({})", code, reason, m),
+                        (Some(m), None) => write!(f, "SIP {} ({})", code, m),
+                        (None, Some(reason)) => write!(f, "SIP {} {}", code, reason),
+                        (None, None) => write!(f, "SIP {}", code),
+                    }
+                }
+                SipMessageType::Unknown => write!(f, "SIP"),
+            },
         }
     }
 }
@@ -341,6 +362,43 @@ pub struct MqttInfo {
     pub qos: Option<u8>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum SipMessageType {
+    #[default]
+    Unknown,
+    Request,
+    Response,
+}
+
+impl std::fmt::Display for SipMessageType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SipMessageType::Unknown => write!(f, "?"),
+            SipMessageType::Request => write!(f, "REQ"),
+            SipMessageType::Response => write!(f, "RESP"),
+        }
+    }
+}
+
+/// Metadata extracted by best-effort SIP DPI. Mirrors the fields named in
+/// RFC 3261 §7. `has_sdp` is derived from `Content-Type: application/sdp`.
+#[derive(Debug, Clone, Default)]
+pub struct SipInfo {
+    pub message_type: SipMessageType,
+    pub method: Option<String>,
+    pub status_code: Option<u16>,
+    pub reason_phrase: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub call_id: Option<String>,
+    pub user_agent: Option<String>,
+    pub server: Option<String>,
+    pub cseq_number: Option<u32>,
+    pub cseq_method: Option<String>,
+    pub content_type: Option<String>,
+    pub has_sdp: bool,
+}
+
 #[derive(Debug, Clone)]
 pub enum ApplicationProtocol {
     Http(HttpInfo),
@@ -358,6 +416,7 @@ pub enum ApplicationProtocol {
     BitTorrent(BitTorrentInfo),
     Stun(StunInfo),
     Mqtt(MqttInfo),
+    Sip(SipInfo),
 }
 
 impl ApplicationProtocol {
@@ -375,6 +434,7 @@ impl ApplicationProtocol {
             ApplicationProtocol::NetBios(_) => "NetBIOS",
             ApplicationProtocol::Ntp(_) => "NTP",
             ApplicationProtocol::Quic(_) => "QUIC",
+            ApplicationProtocol::Sip(_) => "SIP",
             ApplicationProtocol::Snmp(_) => "SNMP",
             ApplicationProtocol::Ssh(_) => "SSH",
             ApplicationProtocol::Ssdp(_) => "SSDP",
@@ -1478,7 +1538,8 @@ impl AppProtocolDistribution {
                     | ApplicationProtocol::NetBios(_)
                     | ApplicationProtocol::BitTorrent(_)
                     | ApplicationProtocol::Stun(_)
-                    | ApplicationProtocol::Mqtt(_) => dist.other_count += 1,
+                    | ApplicationProtocol::Mqtt(_)
+                    | ApplicationProtocol::Sip(_) => dist.other_count += 1,
                 }
             } else {
                 dist.other_count += 1;
@@ -1995,6 +2056,11 @@ impl Connection {
                             Cow::Owned(format!("STUN_{}", info.message_class))
                         }
                         ApplicationProtocol::Mqtt(_) => Cow::Borrowed("MQTT_UDP"),
+                        ApplicationProtocol::Sip(info) => match info.message_type {
+                            SipMessageType::Request => Cow::Borrowed("SIP_REQUEST"),
+                            SipMessageType::Response => Cow::Borrowed("SIP_RESPONSE"),
+                            SipMessageType::Unknown => Cow::Borrowed("SIP"),
+                        },
                     }
                 } else {
                     // Regular UDP without DPI classification
@@ -2113,6 +2179,9 @@ impl Connection {
                         ApplicationProtocol::BitTorrent(_) => Duration::from_secs(60),
                         ApplicationProtocol::Stun(_) => Duration::from_secs(30),
                         ApplicationProtocol::Mqtt(_) => Duration::from_secs(120),
+                        // SIP dialogs idle between transactions; INVITE
+                        // sessions can stay registered for many minutes.
+                        ApplicationProtocol::Sip(_) => Duration::from_secs(300),
                     }
                 } else {
                     // Regular UDP without DPI classification

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3967,6 +3967,105 @@ fn draw_connection_details(
                     );
                 }
             }
+            crate::network::types::ApplicationProtocol::Sip(info) => {
+                push_detail_field(
+                    &mut details_text,
+                    &mut detail_fields,
+                    "Message",
+                    info.message_type.to_string(),
+                    label_style,
+                );
+                if let Some(method) = &info.method {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Method",
+                        method.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(code) = info.status_code {
+                    let status = match &info.reason_phrase {
+                        Some(reason) => format!("{} {}", code, reason),
+                        None => code.to_string(),
+                    };
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Status",
+                        status,
+                        label_style,
+                    );
+                }
+                if let Some(from) = &info.from {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "From",
+                        from.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(to) = &info.to {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "To",
+                        to.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(call_id) = &info.call_id {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Call-ID",
+                        call_id.clone(),
+                        label_style,
+                    );
+                }
+                if let (Some(num), Some(method)) = (info.cseq_number, &info.cseq_method) {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "CSeq",
+                        format!("{} {}", num, method),
+                        label_style,
+                    );
+                }
+                if let Some(ua) = &info.user_agent {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "User-Agent",
+                        ua.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(server) = &info.server {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Server",
+                        server.clone(),
+                        label_style,
+                    );
+                }
+                if let Some(ct) = &info.content_type {
+                    let label = if info.has_sdp {
+                        format!("{} (SDP)", ct)
+                    } else {
+                        ct.clone()
+                    };
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Content-Type",
+                        label,
+                        label_style,
+                    );
+                }
+            }
         }
         right_ranges.push(dpi_start..details_text.len());
     }


### PR DESCRIPTION
Closes #260.

## Summary

Adds best-effort Deep Packet Inspection for plaintext SIP (RFC 3261) over TCP and UDP. SIP shares its request grammar with HTTP, so the detector runs **before** HTTP analysis and rejects payloads whose trailing version token is not `SIP/2.0` — this prevents `INVITE` / `OPTIONS` / `MESSAGE` traffic from being misclassified as HTTP.

## What it does

**Detection**
- Port 5060 (and 5061 hint), plus a cheap start-line signature so non-standard SIP ports are still caught.
- Request methods: `INVITE`, `ACK`, `BYE`, `CANCEL`, `REGISTER`, `OPTIONS`, `PRACK`, `SUBSCRIBE`, `NOTIFY`, `PUBLISH`, `INFO`, `REFER`, `MESSAGE`, `UPDATE`.
- Responses keyed off the `SIP/2.0 <status>` prefix.

**Extracted metadata** (per the issue scope)
- Request method / response status code + reason phrase.
- `From`, `To`, `Call-ID`, `User-Agent`, `Server` (long form + compact `f` / `t` / `i` / `c`).
- `CSeq` parsed into `cseq_number` + `cseq_method`.
- `Content-Type` plus a derived `has_sdp` flag for `application/sdp`.

**Surfaces**
- New `ApplicationProtocol::Sip(SipInfo)` variant with a Display formatter tuned for the connection-table column (requests show method + Call-ID; responses show status code + reason + CSeq method).
- DPI details panel in the TUI renders message type, method/status, `From`, `To`, `Call-ID`, `CSeq`, `User-Agent`, `Server`, `Content-Type` (with an `(SDP)` tag when `has_sdp` is set).
- UDP connection state reports `SIP_REQUEST` / `SIP_RESPONSE`.
- `ConnectionFilter` general search matches `sip`, method, Call-ID, From, To, User-Agent, Server — so existing fuzzy search just works.
- Per-protocol merge keeps stable identity fields and applies latest-wins for `message_type` / `method` / `status_code` / `CSeq`, mirroring how dialogs evolve across multiple packets in the same connection.
- `get_timeout` returns 5 minutes for SIP UDP flows so idle dialogs stay tracked between transactions.

## Why detection runs before HTTP

`INVITE sip:bob@x SIP/2.0` and `OPTIONS / HTTP/1.1` both look like `METHOD <uri> <version>`. The disambiguator is the trailing version token. `sip::is_sip` checks for `SIP/2.0` in the first line; only then does it consume the payload. HTTP traffic is rejected cheaply by the same check (the `OPTIONS` method also exists in SIP, so an explicit test for that case is included).

## Tests

10 new unit tests in `src/network/dpi/sip.rs`:

- Request + response detection.
- Full INVITE parsing (CSeq, headers, has_sdp).
- 200 OK parsing (status, reason, Server).
- REGISTER without body.
- Compact-form headers (`f`, `t`, `i`, `c`).
- HTTP / SIP disambiguation (`OPTIONS /` HTTP is rejected; `OPTIONS sip:…` is accepted).
- Truncated and wrong-version payloads return `None`.

Full suite locally:

- ` cargo test --all-features ` → 335 passed, 0 failed.
- ` cargo clippy --all-features --all-targets -- -D warnings ` → clean.
- ` cargo fmt --all -- --check ` → clean.
- ` cargo build --release ` → clean.

## Test plan

- [x] Unit tests pass locally on macOS (Apple Silicon).
- [ ] CI green on the PR.
- [ ] Live smoke test against a SIP softphone (recommended for the maintainer; I do not have a SIP endpoint handy on this machine).

## Files touched

- ` src/network/dpi/sip.rs ` — new module (~340 lines incl. tests).
- ` src/network/dpi/mod.rs ` — register module, add `PORT_SIP` / `PORT_SIP_TLS`, dispatch SIP before HTTP for TCP, after binary protocols for UDP.
- ` src/network/types.rs ` — `SipInfo`, `SipMessageType`, enum variant, Display arm, `sort_key`, dist counter, UDP state string, idle timeout.
- ` src/network/merge.rs ` — `merge_sip_info` (stable fields first-wins, dialog state latest-wins).
- ` src/filter.rs ` — general-search match arm for SIP metadata.
- ` src/ui.rs ` — DPI details panel rendering for SIP.

No changes to ROADMAP / README / CONTRIBUTING — happy to add a roadmap tick if you'd prefer.