### PR TITLE
feat(log): emit program identity banner + module target on every line (closes #310)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,6 @@ fn main() -> Result<()> {
     // Check privileges BEFORE initializing TUI (so error messages are visible)
     check_privileges_early()?;
 
-    info!("Starting RustNet Monitor");
-
     // Build configuration from command line arguments
     let mut config = app::Config::default();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use log::{LevelFilter, error, info, warn};
 use ratatui::prelude::CrosstermBackend;
-use simplelog::{Config as LogConfig, WriteLogger};
+use simplelog::{ConfigBuilder, WriteLogger};
 use std::fs::{self, File};
 use std::io;
 use std::path::Path;
@@ -432,8 +432,28 @@ fn setup_logging(level: LevelFilter) -> Result<()> {
     let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S");
     let log_file_path = log_dir.join(format!("rustnet_{}.log", timestamp));
 
-    // Initialize the logger
-    WriteLogger::init(level, LogConfig::default(), File::create(log_file_path)?)?;
+    // Enable the `target` field on every log line so each entry carries
+    // the originating module (e.g. `network::dpi::dns`). Combined with
+    // the startup-banner lines below, this addresses #310 — users now
+    // see both the program identity (name/version/pid) at the top of
+    // the file and which subsystem emitted each subsequent line.
+    let config = ConfigBuilder::new()
+        .set_target_level(LevelFilter::Error)
+        .build();
+
+    WriteLogger::init(level, config, File::create(log_file_path)?)?;
+
+    // Startup banner — one identifying header so a user grepping a
+    // long-lived log file can immediately see which binary, which
+    // version, and which pid produced these lines. The `pkg_name` is
+    // the cargo package name (`rustnet-monitor`), not `argv[0]`, so it
+    // stays correct when the binary is renamed or symlinked.
+    info!(
+        "{} v{} starting (pid {})",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+        std::process::id()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Why

Issue [#310](https://github.com/domcyrus/rustnet/issues/310): the existing log file only carries timestamp + level + message, so a user looking at a long-running `rustnet` log has no direct way to confirm which binary, which version, and which pid produced the entries.

## What

Two small changes in `setup_logging`:

1. **Module target on every line.** Switch from `LogConfig::default()` to a `ConfigBuilder` with `set_target_level(LevelFilter::Error)`, which tells `simplelog` to include the originating `target` (module path) on every log line.

   Before:
   ```
   2026-05-25 18:00:00 [INFO] Refreshing connections
   ```
   After:
   ```
   2026-05-25 18:00:00 [INFO] (rustnet_monitor::network::poll) Refreshing connections
   ```

2. **Startup banner with program identity.** Emit one identifying line immediately after the writer is wired up:

   ```
   2026-05-25 18:00:00 [INFO] (rustnet_monitor::main) rustnet-monitor v1.3.0 starting (pid 12345)
   ```

   `pkg_name` and `pkg_version` come from `env!("CARGO_PKG_NAME")` / `env!("CARGO_PKG_VERSION")` so they stay correct when the binary is renamed or symlinked (i.e. not derived from `argv[0]`). The pid uses `std::process::id()`.

## Verification

```
$ cargo build              # clean
$ cargo clippy --all-targets -- -D warnings   # clean
$ cargo fmt --check        # clean
$ cargo test --lib         # 365 passed
```

No behavior change outside the log file format. Open to feedback if you'd prefer the banner phrased differently (e.g. include the BPF filter / interface in the startup line, or include the start timestamp explicitly even though `simplelog` already stamps each line).

Closes #310