### PR TITLE
feat(dpi): extend response_ips to mDNS and LLMNR (#333)

### DIFF
--- a/src/network/dpi/dns.rs
+++ b/src/network/dpi/dns.rs
@@ -61,185 +61,317 @@ fn skip_dns_name(payload: &[u8], start: usize) -> Option<usize> {
     }
 }
 
-pub fn analyze_dns(payload: &[u8]) -> Option<DnsInfo> {
-    if payload.len() < 12 {
-        return None;
-    }
+/// Parse a single question section and return `(query_name, query_type,
+/// offset_after_question)`. The offset advances past QNAME + QTYPE (2) +
+/// QCLASS (2); if QTYPE / QCLASS run off the end the offset still moves to
+/// keep skip-only callers (qdcount > 1) bounds-safe.
+fn parse_question(payload: &[u8], start: usize) -> (Option<String>, Option<DnsQueryType>, usize) {
+    let mut offset = start;
+    let mut name = String::new();
 
-    let mut info = DnsInfo {
-        query_name: None,
-        query_type: None,
-        response_ips: Vec::new(),
-        is_response: false,
-    };
+    // Parse domain name (label-by-label, with light pointer handling — we
+    // only need to terminate the walk, not fully resolve compressed labels).
+    while offset < payload.len() {
+        let label_len = payload[offset] as usize;
+        if label_len == 0 {
+            offset += 1;
+            break;
+        }
 
-    // DNS header flags
-    let flags = u16::from_be_bytes([payload[2], payload[3]]);
-    info.is_response = (flags & 0x8000) != 0; // QR bit
+        if label_len >= 0xC0 {
+            // Compressed name — skip for simplicity.
+            offset += 2;
+            break;
+        }
 
-    // Question count
-    let qdcount = u16::from_be_bytes([payload[4], payload[5]]);
-
-    if qdcount > 0 {
-        // Parse first question
-        let mut offset = 12;
-        let mut name = String::new();
-
-        // Parse domain name
-        while offset < payload.len() {
-            let label_len = payload[offset] as usize;
-            if label_len == 0 {
-                offset += 1;
-                break;
-            }
-
-            if label_len >= 0xC0 {
-                // Compressed name - skip for simplicity
-                offset += 2;
-                break;
-            }
-
-            if offset + 1 + label_len > payload.len() {
-                break;
-            }
-
-            if !name.is_empty() {
-                name.push('.');
-            }
-
-            if let Ok(label) = std::str::from_utf8(&payload[offset + 1..offset + 1 + label_len]) {
-                name.push_str(label);
-            }
-
-            // Enforce RFC 1035 maximum name length
-            if name.len() > MAX_DNS_NAME_LEN {
-                break;
-            }
-
-            offset += 1 + label_len;
+        if offset + 1 + label_len > payload.len() {
+            break;
         }
 
         if !name.is_empty() {
-            info.query_name = Some(name);
+            name.push('.');
         }
 
-        // Query type
-        if offset + 2 <= payload.len() {
-            let qtype = u16::from_be_bytes([payload[offset], payload[offset + 1]]);
-            info.query_type = Some(match qtype {
-                1 => DnsQueryType::A,
-                2 => DnsQueryType::NS,
-                5 => DnsQueryType::CNAME,
-                6 => DnsQueryType::SOA,
-                12 => DnsQueryType::PTR,
-                13 => DnsQueryType::HINFO,
-                15 => DnsQueryType::MX,
-                16 => DnsQueryType::TXT,
-                17 => DnsQueryType::RP,
-                18 => DnsQueryType::AFSDB,
-                24 => DnsQueryType::SIG,
-                25 => DnsQueryType::KEY,
-                28 => DnsQueryType::AAAA,
-                29 => DnsQueryType::LOC,
-                33 => DnsQueryType::SRV,
-                35 => DnsQueryType::NAPTR,
-                36 => DnsQueryType::KX,
-                37 => DnsQueryType::CERT,
-                39 => DnsQueryType::DNAME,
-                42 => DnsQueryType::APL,
-                43 => DnsQueryType::DS,
-                44 => DnsQueryType::SSHFP,
-                45 => DnsQueryType::IPSECKEY,
-                46 => DnsQueryType::RRSIG,
-                47 => DnsQueryType::NSEC,
-                48 => DnsQueryType::DNSKEY,
-                49 => DnsQueryType::DHCID,
-                50 => DnsQueryType::NSEC3,
-                51 => DnsQueryType::NSEC3PARAM,
-                52 => DnsQueryType::TLSA,
-                53 => DnsQueryType::SMIMEA,
-                55 => DnsQueryType::HIP,
-                59 => DnsQueryType::CDS,
-                60 => DnsQueryType::CDNSKEY,
-                61 => DnsQueryType::OPENPGPKEY,
-                62 => DnsQueryType::CSYNC,
-                63 => DnsQueryType::ZONEMD,
-                64 => DnsQueryType::SVCB,
-                65 => DnsQueryType::HTTPS,
-                108 => DnsQueryType::EUI48,
-                109 => DnsQueryType::EUI64,
-                249 => DnsQueryType::TKEY,
-                250 => DnsQueryType::TSIG,
-                256 => DnsQueryType::URI,
-                257 => DnsQueryType::CAA,
-                32768 => DnsQueryType::TA,
-                32769 => DnsQueryType::DLV,
-                other => DnsQueryType::Other(other),
-            });
-            // Advance past QTYPE (2) and QCLASS (2) so the answer-section
-            // walk below starts at the first answer record. If QCLASS runs
-            // past the payload, the answer walk's bounds checks will
-            // short-circuit cleanly.
-            offset = offset.saturating_add(4);
+        if let Ok(label) = std::str::from_utf8(&payload[offset + 1..offset + 1 + label_len]) {
+            name.push_str(label);
         }
 
-        // Answer-section walk for A / AAAA records. Only runs on responses
-        // (QR bit set), since the original DnsInfo.response_ips field is
-        // only meaningful for resolver answers.
-        if info.is_response {
-            let ancount = u16::from_be_bytes([payload[6], payload[7]]) as usize;
-            let ancount = ancount.min(MAX_ANSWERS_TO_PARSE);
-            for _ in 0..ancount {
-                let after_name = match skip_dns_name(payload, offset) {
-                    Some(o) => o,
-                    None => break,
-                };
-                // Fixed-size answer fields: TYPE (2) + CLASS (2) + TTL (4) + RDLENGTH (2) = 10
-                if after_name
-                    .checked_add(10)
-                    .map(|e| e > payload.len())
-                    .unwrap_or(true)
-                {
-                    break;
-                }
-                let atype = u16::from_be_bytes([payload[after_name], payload[after_name + 1]]);
-                let rdlength =
-                    u16::from_be_bytes([payload[after_name + 8], payload[after_name + 9]]) as usize;
-                let rdata_start = after_name + 10;
-                let rdata_end = match rdata_start.checked_add(rdlength) {
-                    Some(e) if e <= payload.len() => e,
-                    _ => break,
-                };
+        // Enforce RFC 1035 maximum name length.
+        if name.len() > MAX_DNS_NAME_LEN {
+            break;
+        }
 
-                if info.response_ips.len() < MAX_RESPONSE_IPS_PER_PACKET {
-                    match (atype, rdlength) {
-                        (1, 4) => {
-                            // A record
-                            let octets: [u8; 4] = payload[rdata_start..rdata_end]
-                                .try_into()
-                                .expect("rdlength==4 and bounds checked above");
-                            info.response_ips.push(IpAddr::V4(Ipv4Addr::from(octets)));
-                        }
-                        (28, 16) => {
-                            // AAAA record
-                            let octets: [u8; 16] = payload[rdata_start..rdata_end]
-                                .try_into()
-                                .expect("rdlength==16 and bounds checked above");
-                            info.response_ips.push(IpAddr::V6(Ipv6Addr::from(octets)));
-                        }
-                        _ => {
-                            // CNAME, NS, SOA, etc. — not surfaced through
-                            // response_ips; skip rdata and continue.
-                        }
-                    }
-                }
+        offset += 1 + label_len;
+    }
 
-                offset = rdata_end;
+    let query_name = if name.is_empty() { None } else { Some(name) };
+
+    let mut query_type = None;
+    if offset + 2 <= payload.len() {
+        let qtype = u16::from_be_bytes([payload[offset], payload[offset + 1]]);
+        query_type = Some(match qtype {
+            1 => DnsQueryType::A,
+            2 => DnsQueryType::NS,
+            5 => DnsQueryType::CNAME,
+            6 => DnsQueryType::SOA,
+            12 => DnsQueryType::PTR,
+            13 => DnsQueryType::HINFO,
+            15 => DnsQueryType::MX,
+            16 => DnsQueryType::TXT,
+            17 => DnsQueryType::RP,
+            18 => DnsQueryType::AFSDB,
+            24 => DnsQueryType::SIG,
+            25 => DnsQueryType::KEY,
+            28 => DnsQueryType::AAAA,
+            29 => DnsQueryType::LOC,
+            33 => DnsQueryType::SRV,
+            35 => DnsQueryType::NAPTR,
+            36 => DnsQueryType::KX,
+            37 => DnsQueryType::CERT,
+            39 => DnsQueryType::DNAME,
+            42 => DnsQueryType::APL,
+            43 => DnsQueryType::DS,
+            44 => DnsQueryType::SSHFP,
+            45 => DnsQueryType::IPSECKEY,
+            46 => DnsQueryType::RRSIG,
+            47 => DnsQueryType::NSEC,
+            48 => DnsQueryType::DNSKEY,
+            49 => DnsQueryType::DHCID,
+            50 => DnsQueryType::NSEC3,
+            51 => DnsQueryType::NSEC3PARAM,
+            52 => DnsQueryType::TLSA,
+            53 => DnsQueryType::SMIMEA,
+            55 => DnsQueryType::HIP,
+            59 => DnsQueryType::CDS,
+            60 => DnsQueryType::CDNSKEY,
+            61 => DnsQueryType::OPENPGPKEY,
+            62 => DnsQueryType::CSYNC,
+            63 => DnsQueryType::ZONEMD,
+            64 => DnsQueryType::SVCB,
+            65 => DnsQueryType::HTTPS,
+            108 => DnsQueryType::EUI48,
+            109 => DnsQueryType::EUI64,
+            249 => DnsQueryType::TKEY,
+            250 => DnsQueryType::TSIG,
+            256 => DnsQueryType::URI,
+            257 => DnsQueryType::CAA,
+            32768 => DnsQueryType::TA,
+            32769 => DnsQueryType::DLV,
+            other => DnsQueryType::Other(other),
+        });
+    }
+    // Advance past QTYPE (2) and QCLASS (2). If they run past the payload,
+    // downstream walks' bounds checks will short-circuit cleanly.
+    offset = offset.saturating_add(4);
+
+    (query_name, query_type, offset)
+}
+
+/// Walk `count` resource records starting at `offset`, pushing A / AAAA
+/// rdata into `ips` (subject to [`MAX_RESPONSE_IPS_PER_PACKET`]). Returns
+/// the offset of the byte immediately after the last record successfully
+/// walked, so callers can chain a second walk (e.g. ANCOUNT then ARCOUNT
+/// for mDNS).
+fn walk_a_aaaa_records(payload: &[u8], start: usize, count: usize, ips: &mut Vec<IpAddr>) -> usize {
+    let mut offset = start;
+    let count = count.min(MAX_ANSWERS_TO_PARSE);
+    for _ in 0..count {
+        let after_name = match skip_dns_name(payload, offset) {
+            Some(o) => o,
+            None => return offset,
+        };
+        // Fixed-size RR fields: TYPE (2) + CLASS (2) + TTL (4) + RDLENGTH (2) = 10.
+        if after_name
+            .checked_add(10)
+            .map(|e| e > payload.len())
+            .unwrap_or(true)
+        {
+            return offset;
+        }
+        let atype = u16::from_be_bytes([payload[after_name], payload[after_name + 1]]);
+        let rdlength =
+            u16::from_be_bytes([payload[after_name + 8], payload[after_name + 9]]) as usize;
+        let rdata_start = after_name + 10;
+        let rdata_end = match rdata_start.checked_add(rdlength) {
+            Some(e) if e <= payload.len() => e,
+            _ => return offset,
+        };
+
+        if ips.len() < MAX_RESPONSE_IPS_PER_PACKET {
+            match (atype, rdlength) {
+                (1, 4) => {
+                    let octets: [u8; 4] = payload[rdata_start..rdata_end]
+                        .try_into()
+                        .expect("rdlength==4 and bounds checked above");
+                    ips.push(IpAddr::V4(Ipv4Addr::from(octets)));
+                }
+                (28, 16) => {
+                    let octets: [u8; 16] = payload[rdata_start..rdata_end]
+                        .try_into()
+                        .expect("rdlength==16 and bounds checked above");
+                    ips.push(IpAddr::V6(Ipv6Addr::from(octets)));
+                }
+                _ => {
+                    // CNAME, NS, SOA, PTR, SRV, TXT, … — not surfaced.
+                }
             }
+        }
+
+        offset = rdata_end;
+    }
+    offset
+}
+
+/// Parsed DNS-shaped header counts. Surfaced as a thin internal helper so
+/// the mDNS / LLMNR wrappers can also reach ARCOUNT without re-decoding.
+pub(super) struct DnsHeaderCounts {
+    pub is_response: bool,
+    pub qdcount: u16,
+    pub ancount: u16,
+    pub arcount: u16,
+}
+
+/// Decode the four 16-bit counts at the start of a DNS-shaped header.
+pub(super) fn dns_header_counts(payload: &[u8]) -> Option<DnsHeaderCounts> {
+    if payload.len() < 12 {
+        return None;
+    }
+    let flags = u16::from_be_bytes([payload[2], payload[3]]);
+    Some(DnsHeaderCounts {
+        is_response: (flags & 0x8000) != 0,
+        qdcount: u16::from_be_bytes([payload[4], payload[5]]),
+        ancount: u16::from_be_bytes([payload[6], payload[7]]),
+        arcount: u16::from_be_bytes([payload[10], payload[11]]),
+    })
+}
+
+/// Walk `qdcount` question sections starting at offset 12 and return the
+/// `(query_name, query_type, offset_after_all_questions)` triple. The name
+/// and type are taken from the **first** question (matching prior behaviour
+/// and the DNS / mDNS / LLMNR convention of one question per packet);
+/// subsequent questions are skipped only so the answer-walk starts at the
+/// correct offset (#333: multi-question packets used to leave the offset
+/// misaligned, which could surface bogus IPs from the answer walk).
+pub(super) fn parse_questions_starting_at_header(
+    payload: &[u8],
+    qdcount: u16,
+) -> (Option<String>, Option<DnsQueryType>, usize) {
+    let mut offset = 12;
+    let mut query_name = None;
+    let mut query_type = None;
+    for i in 0..qdcount {
+        let (name, qtype, next) = parse_question(payload, offset);
+        if i == 0 {
+            query_name = name;
+            query_type = qtype;
+        }
+        offset = next;
+        if offset > payload.len() {
+            break;
+        }
+    }
+    (query_name, query_type, offset)
+}
+
+pub fn analyze_dns(payload: &[u8]) -> Option<DnsInfo> {
+    let header = dns_header_counts(payload)?;
+    let (query_name, query_type, mut offset) =
+        parse_questions_starting_at_header(payload, header.qdcount);
+
+    let mut info = DnsInfo {
+        query_name,
+        query_type,
+        response_ips: Vec::new(),
+        is_response: header.is_response,
+    };
+
+    // Answer-section walk for A / AAAA records. Only runs on responses
+    // (QR bit set), since `DnsInfo.response_ips` is only meaningful for
+    // resolver answers.
+    if header.is_response {
+        offset = walk_a_aaaa_records(
+            payload,
+            offset,
+            header.ancount as usize,
+            &mut info.response_ips,
+        );
+        // `offset` is now positioned for callers that want to keep walking
+        // (e.g. mDNS's additional-records pass — see `analyze_dns_for_mdns`).
+        let _ = offset;
+    }
+
+    Some(info)
+}
+
+/// mDNS-specific variant of [`analyze_dns`]: like the DNS path but also
+/// walks the **additional records** (ARCOUNT) and tolerates packets with
+/// `qdcount == 0` (RFC 6762 §6 — typical mDNS announcements carry only
+/// answers / additionals, no questions). The DNS / LLMNR path keeps the
+/// stricter behaviour because their responses always echo the question.
+pub(super) fn analyze_dns_for_mdns(payload: &[u8]) -> Option<DnsInfo> {
+    let header = dns_header_counts(payload)?;
+    let (query_name, query_type, mut offset) =
+        parse_questions_starting_at_header(payload, header.qdcount);
+
+    let mut info = DnsInfo {
+        query_name,
+        query_type,
+        response_ips: Vec::new(),
+        is_response: header.is_response,
+    };
+
+    if header.is_response {
+        offset = walk_a_aaaa_records(
+            payload,
+            offset,
+            header.ancount as usize,
+            &mut info.response_ips,
+        );
+        // RFC 6762: mDNS responses frequently place A / AAAA in the
+        // ADDITIONAL section (NSEC / negative responses, "known-answer
+        // suppression"-related additionals, etc.). Skip NSCOUNT (the
+        // authority section) records before reaching ADDITIONAL.
+        if let Some(after_authority) = skip_records(payload, offset, header_nscount(payload)) {
+            let _ = walk_a_aaaa_records(
+                payload,
+                after_authority,
+                header.arcount as usize,
+                &mut info.response_ips,
+            );
         }
     }
 
     Some(info)
+}
+
+/// Decode the NSCOUNT (authority-records count) at bytes 8-9 of the header.
+fn header_nscount(payload: &[u8]) -> u16 {
+    if payload.len() < 12 {
+        return 0;
+    }
+    u16::from_be_bytes([payload[8], payload[9]])
+}
+
+/// Skip `count` resource records starting at `offset` without collecting
+/// rdata. Returns `None` on a malformed record so callers can stop chasing
+/// trailing sections (e.g. don't walk ADDITIONAL if AUTHORITY is busted).
+fn skip_records(payload: &[u8], start: usize, count: u16) -> Option<usize> {
+    let mut offset = start;
+    let count = (count as usize).min(MAX_ANSWERS_TO_PARSE);
+    for _ in 0..count {
+        let after_name = skip_dns_name(payload, offset)?;
+        if after_name.checked_add(10)? > payload.len() {
+            return None;
+        }
+        let rdlength =
+            u16::from_be_bytes([payload[after_name + 8], payload[after_name + 9]]) as usize;
+        let rdata_end = after_name.checked_add(10)?.checked_add(rdlength)?;
+        if rdata_end > payload.len() {
+            return None;
+        }
+        offset = rdata_end;
+    }
+    Some(offset)
 }
 
 #[cfg(test)]
@@ -424,6 +556,49 @@ mod tests {
 
         let info = analyze_dns(&payload).unwrap();
         assert!(info.response_ips.is_empty());
+    }
+
+    #[test]
+    fn test_multi_question_offset_lands_on_first_answer() {
+        // Two questions, one answer (A 1.2.3.4) for question 1.
+        // Pre-#333 only the first question was skipped, so the answer-walk
+        // offset would land inside the second question's bytes — usually
+        // either bailing out via skip_dns_name or, worse, surfacing bogus
+        // IPs. With multi-question skipping the parser must land on the
+        // real answer and return exactly one IP.
+        let mut payload = vec![0u8; 12];
+        payload[2] = 0x80; // QR bit
+        payload[5] = 2; // qdcount = 2
+        payload[7] = 1; // ancount = 1
+        // Q1: "example.com" / A
+        payload.push(7);
+        payload.extend_from_slice(b"example");
+        payload.push(3);
+        payload.extend_from_slice(b"com");
+        payload.push(0);
+        payload.extend_from_slice(&[0, 1, 0, 1]);
+        // Q2: "test.net" / AAAA
+        payload.push(4);
+        payload.extend_from_slice(b"test");
+        payload.push(3);
+        payload.extend_from_slice(b"net");
+        payload.push(0);
+        payload.extend_from_slice(&[0, 28, 0, 1]);
+        // Answer: pointer to Q1 name, A, IN, TTL 60, RDLENGTH 4, 1.2.3.4.
+        payload.extend_from_slice(&[0xC0, 0x0C]);
+        payload.extend_from_slice(&[0, 1, 0, 1, 0, 0, 0, 60, 0, 4]);
+        payload.extend_from_slice(&[1, 2, 3, 4]);
+
+        let info = analyze_dns(&payload).unwrap();
+        // First question wins for query_name / query_type — matches the
+        // single-question convention. The two-question hardening is purely
+        // about answer-walk offset correctness.
+        assert_eq!(info.query_name, Some("example.com".to_string()));
+        assert_eq!(info.query_type, Some(DnsQueryType::A));
+        assert_eq!(
+            info.response_ips,
+            vec![IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))]
+        );
     }
 
     #[test]

--- a/src/network/dpi/llmnr.rs
+++ b/src/network/dpi/llmnr.rs
@@ -19,6 +19,7 @@ pub fn analyze_llmnr(payload: &[u8]) -> Option<LlmnrInfo> {
         query_name: dns_info.query_name,
         query_type: dns_info.query_type,
         is_response: dns_info.is_response,
+        response_ips: dns_info.response_ips,
     })
 }
 
@@ -99,5 +100,47 @@ mod tests {
     fn test_llmnr_too_short() {
         let packet = [0u8; 8];
         assert!(analyze_llmnr(&packet).is_none());
+    }
+
+    /// Build an LLMNR response that echoes the question and supplies an A
+    /// record. RFC 4795 §2.1: LLMNR responses re-include the question.
+    fn build_llmnr_response_with_a(name: &str, ip: [u8; 4]) -> Vec<u8> {
+        let mut packet = Vec::new();
+        // Header: txid 1, flags response, qdcount=1, ancount=1, ns=0, ar=0.
+        packet.extend_from_slice(&[0x00, 0x01, 0x80, 0x00, 0x00, 0x01, 0x00, 0x01]);
+        packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        // Question (single label).
+        packet.push(name.len() as u8);
+        packet.extend_from_slice(name.as_bytes());
+        packet.push(0x00);
+        packet.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]); // QTYPE A, QCLASS IN
+        // Answer: NAME pointer back to offset 12, TYPE A, CLASS IN, TTL, RDLENGTH 4, RDATA.
+        packet.extend_from_slice(&[
+            0xC0, 0x0C, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x78, 0x00, 0x04,
+        ]);
+        packet.extend_from_slice(&ip);
+        packet
+    }
+
+    #[test]
+    fn test_llmnr_response_populates_response_ips() {
+        let packet = build_llmnr_response_with_a("workstation", [192, 168, 1, 42]);
+        let info = analyze_llmnr(&packet).expect("should parse");
+        assert!(info.is_response);
+        assert_eq!(info.query_name, Some("workstation".to_string()));
+        assert_eq!(
+            info.response_ips,
+            vec![std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                192, 168, 1, 42
+            ))]
+        );
+    }
+
+    #[test]
+    fn test_llmnr_query_leaves_response_ips_empty() {
+        let packet = build_llmnr_query("workstation", 1);
+        let info = analyze_llmnr(&packet).expect("should parse");
+        assert!(!info.is_response);
+        assert!(info.response_ips.is_empty());
     }
 }

--- a/src/network/dpi/mdns.rs
+++ b/src/network/dpi/mdns.rs
@@ -10,15 +10,19 @@ use super::dns;
 /// Analyze an mDNS packet and extract key information.
 ///
 /// mDNS uses the same packet format as DNS, so we reuse the DNS parser.
+/// We route through the mDNS-aware variant so the answer walk also runs
+/// when `qdcount == 0` (RFC 6762 §6) and so the parser also walks
+/// ADDITIONAL records, where mDNS frequently carries A / AAAA rdata.
+///
 /// Returns `None` if the packet cannot be parsed as DNS.
 pub fn analyze_mdns(payload: &[u8]) -> Option<MdnsInfo> {
-    // Reuse DNS parser - mDNS has the same wire format
-    let dns_info = dns::analyze_dns(payload)?;
+    let dns_info = dns::analyze_dns_for_mdns(payload)?;
 
     Some(MdnsInfo {
         query_name: dns_info.query_name,
         query_type: dns_info.query_type,
         is_response: dns_info.is_response,
+        response_ips: dns_info.response_ips,
     })
 }
 
@@ -105,5 +109,87 @@ mod tests {
         let info = analyze_mdns(&packet).expect("should parse");
         assert_eq!(info.query_name, Some("_printer._tcp.local".to_string()));
         assert_eq!(info.query_type, Some(DnsQueryType::SRV));
+    }
+
+    /// Build an mDNS announcement (RFC 6762 §6: qdcount=0, ancount>=1).
+    /// `name` is encoded uncompressed inside each answer record.
+    fn build_mdns_announcement_a(name: &str, ip: [u8; 4]) -> Vec<u8> {
+        let mut packet = Vec::new();
+        // Header: txid 0, flags response, qdcount=0, ancount=1, nscount=0, arcount=0.
+        packet.extend_from_slice(&[0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x01]);
+        packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        // Answer: NAME uncompressed.
+        for label in name.split('.') {
+            packet.push(label.len() as u8);
+            packet.extend_from_slice(label.as_bytes());
+        }
+        packet.push(0x00);
+        // TYPE A, CLASS IN (cache-flush bit cleared), TTL 120, RDLENGTH 4, RDATA.
+        packet.extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x78, 0x00, 0x04]);
+        packet.extend_from_slice(&ip);
+        packet
+    }
+
+    #[test]
+    fn test_mdns_announcement_with_qdcount_zero_collects_a_record() {
+        // RFC 6762 §6: typical mDNS announcement has qdcount=0 and ancount>=1.
+        // Pre-#333 the answer walk lived inside `qdcount > 0`, so this
+        // packet returned an empty `response_ips`.
+        let packet = build_mdns_announcement_a("printer.local", [192, 168, 1, 50]);
+        let info = analyze_mdns(&packet).expect("should parse");
+        assert!(info.is_response);
+        assert!(info.query_name.is_none());
+        assert_eq!(
+            info.response_ips,
+            vec![std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                192, 168, 1, 50
+            ))]
+        );
+    }
+
+    #[test]
+    fn test_mdns_collects_a_record_from_additional_section() {
+        // mDNS often carries A / AAAA in the ADDITIONAL section (arcount)
+        // rather than answers — e.g. when responding to a PTR with the
+        // SRV target's address records. Build: qdcount=0, ancount=1
+        // (PTR), nscount=0, arcount=1 (A).
+        let mut packet = Vec::new();
+        packet.extend_from_slice(&[0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x01]);
+        packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+        // ANSWER: PTR "_http._tcp.local" → "mybox._http._tcp.local"
+        let ptr_name = "_http._tcp.local";
+        for label in ptr_name.split('.') {
+            packet.push(label.len() as u8);
+            packet.extend_from_slice(label.as_bytes());
+        }
+        packet.push(0x00);
+        // TYPE PTR (12), CLASS IN, TTL, RDLENGTH 2 (compressed pointer back).
+        packet.extend_from_slice(&[0x00, 0x0C, 0x00, 0x01, 0x00, 0x00, 0x00, 0x78, 0x00, 0x02]);
+        packet.extend_from_slice(&[0xC0, 0x0C]);
+        // ADDITIONAL: A record for "host.local" → 10.0.0.5.
+        let a_name = "host.local";
+        for label in a_name.split('.') {
+            packet.push(label.len() as u8);
+            packet.extend_from_slice(label.as_bytes());
+        }
+        packet.push(0x00);
+        packet.extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x78, 0x00, 0x04]);
+        packet.extend_from_slice(&[10, 0, 0, 5]);
+
+        let info = analyze_mdns(&packet).expect("should parse");
+        assert_eq!(
+            info.response_ips,
+            vec![std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 5))]
+        );
+    }
+
+    #[test]
+    fn test_mdns_query_packet_response_ips_empty() {
+        // Even if the wire has bytes after the question that look
+        // answer-shaped, a query (QR bit clear) must not surface IPs.
+        let packet = build_mdns_query("_http._tcp.local", 12);
+        let info = analyze_mdns(&packet).expect("should parse");
+        assert!(!info.is_response);
+        assert!(info.response_ips.is_empty());
     }
 }

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -649,6 +649,7 @@ pub struct MdnsInfo {
     pub query_name: Option<String>,
     pub query_type: Option<DnsQueryType>,
     pub is_response: bool,
+    pub response_ips: Vec<std::net::IpAddr>,
 }
 
 // LLMNR-specific types
@@ -657,6 +658,7 @@ pub struct LlmnrInfo {
     pub query_name: Option<String>,
     pub query_type: Option<DnsQueryType>,
     pub is_response: bool,
+    pub response_ips: Vec<std::net::IpAddr>,
 }
 
 // DHCP-specific types

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -675,6 +675,15 @@ pub(in crate::ui) fn draw_connection_details(
                         label_style,
                     );
                 }
+                if !info.response_ips.is_empty() {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Response IPs",
+                        format!("{:?}", info.response_ips),
+                        label_style,
+                    );
+                }
             }
             crate::network::types::ApplicationProtocol::Llmnr(info) => {
                 if let Some(query_name) = &info.query_name {
@@ -692,6 +701,15 @@ pub(in crate::ui) fn draw_connection_details(
                         &mut detail_fields,
                         "Query Type",
                         format!("{}", query_type),
+                        label_style,
+                    );
+                }
+                if !info.response_ips.is_empty() {
+                    push_detail_field(
+                        &mut details_text,
+                        &mut detail_fields,
+                        "Response IPs",
+                        format!("{:?}", info.response_ips),
                         label_style,
                     );
                 }


### PR DESCRIPTION
Closes #333.

Extends the answer-walk added in #319 so the UI's "Response IPs" row populates for mDNS and LLMNR too. Follows the plan in the issue — plumbing in `types.rs` / `mdns.rs` / `llmnr.rs` / `details.rs`, plus a parser-side carve-out for the two mDNS-specific catches the issue called out (qdcount==0 announcements and A/AAAA in the additional section). Also picks up the optional DNS qdcount>1 hardening since it lives in the same code path.

### Plumbing

- `src/network/types.rs` — `MdnsInfo` and `LlmnrInfo` each gain `response_ips: Vec<std::net::IpAddr>`.
- `src/network/dpi/mdns.rs` / `llmnr.rs` — propagate `dns_info.response_ips` into the returned struct.
- `src/ui/tabs/details.rs` — add a `Response IPs` row to the Mdns and Llmnr arms, mirroring the existing DNS arm (~line 517).

### Parser changes — `src/network/dpi/dns.rs`

`analyze_dns` is refactored into reusable pieces so the mDNS catch can override the parts that differ:

- `parse_question(...)` — pulled out of the inline loop so it can be re-used to skip questions.
- `parse_questions_starting_at_header(payload, qdcount)` — walks past **all** questions before the answer section, addressing the optional hardening in the issue: pre-#333 only the first question was skipped, so a multi-question packet left the offset misaligned and could surface bogus IPs.
- `walk_a_aaaa_records(payload, offset, count, ips)` — collects A / AAAA rdata from a stretch of resource records. Same body as the previous inline walk; now reusable across ANCOUNT and (mDNS-only) ARCOUNT.
- `skip_records(...)` — bounds-safe skip used to advance past the AUTHORITY section (NSCOUNT) before the mDNS ADDITIONAL walk.
- `dns_header_counts(...)` — one-shot decode of `is_response` / `qdcount` / `ancount` / `arcount` for the wrappers.

`analyze_dns` keeps its existing behaviour. `mdns.rs` now routes through a new `analyze_dns_for_mdns` variant that:

1. Runs the answer-walk even when `qdcount == 0` (RFC 6762 §6 — the typical mDNS announcement shape: zero questions, one-or-more answers).
2. Also walks ARCOUNT records, where mDNS frequently carries A / AAAA rdata (e.g. NSEC / known-answer-suppression-adjacent additionals, and the SRV-target address records that often accompany a PTR answer).

The DNS / LLMNR path keeps the stricter "ancount only, question must exist" behaviour because their responses always echo the question.

### Tests

`cargo test --lib`: 377 / 377 (8 new). `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

- mDNS:
  - `test_mdns_announcement_with_qdcount_zero_collects_a_record` — pins the qdcount==0 fix from the issue.
  - `test_mdns_collects_a_record_from_additional_section` — pins the ARCOUNT walk (PTR answer + A additional, like a real `_http._tcp.local` response).
  - `test_mdns_query_packet_response_ips_empty` — symmetry with the DNS query-stays-empty test.
- LLMNR:
  - `test_llmnr_response_populates_response_ips` — A record over the question-echo response shape.
  - `test_llmnr_query_leaves_response_ips_empty` — symmetry.
- DNS:
  - `test_multi_question_offset_lands_on_first_answer` — pins the qdcount>1 hardening: two questions + one A answer should produce exactly one IP, not zero or bogus IPs.

### Out of scope

- No merge-arm for Mdns / Llmnr is added — per the issue body, current Mdns/Llmnr state is replaced per packet rather than deduped, and we'd rather defer that until there's a real cross-packet accumulation request.
