### PR TITLE
refactor(app): zero-alloc process-name diff for lsof debug log

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1175,15 +1175,11 @@ impl App {
 
                     // Only set process name if it's missing
                     if let Some(existing_name) = &entry.process_name {
-                        // Check if the existing name differs significantly (for debugging)
-                        let existing_normalized = existing_name
-                            .split_whitespace()
-                            .collect::<Vec<&str>>()
-                            .join(" ");
-                        let new_normalized =
-                            name.split_whitespace().collect::<Vec<&str>>().join(" ");
-
-                        if existing_normalized != new_normalized {
+                        // Whitespace-collapsed compare for debug logging.
+                        // `Iterator::ne` walks token-by-token, so we skip the
+                        // intermediate `Vec<&str>` + joined `String` pair the
+                        // old code built per connection only to drop again.
+                        if existing_name.split_whitespace().ne(name.split_whitespace()) {
                             debug!(
                                 "⚠️  Process name differs: existing='{}' vs lsof='{}'",
                                 existing_name, name


### PR DESCRIPTION
## Summary

\`enrich_with_lsof\` (\`src/app.rs:1177\`) walks every connection that already has a \`process_name\` set and, when lsof returns a new candidate name, compares the two to log a debug-level mismatch:

\`\`\`rust
let existing_normalized = existing_name
    .split_whitespace()
    .collect::<Vec<&str>>()
    .join(\" \");
let new_normalized =
    name.split_whitespace().collect::<Vec<&str>>().join(\" \");

if existing_normalized != new_normalized {
    debug!(\"...\");
}
\`\`\`

That's a \`Vec<&str>\` + a heap \`String\` per side, both dropped on the next statement, every connection, every enrichment pass — even when debug logging is off.

## Patch

Use \`Iterator::ne\` on the \`split_whitespace\` token iterators directly:

\`\`\`rust
if existing_name
    .split_whitespace()
    .ne(name.split_whitespace())
{
    debug!(\"...\");
}
\`\`\`

\`Iterator::ne\` walks both iterators in lockstep and short-circuits on the first divergence, so the whitespace-collapsed comparison is equivalent to the old join-then-compare but allocates nothing.

## Test plan

- \`cargo fmt\` clean
- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo test --lib\` 365/365

No behavior change (debug-log gating is unchanged, branch condition is observationally equivalent).