### PR TITLE
refactor(dpi/bittorrent): single-allocation `hex_encode` for info-hash render

### DIFF
--- a/src/network/dpi/bittorrent.rs
+++ b/src/network/dpi/bittorrent.rs
@@ -1,4 +1,5 @@
 use crate::network::types::{BitTorrentInfo, BitTorrentType};
+use std::fmt::Write as _;
 
 /// BitTorrent protocol handshake prefix: length byte (19) + "BitTorrent protocol"
 const BT_HANDSHAKE_PREFIX: &[u8] = b"\x13BitTorrent protocol";
@@ -273,7 +274,12 @@ fn format_version(bytes: &[u8]) -> String {
 
 /// Encode bytes as a lowercase hex string.
 fn hex_encode(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // write! to a String never fails.
+        let _ = write!(out, "{b:02x}");
+    }
+    out
 }
 
 /// Find the first occurrence of a subsequence in a byte slice.
@@ -610,5 +616,29 @@ mod tests {
     #[test]
     fn test_udp_returns_none_for_unknown() {
         assert!(analyze_udp_bittorrent(b"GET / HTTP/1.1\r\n").is_none());
+    }
+
+    #[test]
+    fn test_hex_encode_lowercase_20_byte_info_hash() {
+        // A representative 20-byte info-hash (the size BitTorrent always uses).
+        let info_hash: [u8; 20] = [
+            0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x00, 0xff, 0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+        ];
+        assert_eq!(
+            hex_encode(&info_hash),
+            "123456789abcdef000ff0102030405060708090a"
+        );
+    }
+
+    #[test]
+    fn test_hex_encode_empty_slice() {
+        assert_eq!(hex_encode(&[]), "");
+    }
+
+    #[test]
+    fn test_hex_encode_pads_single_digit_bytes() {
+        // Locks the `{:02x}` padding contract — 0x00..=0x0f stay two chars.
+        assert_eq!(hex_encode(&[0x00, 0x0a, 0x0f, 0x10]), "000a0f10");
     }
 }


### PR DESCRIPTION
## Summary

`hex_encode` was building one heap-allocated `String` per byte via `format!("{b:02x}")` and then collecting them into the final `String`. A 20-byte BitTorrent info-hash therefore went through 20 intermediate heap allocations on every peer-handshake analyze.

Replace the iterator with a single `String::with_capacity(bytes.len() * 2)` and a per-byte `write!`. Writing into a pre-sized `String` does not reallocate, so the helper now performs exactly one heap allocation per call regardless of the input length. The lowercase `{:02x}` output contract is unchanged.

## Tests

Three regression tests added:

- The exact-size 20-byte info-hash case (the only size BitTorrent uses in the wild) to lock the lowercase, fixed-width output.
- The empty-slice base case.
- A mix of single-digit bytes (0x00..=0x0f) to lock the zero-padding contract that `{:02x}` provides.

Local checks:

- `cargo test --lib` — 364 passed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

Closes #304