### PR TITLE
refactor(dpi/ssdp): case-fold header name without allocating

### DIFF
--- a/src/network/dpi/ssdp.rs
+++ b/src/network/dpi/ssdp.rs
@@ -37,11 +37,15 @@ pub fn analyze_ssdp(payload: &[u8]) -> Option<SsdpInfo> {
         return None;
     };
 
-    // Extract service type from ST or NT header
+    // Extract service type from ST or NT header. Compare the 3-byte prefix
+    // with `eq_ignore_ascii_case` so we don't allocate a lowercased copy
+    // of every header line just to check two ASCII names.
     let mut service_type = None;
     for line in text.lines().skip(1) {
-        let line_lower = line.to_lowercase();
-        if line_lower.starts_with("st:") || line_lower.starts_with("nt:") {
+        let is_st_or_nt = line.get(..3).is_some_and(|prefix| {
+            prefix.eq_ignore_ascii_case("st:") || prefix.eq_ignore_ascii_case("nt:")
+        });
+        if is_st_or_nt {
             // Extract value after the colon
             if let Some(value) = line.get(3..) {
                 let trimmed = value.trim();
@@ -132,5 +136,34 @@ mod tests {
     fn test_ssdp_not_ssdp() {
         let packet = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
         assert!(analyze_ssdp(packet).is_none());
+    }
+
+    #[test]
+    fn test_ssdp_mixed_case_st_and_nt_headers() {
+        // SSDP / UPnP servers in the wild use varied capitalisation for
+        // header names (HTTP §3.2 lets the field-name be case-insensitive).
+        // Lock the invariant the `eq_ignore_ascii_case` refactor relies on:
+        // any case mix on the 2-byte field-name still extracts the value.
+        let st_variants = [
+            b"M-SEARCH * HTTP/1.1\r\nST: ssdp:all\r\n\r\n".to_vec(),
+            b"M-SEARCH * HTTP/1.1\r\nSt: ssdp:all\r\n\r\n".to_vec(),
+            b"M-SEARCH * HTTP/1.1\r\nsT: ssdp:all\r\n\r\n".to_vec(),
+            b"M-SEARCH * HTTP/1.1\r\nst: ssdp:all\r\n\r\n".to_vec(),
+        ];
+        for packet in &st_variants {
+            let info = analyze_ssdp(packet).expect("should parse");
+            assert_eq!(info.service_type, Some("ssdp:all".to_string()));
+        }
+
+        let nt_variants = [
+            b"NOTIFY * HTTP/1.1\r\nNT: upnp:rootdevice\r\n\r\n".to_vec(),
+            b"NOTIFY * HTTP/1.1\r\nNt: upnp:rootdevice\r\n\r\n".to_vec(),
+            b"NOTIFY * HTTP/1.1\r\nnT: upnp:rootdevice\r\n\r\n".to_vec(),
+            b"NOTIFY * HTTP/1.1\r\nnt: upnp:rootdevice\r\n\r\n".to_vec(),
+        ];
+        for packet in &nt_variants {
+            let info = analyze_ssdp(packet).expect("should parse");
+            assert_eq!(info.service_type, Some("upnp:rootdevice".to_string()));
+        }
     }
 }


### PR DESCRIPTION
## Summary

The ST/NT header lookup in `analyze_ssdp` converted each header line into a fresh lowercased `String` just to compare the 3-byte prefix `\"st:\"` / `\"nt:\"`. For an SSDP packet with N header lines this allocates N times per packet, and only the prefix actually needs case-insensitive comparison.

Replace the per-line `to_lowercase()` allocation with `line.get(..3).is_some_and(|p| p.eq_ignore_ascii_case(\"st:\") || p.eq_ignore_ascii_case(\"nt:\"))`. The value extraction via `line.get(3..)` is unchanged, since both `\"st:\"` and `\"nt:\"` are exactly 3 ASCII bytes.

Behavior is unchanged: the field-name check is still case-insensitive (HTTP/1.1 §3.2), and the value is still trimmed and required to be non-empty.

## Why a regression test

The existing tests only exercise upper-case `ST:` / `NT:`, so dropping the case-fold would not have failed any test. The new `test_ssdp_mixed_case_st_and_nt_headers` exercises all four case mixes per field name (`ST`, `St`, `sT`, `st` and `NT`, `Nt`, `nT`, `nt`) so a future refactor that drops the case fold will fail this test instead of silently regressing — same shape as the regression test added in #278 for `decode_netbios_name`.

## Verification

- `cargo test --lib`: 360 passed, 0 failed (8 in `network::dpi::ssdp`, incl. the new test).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.

## Notes

Real SSDP traffic from UPnP devices commonly uses mixed-case header names — the Microsoft Windows SSDP stack and the Linux miniupnpd implementation both differ from each other in capitalisation, and HTTP §3.2 explicitly makes the field-name case-insensitive.