### PR TITLE
docs: add PR template and tighten contributor guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+<!--
+Thanks for contributing to rustnet. Please read CONTRIBUTING.md before
+opening the PR, then fill in the sections below.
+
+CONTRIBUTING.md: https://github.com/domcyrus/rustnet/blob/main/CONTRIBUTING.md
+
+PRs that ship without the checklist completed will usually be asked to
+update before review.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? One or two paragraphs. -->
+
+## Linked issue
+
+<!-- For features and non-trivial changes, link the issue where the
+approach was discussed. If there is no issue, please open one first
+(see CONTRIBUTING.md: https://github.com/domcyrus/rustnet/blob/main/CONTRIBUTING.md#development-workflow).
+Bug fixes and typo corrections do not need a prior issue. -->
+
+Closes #
+
+## Verification
+
+Per [CONTRIBUTING.md > Code Quality Requirements](https://github.com/domcyrus/rustnet/blob/main/CONTRIBUTING.md#code-quality-requirements),
+I ran the following locally and they all pass:
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] `cargo test --all-features`
+- [ ] `cargo build --release`
+
+<!-- If any of these did not run, say which and why. CI will also run
+them, but local verification catches issues faster. -->
+
+## Scope
+
+- [ ] One feature or fix per PR (no unrelated cleanups bundled in)
+- [ ] No new dependencies, or rationale provided in the summary above
+- [ ] No `#[allow(clippy::...)]` suppressions, or rationale provided
+  (see [CONTRIBUTING.md](https://github.com/domcyrus/rustnet/blob/main/CONTRIBUTING.md#code-quality-requirements))
+
+## AI-assisted contributions
+
+If you used an AI assistant (Copilot, Claude, ChatGPT, Cursor, etc.) to
+write any of this code, that is fine, but please confirm:
+
+- [ ] I have read every line I am submitting
+- [ ] I ran the verification commands above myself
+- [ ] The PR description reflects what the code actually does
+
+## Notes for the reviewer
+
+<!-- Anything that would help review: tricky edge cases, deliberate
+trade-offs, follow-up work you plan to do in a separate PR. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Pull requests are very welcome! Whether you're fixing bugs, adding features, imp
 
 We use the standard open-source fork and feature branch approach:
 
-1. **Open an issue first** to discuss your proposed changes (for non-trivial work)
+1. **Open an issue first** to discuss your proposed changes. For features and non-trivial refactors, please wait for a maintainer response before writing code. Typo fixes, small bug fixes, and documentation corrections do not need a prior issue.
 2. Fork the repository
 3. Clone your fork locally
 4. Create a feature branch from `main` (`git checkout -b feature/your-feature`)
@@ -70,6 +70,27 @@ Security is important for a network monitoring tool:
 - Link any related issues
 - Keep PRs focused - one feature or fix per PR
 - Be responsive to review feedback
+- Verify locally before opening the PR. The PR template lists the exact commands.
+
+## Duplicate Pull Requests
+
+If two or more PRs address the same issue, the maintainers will evaluate them on their merits (code quality, test coverage, architectural fit) rather than submission order. The PR that best fits the project will be merged; others will be closed with thanks. If your PR is closed in favor of another, useful pieces from your work (documentation, tests, edge cases) may be ported over and credited.
+
+To avoid duplicate work, please comment on the linked issue stating that you intend to work on it before you start writing code.
+
+## AI-Assisted Contributions
+
+AI-assisted contributions are welcome, provided you treat the output as your own work and take responsibility for it.
+
+If you use an AI assistant (Copilot, Claude, ChatGPT, Cursor, or similar) to help write code or documentation:
+
+- **Read every line** you are submitting. You are accountable for it.
+- **Run the verification commands** listed in the PR template yourself. Do not submit code with a note that tests "could not be run locally" and ask the reviewer to verify.
+- **Make sure the PR description matches the code.** If the model wrote the PR body, confirm it describes what the diff actually does.
+- **Do not split a single change into many cosmetic per-file commits** to make the work look incremental. One logical change, one commit, with a real commit message.
+- **Do not open a PR seconds after filing the issue that motivates it.** Allow time for the maintainers and other contributors to weigh in on the proposed approach.
+
+PRs that show signs of unreviewed AI output (failing tests, fabricated APIs, unrelated bundled changes, mismatched descriptions) will be closed.
 
 ## Questions?
 


### PR DESCRIPTION
Adds `.github/pull_request_template.md` with a verification checklist (fmt, clippy, test, build) and AI-assisted-contribution acknowledgements.

Extends CONTRIBUTING.md with a duplicate-PR policy, an AI-assisted-contributions section, and stronger issue-first wording for features.