### PR TITLE
refactor(ui/details): single-allocation hex render for STUN Transaction ID

### DIFF
--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -4,6 +4,8 @@
 //! helpers that build the label/value lines and the click-to-copy
 //! registry.
 
+use std::fmt::Write as _;
+
 use anyhow::Result;
 use ratatui::{
     Frame,
@@ -861,11 +863,12 @@ pub(in crate::ui) fn draw_connection_details(
                     info.message_class.to_string(),
                     label_style,
                 );
-                let txn_id = info
-                    .transaction_id
-                    .iter()
-                    .map(|b| format!("{:02x}", b))
-                    .collect::<String>();
+                let txn_id_bytes: &[u8] = &info.transaction_id;
+                let mut txn_id = String::with_capacity(txn_id_bytes.len() * 2);
+                for b in txn_id_bytes {
+                    // Infallible: writing to a String never returns Err.
+                    let _ = write!(txn_id, "{:02x}", b);
+                }
                 push_detail_field(
                     &mut details_text,
                     &mut detail_fields,


### PR DESCRIPTION
## Summary

Detail panel rendered the STUN Transaction-ID display string with

```rust
info.transaction_id.iter().map(|b| format!("{:02x}", b)).collect::<String>()
```

which yields 13 heap allocations per render: one short \`String\` per byte across the 12-byte RFC 5389 transaction ID, plus the final \`String\` into which they are collected (\`src/ui/tabs/details.rs:867\`).

Rewrite to a single \`String::with_capacity(bytes.len() * 2)\` + \`write!\` per byte:
- One allocation, sized exactly (2 hex chars per byte = 24).
- \`write!\`-to-\`String\` is infallible; \`Result\` discarded via \`let _\`.
- Same observable hex output (lowercase, zero-padded, no separator).

## Why this shape

Matches the merged single-alloc hex pattern from

> 575ed75 refactor(dpi/bittorrent): single-allocation hex_encode for info-hash render (#307)

applied to the parallel UI render path. \`info.transaction_id\` is \`[u8; 12]\` so the capacity hint is exact.

## Test plan

- \`cargo fmt\` clean
- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo test --lib\` 365/365 (including \`ui::snapshot_tests::*\`)

No behavior, layout, or copy change.