### PR TITLE
refactor(ebpf/maps_libbpf): drop `ConnKey::new` IpAddr ctor + both `unreachable!()` arms

### DIFF
--- a/src/network/platform/linux/ebpf/maps_libbpf.rs
+++ b/src/network/platform/linux/ebpf/maps_libbpf.rs
@@ -3,7 +3,7 @@
 use super::ProcessInfo;
 use anyhow::Result;
 use libbpf_rs::MapCore;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// Connection key matching the eBPF program structure (supports IPv4 and IPv6)
 #[repr(C, packed)]
@@ -27,55 +27,69 @@ pub struct ConnInfo {
     pub timestamp: u64,
 }
 
+// AF_INET / AF_INET6 (matches kernel `<linux/socket.h>` numeric values).
+const AF_INET: u8 = 2;
+const AF_INET6: u8 = 10;
+
+// IPPROTO_* values used by the eBPF socket map.
+const IPPROTO_ICMP: u8 = 1;
+const IPPROTO_TCP: u8 = 6;
+const IPPROTO_UDP: u8 = 17;
+const IPPROTO_ICMPV6: u8 = 58;
+
 impl ConnKey {
-    pub fn new(src_ip: IpAddr, dst_ip: IpAddr, src_port: u16, dst_port: u16, is_tcp: bool) -> Self {
-        let mut key = Self {
+    /// Build an empty key for an IPv4 connection. Address fields stay zeroed
+    /// and are filled by [`Self::fill_v4`].
+    fn empty_v4(sport: u16, dport: u16, proto: u8) -> Self {
+        Self {
             saddr: [0; 4],
             daddr: [0; 4],
-            sport: src_port,
-            dport: dst_port,
-            proto: if is_tcp { 6 } else { 17 }, // IPPROTO_TCP or IPPROTO_UDP
-            family: match src_ip {
-                IpAddr::V4(_) => 2,  // AF_INET
-                IpAddr::V6(_) => 10, // AF_INET6
-            },
-        };
-
-        match (src_ip, dst_ip) {
-            (IpAddr::V4(src), IpAddr::V4(dst)) => {
-                // Use little-endian to match kernel/eBPF native format
-                key.saddr[0] = u32::from_le_bytes(src.octets());
-                key.daddr[0] = u32::from_le_bytes(dst.octets());
-            }
-            (IpAddr::V6(src), IpAddr::V6(dst)) => {
-                let src_bytes = src.octets();
-                let dst_bytes = dst.octets();
-
-                // Convert 16-byte IPv6 addresses to 4 u32 values (big-endian)
-                for i in 0..4 {
-                    let src_start = i * 4;
-                    let dst_start = i * 4;
-                    key.saddr[i] = u32::from_be_bytes([
-                        src_bytes[src_start],
-                        src_bytes[src_start + 1],
-                        src_bytes[src_start + 2],
-                        src_bytes[src_start + 3],
-                    ]);
-                    key.daddr[i] = u32::from_be_bytes([
-                        dst_bytes[dst_start],
-                        dst_bytes[dst_start + 1],
-                        dst_bytes[dst_start + 2],
-                        dst_bytes[dst_start + 3],
-                    ]);
-                }
-            }
-            _ => {
-                // Callers use new_v4(Ipv4, Ipv4) or new_v6(Ipv6, Ipv6), so mixed types are impossible
-                unreachable!("Mixed IPv4/IPv6 addresses not supported");
-            }
+            sport,
+            dport,
+            proto,
+            family: AF_INET,
         }
+    }
 
-        key
+    /// Build an empty key for an IPv6 connection. Address fields stay zeroed
+    /// and are filled by [`Self::fill_v6`].
+    fn empty_v6(sport: u16, dport: u16, proto: u8) -> Self {
+        Self {
+            saddr: [0; 4],
+            daddr: [0; 4],
+            sport,
+            dport,
+            proto,
+            family: AF_INET6,
+        }
+    }
+
+    fn fill_v4(&mut self, src_ip: Ipv4Addr, dst_ip: Ipv4Addr) {
+        // Use little-endian to match kernel/eBPF native format.
+        self.saddr[0] = u32::from_le_bytes(src_ip.octets());
+        self.daddr[0] = u32::from_le_bytes(dst_ip.octets());
+    }
+
+    fn fill_v6(&mut self, src_ip: Ipv6Addr, dst_ip: Ipv6Addr) {
+        let src_bytes = src_ip.octets();
+        let dst_bytes = dst_ip.octets();
+
+        // Convert 16-byte IPv6 addresses to 4 u32 values (big-endian).
+        for i in 0..4 {
+            let start = i * 4;
+            self.saddr[i] = u32::from_be_bytes([
+                src_bytes[start],
+                src_bytes[start + 1],
+                src_bytes[start + 2],
+                src_bytes[start + 3],
+            ]);
+            self.daddr[i] = u32::from_be_bytes([
+                dst_bytes[start],
+                dst_bytes[start + 1],
+                dst_bytes[start + 2],
+                dst_bytes[start + 3],
+            ]);
+        }
     }
 
     pub fn new_v4(
@@ -85,13 +99,10 @@ impl ConnKey {
         dst_port: u16,
         is_tcp: bool,
     ) -> Self {
-        Self::new(
-            IpAddr::V4(src_ip),
-            IpAddr::V4(dst_ip),
-            src_port,
-            dst_port,
-            is_tcp,
-        )
+        let proto = if is_tcp { IPPROTO_TCP } else { IPPROTO_UDP };
+        let mut key = Self::empty_v4(src_port, dst_port, proto);
+        key.fill_v4(src_ip, dst_ip);
+        key
     }
 
     pub(crate) fn new_v6(
@@ -101,67 +112,25 @@ impl ConnKey {
         dst_port: u16,
         is_tcp: bool,
     ) -> Self {
-        Self::new(
-            IpAddr::V6(src_ip),
-            IpAddr::V6(dst_ip),
-            src_port,
-            dst_port,
-            is_tcp,
-        )
+        let proto = if is_tcp { IPPROTO_TCP } else { IPPROTO_UDP };
+        let mut key = Self::empty_v6(src_port, dst_port, proto);
+        key.fill_v6(src_ip, dst_ip);
+        key
     }
 
-    /// Create a key for ICMP lookup
-    /// icmp_id acts as the "source port", dport is 0
-    pub fn new_icmp(src_ip: IpAddr, dst_ip: IpAddr, icmp_id: u16) -> Self {
-        let mut key = Self {
-            saddr: [0; 4],
-            daddr: [0; 4],
-            sport: icmp_id,
-            dport: 0,
-            proto: match src_ip {
-                IpAddr::V4(_) => 1,  // IPPROTO_ICMP
-                IpAddr::V6(_) => 58, // IPPROTO_ICMPV6
-            },
-            family: match src_ip {
-                IpAddr::V4(_) => 2,  // AF_INET
-                IpAddr::V6(_) => 10, // AF_INET6
-            },
-        };
+    /// Create an IPv4 ICMP lookup key. `icmp_id` acts as the "source port",
+    /// `dport` is 0.
+    pub fn new_icmp_v4(src_ip: Ipv4Addr, dst_ip: Ipv4Addr, icmp_id: u16) -> Self {
+        let mut key = Self::empty_v4(icmp_id, 0, IPPROTO_ICMP);
+        key.fill_v4(src_ip, dst_ip);
+        key
+    }
 
-        match (src_ip, dst_ip) {
-            (IpAddr::V4(src), IpAddr::V4(dst)) => {
-                // Use little-endian to match kernel/eBPF native format
-                key.saddr[0] = u32::from_le_bytes(src.octets());
-                key.daddr[0] = u32::from_le_bytes(dst.octets());
-            }
-            (IpAddr::V6(src), IpAddr::V6(dst)) => {
-                let src_bytes = src.octets();
-                let dst_bytes = dst.octets();
-
-                // Convert 16-byte IPv6 addresses to 4 u32 values (big-endian)
-                for i in 0..4 {
-                    let src_start = i * 4;
-                    let dst_start = i * 4;
-                    key.saddr[i] = u32::from_be_bytes([
-                        src_bytes[src_start],
-                        src_bytes[src_start + 1],
-                        src_bytes[src_start + 2],
-                        src_bytes[src_start + 3],
-                    ]);
-                    key.daddr[i] = u32::from_be_bytes([
-                        dst_bytes[dst_start],
-                        dst_bytes[dst_start + 1],
-                        dst_bytes[dst_start + 2],
-                        dst_bytes[dst_start + 3],
-                    ]);
-                }
-            }
-            _ => {
-                // Callers use new_icmp with addresses from a single connection (always same family)
-                unreachable!("Mixed IPv4/IPv6 addresses not supported");
-            }
-        }
-
+    /// Create an IPv6 ICMPv6 lookup key. `icmp_id` acts as the "source port",
+    /// `dport` is 0.
+    pub fn new_icmp_v6(src_ip: Ipv6Addr, dst_ip: Ipv6Addr, icmp_id: u16) -> Self {
+        let mut key = Self::empty_v6(icmp_id, 0, IPPROTO_ICMPV6);
+        key.fill_v6(src_ip, dst_ip);
         key
     }
 
@@ -331,5 +300,107 @@ impl MapReader {
 
         log::info!("=== End Lookup Debug ===");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_v4_writes_little_endian_addrs_and_tcp_proto() {
+        let key = ConnKey::new_v4(
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(192, 168, 1, 100),
+            12345,
+            443,
+            true,
+        );
+        assert_eq!(key.family, AF_INET);
+        assert_eq!(key.proto, IPPROTO_TCP);
+        assert_eq!(key.sport, 12345);
+        assert_eq!(key.dport, 443);
+        // Octets reinterpreted as host-order u32 — matches what
+        // u32::from_le_bytes(ip.octets()) produced previously.
+        assert_eq!(
+            key.saddr[0],
+            u32::from_le_bytes(Ipv4Addr::new(10, 0, 0, 1).octets())
+        );
+        assert_eq!(
+            key.daddr[0],
+            u32::from_le_bytes(Ipv4Addr::new(192, 168, 1, 100).octets())
+        );
+        // Upper IPv6 slots stay zeroed for IPv4 keys.
+        assert_eq!(&key.saddr[1..], &[0, 0, 0]);
+        assert_eq!(&key.daddr[1..], &[0, 0, 0]);
+    }
+
+    #[test]
+    fn new_v4_marks_udp_when_not_tcp() {
+        let key = ConnKey::new_v4(
+            Ipv4Addr::new(127, 0, 0, 1),
+            Ipv4Addr::new(8, 8, 8, 8),
+            53000,
+            53,
+            false,
+        );
+        assert_eq!(key.proto, IPPROTO_UDP);
+    }
+
+    #[test]
+    fn new_v6_writes_big_endian_addrs_across_all_four_slots() {
+        let src = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        let dst = Ipv6Addr::new(0xfe80, 0, 0, 0, 0x1234, 0x5678, 0x9abc, 0xdef0);
+        let key = ConnKey::new_v6(src, dst, 1, 2, true);
+        assert_eq!(key.family, AF_INET6);
+        assert_eq!(key.proto, IPPROTO_TCP);
+
+        let src_bytes = src.octets();
+        let dst_bytes = dst.octets();
+        for i in 0..4 {
+            let start = i * 4;
+            assert_eq!(
+                key.saddr[i],
+                u32::from_be_bytes([
+                    src_bytes[start],
+                    src_bytes[start + 1],
+                    src_bytes[start + 2],
+                    src_bytes[start + 3],
+                ])
+            );
+            assert_eq!(
+                key.daddr[i],
+                u32::from_be_bytes([
+                    dst_bytes[start],
+                    dst_bytes[start + 1],
+                    dst_bytes[start + 2],
+                    dst_bytes[start + 3],
+                ])
+            );
+        }
+    }
+
+    #[test]
+    fn new_icmp_v4_uses_icmp_proto_and_zero_dport() {
+        let key = ConnKey::new_icmp_v4(
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(8, 8, 8, 8),
+            0x4242,
+        );
+        assert_eq!(key.proto, IPPROTO_ICMP);
+        assert_eq!(key.family, AF_INET);
+        assert_eq!(key.sport, 0x4242);
+        assert_eq!(key.dport, 0);
+    }
+
+    #[test]
+    fn new_icmp_v6_uses_icmpv6_proto_and_zero_dport() {
+        let src = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        let dst = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2);
+        let key = ConnKey::new_icmp_v6(src, dst, 0x0101);
+        assert_eq!(key.proto, IPPROTO_ICMPV6);
+        assert_eq!(key.family, AF_INET6);
+        assert_eq!(key.sport, 0x0101);
+        assert_eq!(key.dport, 0);
     }
 }

--- a/src/network/platform/linux/ebpf/maps_libbpf.rs
+++ b/src/network/platform/linux/ebpf/maps_libbpf.rs
@@ -307,6 +307,9 @@ impl MapReader {
 mod tests {
     use super::*;
 
+    // ConnKey is #[repr(C, packed)], so test asserts copy each field into
+    // a local first — taking a reference to a packed field (including the
+    // implicit one assert_eq! creates) is E0793 under Rust 2024.
     #[test]
     fn new_v4_writes_little_endian_addrs_and_tcp_proto() {
         let key = ConnKey::new_v4(
@@ -316,23 +319,27 @@ mod tests {
             443,
             true,
         );
+        let saddr = key.saddr;
+        let daddr = key.daddr;
+        let sport = key.sport;
+        let dport = key.dport;
         assert_eq!(key.family, AF_INET);
         assert_eq!(key.proto, IPPROTO_TCP);
-        assert_eq!(key.sport, 12345);
-        assert_eq!(key.dport, 443);
+        assert_eq!(sport, 12345);
+        assert_eq!(dport, 443);
         // Octets reinterpreted as host-order u32 — matches what
         // u32::from_le_bytes(ip.octets()) produced previously.
         assert_eq!(
-            key.saddr[0],
+            saddr[0],
             u32::from_le_bytes(Ipv4Addr::new(10, 0, 0, 1).octets())
         );
         assert_eq!(
-            key.daddr[0],
+            daddr[0],
             u32::from_le_bytes(Ipv4Addr::new(192, 168, 1, 100).octets())
         );
         // Upper IPv6 slots stay zeroed for IPv4 keys.
-        assert_eq!(&key.saddr[1..], &[0, 0, 0]);
-        assert_eq!(&key.daddr[1..], &[0, 0, 0]);
+        assert_eq!(&saddr[1..], &[0, 0, 0]);
+        assert_eq!(&daddr[1..], &[0, 0, 0]);
     }
 
     #[test]
@@ -352,6 +359,8 @@ mod tests {
         let src = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
         let dst = Ipv6Addr::new(0xfe80, 0, 0, 0, 0x1234, 0x5678, 0x9abc, 0xdef0);
         let key = ConnKey::new_v6(src, dst, 1, 2, true);
+        let saddr = key.saddr;
+        let daddr = key.daddr;
         assert_eq!(key.family, AF_INET6);
         assert_eq!(key.proto, IPPROTO_TCP);
 
@@ -360,7 +369,7 @@ mod tests {
         for i in 0..4 {
             let start = i * 4;
             assert_eq!(
-                key.saddr[i],
+                saddr[i],
                 u32::from_be_bytes([
                     src_bytes[start],
                     src_bytes[start + 1],
@@ -369,7 +378,7 @@ mod tests {
                 ])
             );
             assert_eq!(
-                key.daddr[i],
+                daddr[i],
                 u32::from_be_bytes([
                     dst_bytes[start],
                     dst_bytes[start + 1],
@@ -387,10 +396,12 @@ mod tests {
             Ipv4Addr::new(8, 8, 8, 8),
             0x4242,
         );
+        let sport = key.sport;
+        let dport = key.dport;
         assert_eq!(key.proto, IPPROTO_ICMP);
         assert_eq!(key.family, AF_INET);
-        assert_eq!(key.sport, 0x4242);
-        assert_eq!(key.dport, 0);
+        assert_eq!(sport, 0x4242);
+        assert_eq!(dport, 0);
     }
 
     #[test]
@@ -398,9 +409,11 @@ mod tests {
         let src = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
         let dst = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2);
         let key = ConnKey::new_icmp_v6(src, dst, 0x0101);
+        let sport = key.sport;
+        let dport = key.dport;
         assert_eq!(key.proto, IPPROTO_ICMPV6);
         assert_eq!(key.family, AF_INET6);
-        assert_eq!(key.sport, 0x0101);
-        assert_eq!(key.dport, 0);
+        assert_eq!(sport, 0x0101);
+        assert_eq!(dport, 0);
     }
 }

--- a/src/network/platform/linux/ebpf/tracker_libbpf.rs
+++ b/src/network/platform/linux/ebpf/tracker_libbpf.rs
@@ -150,10 +150,26 @@ impl LibbpfSocketTracker {
         dst_ip: IpAddr,
         icmp_id: u16,
     ) -> Option<ProcessInfo> {
+        match (src_ip, dst_ip) {
+            (IpAddr::V4(src), IpAddr::V4(dst)) => self.lookup_icmp_v4(src, dst, icmp_id),
+            (IpAddr::V6(src), IpAddr::V6(dst)) => self.lookup_icmp_v6(src, dst, icmp_id),
+            _ => {
+                log::warn!("Mixed IPv4/IPv6 addresses not supported in eBPF ICMP lookup");
+                None
+            }
+        }
+    }
+
+    fn lookup_icmp_v4(
+        &mut self,
+        src_ip: Ipv4Addr,
+        dst_ip: Ipv4Addr,
+        icmp_id: u16,
+    ) -> Option<ProcessInfo> {
         let socket_map = self.loader.socket_map();
 
         // Try exact match first
-        let key = ConnKey::new_icmp(src_ip, dst_ip, icmp_id);
+        let key = ConnKey::new_icmp_v4(src_ip, dst_ip, icmp_id);
         match MapReader::lookup_connection(socket_map, key) {
             Ok(Some(result)) => return Some(result),
             Ok(None) => {
@@ -165,11 +181,50 @@ impl LibbpfSocketTracker {
         }
 
         // Try with zero source address (common for ICMP - socket not bound to specific IP)
-        let zero_src_ip = match src_ip {
-            IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-        };
-        let zero_src_key = ConnKey::new_icmp(zero_src_ip, dst_ip, icmp_id);
+        let zero_src_key = ConnKey::new_icmp_v4(Ipv4Addr::new(0, 0, 0, 0), dst_ip, icmp_id);
+
+        match MapReader::lookup_connection(socket_map, zero_src_key) {
+            Ok(Some(result)) => {
+                log::debug!(
+                    "eBPF ICMP lookup succeeded with zero source address! PID: {}, comm: {}",
+                    result.pid,
+                    result.comm
+                );
+                Some(result)
+            }
+            Ok(None) => {
+                log::debug!("eBPF ICMP lookup miss for ID: {}", icmp_id);
+                None
+            }
+            Err(e) => {
+                log::debug!("eBPF ICMP zero-source lookup failed: {}", e);
+                None
+            }
+        }
+    }
+
+    fn lookup_icmp_v6(
+        &mut self,
+        src_ip: Ipv6Addr,
+        dst_ip: Ipv6Addr,
+        icmp_id: u16,
+    ) -> Option<ProcessInfo> {
+        let socket_map = self.loader.socket_map();
+
+        // Try exact match first
+        let key = ConnKey::new_icmp_v6(src_ip, dst_ip, icmp_id);
+        match MapReader::lookup_connection(socket_map, key) {
+            Ok(Some(result)) => return Some(result),
+            Ok(None) => {
+                log::debug!("eBPF ICMP exact lookup miss, trying with zero source address");
+            }
+            Err(e) => {
+                log::debug!("eBPF ICMP lookup failed: {}", e);
+            }
+        }
+
+        // Try with zero source address (common for ICMP - socket not bound to specific IP)
+        let zero_src_key = ConnKey::new_icmp_v6(Ipv6Addr::UNSPECIFIED, dst_ip, icmp_id);
 
         match MapReader::lookup_connection(socket_map, zero_src_key) {
             Ok(Some(result)) => {


### PR DESCRIPTION
## Summary

`ConnKey::new` and `ConnKey::new_icmp` both accepted `IpAddr`, matched `(src_ip, dst_ip)` and panicked on the mixed-family arm via `unreachable!("Mixed IPv4/IPv6 addresses not supported")`. In practice every in-repo caller of `new` already went through the typed `new_v4(Ipv4Addr, Ipv4Addr, ...)` / `new_v6(Ipv6Addr, Ipv6Addr, ...)` wrappers, so the mixed arm in `new` was unreachable by construction — it existed only because the inner constructor lost the family information by widening to `IpAddr`. Same shape as the recently merged stun fix in #289.

This goes with option 2 from #306 (you noted you would defer to my call): drop the `IpAddr` entry points entirely so the typed surface is the only way in.

## What changed

`src/network/platform/linux/ebpf/maps_libbpf.rs`:

- Replace `pub fn new(IpAddr, IpAddr, ...)` with two small private helpers `empty_v4` / `empty_v6` (build a zeroed key with the right `family` and `proto`) plus `fill_v4` / `fill_v6` (write the address slots in the family-specific endianness). `new_v4` / `new_v6` call these directly — there is no longer a shared `IpAddr`-typed seam.
- Replace `pub fn new_icmp(IpAddr, IpAddr, u16)` with concrete `new_icmp_v4(Ipv4Addr, Ipv4Addr, u16)` and `new_icmp_v6(Ipv6Addr, Ipv6Addr, u16)`, built on the same helpers.
- Pull the family numbers and `IPPROTO_*` byte values out as named constants (`AF_INET` = 2, `AF_INET6` = 10, `IPPROTO_TCP` = 6, `IPPROTO_UDP` = 17, `IPPROTO_ICMP` = 1, `IPPROTO_ICMPV6` = 58) so the constructors read at the level the kernel headers use.

`src/network/platform/linux/ebpf/tracker_libbpf.rs`:

- `lookup_icmp` now dispatches on `(src_ip, dst_ip)` at the entry point (matching the shape `lookup` already used for the TCP/UDP path) and forwards to private `lookup_icmp_v4` / `lookup_icmp_v6` helpers, which pass concrete address types into the new `new_icmp_v4` / `new_icmp_v6` constructors.
- The mixed-family case is now handled exactly like the TCP/UDP path: a `log::warn!` plus `None` return, no `unreachable!()` panic.

## Net effect

- Both `unreachable!()` arms are gone.
- The wire-format byte layout of `ConnKey` is unchanged.
- The public surface (`new_v4` / `new_v6` / new `new_icmp_v4` / new `new_icmp_v6`) is now typesafe — passing mismatched address families is a compile error rather than a runtime panic.

## Tests

Five new `#[cfg(test)] mod tests` cases in `maps_libbpf.rs` lock the byte layout of `new_v4` / `new_v6` / `new_icmp_v4` / `new_icmp_v6` against the previous behaviour:

- `new_v4_writes_little_endian_addrs_and_tcp_proto` — full IPv4 key shape with TCP.
- `new_v4_marks_udp_when_not_tcp` — locks the `is_tcp=false` → `IPPROTO_UDP` branch.
- `new_v6_writes_big_endian_addrs_across_all_four_slots` — IPv6 key compared against the same per-slot `u32::from_be_bytes` formula the old code used.
- `new_icmp_v4_uses_icmp_proto_and_zero_dport` — locks `IPPROTO_ICMP`, `dport=0`, `icmp_id` lives in `sport`.
- `new_icmp_v6_uses_icmpv6_proto_and_zero_dport` — same for IPv6 / `IPPROTO_ICMPV6`.

The test module is inside the existing `cfg(target_os = "linux")` / `feature = "ebpf"` gating of the file, so it runs on the Linux CI runner.

Local checks (macOS host):

- `cargo check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test --lib` — 361 passed.

Closes #306