### PR TITLE
docs: link to Repology packaging overview

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,8 @@
 
 This guide covers all installation methods for RustNet across different platforms.
 
+> **Tip:** For an at-a-glance view of which distributions package RustNet and which version each carries, see [RustNet on Repology](https://repology.org/project/rustnet/versions).
+
 ## Table of Contents
 
 - [Installing from Release Packages](#installing-from-release-packages)

--- a/INSTALL.zh-CN.md
+++ b/INSTALL.zh-CN.md
@@ -4,6 +4,8 @@
 
 本文档涵盖 RustNet 在各平台上的所有安装方法。
 
+> **提示：** 想一眼看清哪些发行版打包了 RustNet、各自分发的版本号是多少，请查看 [Repology 上的 RustNet 页面](https://repology.org/project/rustnet/versions)。
+
 ## 目录
 
 - [从发布包安装](#installing-from-release-packages)


### PR DESCRIPTION
Add a one-line pointer at the top of INSTALL.md (and zh-CN) to the Repology project page, which lists every distribution that packages RustNet and which version each one carries.