### PR TITLE
docs: point Homebrew install at official homebrew-core formula

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -252,7 +252,6 @@ rustnet
 
 **On macOS:**
 ```bash
-brew tap domcyrus/rustnet
 brew install rustnet
 
 # Follow the caveats displayed after installation for permission setup
@@ -260,7 +259,7 @@ brew install rustnet
 
 **On Linux:**
 ```bash
-brew install domcyrus/rustnet/rustnet
+brew install rustnet
 
 # Grant capabilities to the Homebrew-installed binary (modern kernel 5.8+)
 sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' $(brew --prefix)/bin/rustnet
@@ -634,7 +633,6 @@ sudo chgrp access_bpf /dev/bpf*
 If installed via Homebrew, the formula will provide detailed setup instructions:
 
 ```bash
-brew tap domcyrus/rustnet
 brew install rustnet
 # Follow the caveats displayed after installation
 ```

--- a/INSTALL.zh-CN.md
+++ b/INSTALL.zh-CN.md
@@ -252,7 +252,6 @@ rustnet
 
 **在 macOS 上：**
 ```bash
-brew tap domcyrus/rustnet
 brew install rustnet
 
 # 按照安装后显示的提示进行权限配置
@@ -260,7 +259,7 @@ brew install rustnet
 
 **在 Linux 上：**
 ```bash
-brew install domcyrus/rustnet/rustnet
+brew install rustnet
 
 # 为 Homebrew 安装的二进制文件授予 Linux capabilities（现代内核 5.8+）
 sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' $(brew --prefix)/bin/rustnet
@@ -634,7 +633,6 @@ sudo chgrp access_bpf /dev/bpf*
 如果通过 Homebrew 安装，formula 会提供详细的配置说明：
 
 ```bash
-brew tap domcyrus/rustnet
 brew install rustnet
 # 按照安装后显示的提示操作
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Stats are collected every 2 seconds in a background thread with minimal performa
 
 **Homebrew (macOS / Linux):**
 ```bash
-brew tap domcyrus/rustnet
 brew install rustnet
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,7 +120,6 @@ RustNet 在所有支持的平台上提供实时的网络接口统计：
 
 **Homebrew(macOS / Linux):**
 ```bash
-brew tap domcyrus/rustnet
 brew install rustnet
 ```
 


### PR DESCRIPTION
## Summary
- rustnet is now available in [homebrew-core](https://formulae.brew.sh/formula/rustnet), so `brew install rustnet` works directly without adding the `domcyrus/rustnet` tap.
- Dropped the `brew tap domcyrus/rustnet` step (and the fully-qualified `brew install domcyrus/rustnet/rustnet` Linux variant) from the English and Chinese README and INSTALL docs.

## Notes
- The `domcyrus/homebrew-rustnet` tap can be deprecated separately later (e.g. via `deprecate!` in the formula) so existing users get a pointer to the core formula rather than a hard failure.

## Test plan
- [x] `brew install rustnet` resolves to the homebrew-core formula on macOS and Linux
- [x] Rendered Markdown reads correctly in all four docs