### PR TITLE
perf(dpi/bittorrent): build format_version directly, drop per-byte String + Vec

### DIFF
--- a/crates/rustnet-core/src/network/dpi/bittorrent.rs
+++ b/crates/rustnet-core/src/network/dpi/bittorrent.rs
@@ -257,19 +257,20 @@ fn decode_client_name(peer_id: &[u8]) -> Option<String> {
 
 /// Format version bytes into a dotted version string.
 fn format_version(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .filter_map(|&b| {
-            if b.is_ascii_digit() {
-                Some((b - b'0').to_string())
-            } else if b.is_ascii_alphanumeric() {
-                Some((b as char).to_string())
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(".")
+    // Keep ASCII alphanumeric bytes (digits are a subset, so both former
+    // branches produced `b as char`), joined by '.'. Build the string
+    // directly to avoid a per-byte String plus the intermediate Vec<String>.
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        if !b.is_ascii_alphanumeric() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push('.');
+        }
+        out.push(b as char);
+    }
+    out
 }
 
 /// Encode bytes as a lowercase hex string.


### PR DESCRIPTION
## Summary

Closes #348.

`format_version` (`src/network/dpi/bittorrent.rs`) mapped each kept byte to its own `String`, collected into a `Vec<String>`, then `join(".")` — one `String` allocation per byte plus the intermediate `Vec` on every client-version parse. The digit branch was redundant too: ASCII digits are a subset of ASCII alphanumerics, and `(b - b'0').to_string()` equals `(b as char).to_string()` for digit bytes.

## Change

Keep ASCII-alphanumeric bytes and push `b as char` into a single pre-sized `String`, separating with `.`. Identical output, no per-byte `String`, no `Vec`.

## Verification

`cargo test --lib bittorrent` — 41 passed, 0 failed (includes the existing version-format cases). `cargo fmt` clean.