### PR TITLE
refactor(dpi/netbios): drop redundant padding check, lock invariant in test

### DIFF
--- a/src/network/dpi/netbios.rs
+++ b/src/network/dpi/netbios.rs
@@ -132,8 +132,10 @@ fn decode_netbios_name(data: &[u8]) -> Option<String> {
         let lo_nibble = lo - b'A';
         let c = hi_nibble | lo_nibble;
 
-        // Skip padding spaces (0x20)
-        if c != 0x20 && (c.is_ascii_graphic() || c.is_ascii_alphanumeric()) {
+        // Keep only printable ASCII: this naturally drops the trailing
+        // service-type suffix (0x00/0x1B/etc.) and padding spaces (0x20),
+        // since `is_ascii_graphic` covers 0x21..=0x7E exclusively.
+        if c.is_ascii_graphic() {
             name.push(c as char);
         }
     }
@@ -255,5 +257,26 @@ mod tests {
         let encoded = encode_netbios_name("PC");
         let name = decode_netbios_name(&encoded).expect("should decode");
         assert_eq!(name, "PC");
+    }
+
+    #[test]
+    fn test_decode_netbios_name_strips_service_type_suffix() {
+        // Real NetBIOS names embed a service-type byte at the 16th position
+        // (workstation=0x00, file_server=0x20, master_browser=0x1D, etc.).
+        // The non-printable suffix must NOT appear in the decoded name —
+        // decoding only keeps `is_ascii_graphic` characters (0x21..=0x7E).
+        let mut encoded = Vec::with_capacity(33);
+        encoded.push(32);
+        let padded = b"WORKSTATION    "; // 15 chars
+        for &b in padded {
+            encoded.push(b'A' + ((b >> 4) & 0x0F));
+            encoded.push(b'A' + (b & 0x0F));
+        }
+        // 16th byte = service-type 0x00 (workstation)
+        encoded.push(b'A');
+        encoded.push(b'A');
+
+        let decoded = decode_netbios_name(&encoded).expect("should decode");
+        assert_eq!(decoded, "WORKSTATION");
     }
 }


### PR DESCRIPTION
## What

`decode_netbios_name` filters decoded bytes with:

```rust
if c != 0x20 && (c.is_ascii_graphic() || c.is_ascii_alphanumeric()) {
    name.push(c as char);
}
```

Two of the three clauses are dead:

- `c.is_ascii_alphanumeric()` matches `b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z'`, all of which are already `is_ascii_graphic`. The OR can never add a match.
- `is_ascii_graphic` is `c >= 0x21 && c <= 0x7E`, which excludes 0x20 by construction, so `c != 0x20` is redundant.

The whole condition collapses to `c.is_ascii_graphic()`.

## Why it matters

The intent the original comment was reaching for ("skip padding spaces") is actually the broader invariant **"keep only printable ASCII"** — that's what makes the decoder safely strip the non-printable service-type byte at position 16 of a real NetBIOS name (workstation = 0x00, master_browser = 0x1D, file_server = 0x20, etc., per [Microsoft's NetBIOS suffix table](https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/netbios-suffixes-16th-character-of-netbios-name)).

The existing test suite only exercised short names like `"TEST"` and `"PC"` where the 16th byte happens to be a padding space, so neither the dead clauses nor the real suffix-stripping behavior was actually covered. A test that constructs a name ending in 0x00 fails the same way under both the old and new conditions if the invariant is ever broken — that's the regression case worth pinning down.

## Changes

- `src/network/dpi/netbios.rs`: simplify the filter to `c.is_ascii_graphic()` and update the inline comment to spell out *why* the filter is sufficient (it covers padding, suffix bytes, and any control/binary noise in one rule).
- Add `test_decode_netbios_name_strips_service_type_suffix`: builds a real-looking 32-byte first-level-encoded name where the 16th byte is 0x00 (workstation suffix) and asserts the decoded name comes back as `"WORKSTATION"` with the suffix dropped.

## Tests

```
$ cargo test --quiet -p rustnet-monitor netbios
running 8 tests
........
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy --all-targets --quiet
(clean)
```

Full suite stays at 325 passing.

No behavior change for valid input — purely a clarity + coverage fix.