### PR TITLE
feat(packaging): add openSUSE OBS release pipeline

### DIFF
--- a/.github/workflows/obs-release.yml
+++ b/.github/workflows/obs-release.yml
@@ -1,0 +1,144 @@
+name: Release to OBS
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-obs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: version
+        run: |
+          # Extract version by removing 'v' prefix if it exists, fallback to Cargo.toml
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Setup Linux dependencies
+        uses: ./.github/actions/setup-linux-deps
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable # unpinned: maintained branch by Rust team member
+        with:
+          toolchain: stable
+
+      - name: Install OBS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y osc obs-build build-essential
+
+      - name: Configure OBS credentials
+        run: |
+          cat <<EOF > ~/.oscrc
+          [general]
+          apiurl = https://api.opensuse.org
+          
+          [https://api.opensuse.org]
+          user = ${{ secrets.OBS_USER }}
+          pass = ${{ secrets.OBS_PASS }}
+          EOF
+          chmod 600 ~/.oscrc
+
+      - name: Download source tarball
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PACKAGE_NAME="rustnet"
+          
+          # Output filename must match Source0's basename (v%{version}.tar.gz)
+          # so the offline OBS build can resolve it; the internal dir prefix
+          # stays rustnet-%{version}/ to match %autosetup -n.
+          RELEASE_TAG="v${VERSION}"
+          if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "✓ Found release tag: $RELEASE_TAG"
+            git archive --format=tar --prefix="${PACKAGE_NAME}-${VERSION}/" "$RELEASE_TAG" | gzip > "v${VERSION}.tar.gz"
+          else
+            echo "⚠ Release tag $RELEASE_TAG not found, using HEAD"
+            git archive --format=tar --prefix="${PACKAGE_NAME}-${VERSION}/" HEAD | gzip > "v${VERSION}.tar.gz"
+          fi
+
+      - name: Vendor dependencies
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PACKAGE_NAME="rustnet"
+          RELEASE_TAG="v${VERSION}"
+          
+          mkdir -p build-vendor
+          if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+            git archive --format=tar "$RELEASE_TAG" | tar -x -C build-vendor
+          else
+            git archive --format=tar HEAD | tar -x -C build-vendor
+          fi
+          
+          cd build-vendor
+          # Capture the source-replacement config that cargo prints. The OBS
+          # build has no network, so it needs this at .cargo/config.toml to
+          # resolve crates from the vendored directory instead of crates.io.
+          mkdir -p .cargo
+          cargo vendor vendor > .cargo/config.toml
+
+          # Clean up static libs to reduce size
+          find vendor -name "*.a" -delete
+          find vendor -name "*.lib" -delete
+
+          # Bundle .cargo/config.toml alongside vendor/ so `%autosetup -a 1`
+          # drops both into the source tree for the offline build.
+          tar --use-compress-program="zstd -T0 -10" -cf ../vendor.tar.zst .cargo vendor
+          cd ..
+          rm -rf build-vendor
+
+      - name: Prepare and push to OBS
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          OBS_PROJECT="${{ secrets.OBS_PROJECT }}"
+          OBS_PACKAGE="rustnet"
+          
+          if [ -z "$OBS_PROJECT" ]; then
+            echo "::error::OBS_PROJECT secret is not set!"
+            exit 1
+          fi
+          
+          # Checkout OBS project
+          osc checkout "$OBS_PROJECT" "$OBS_PACKAGE"
+          cd "$OBS_PROJECT/$OBS_PACKAGE"
+          
+          # Clean old files
+          rm -f *.tar.gz *.tar.zst *.spec
+          
+          # Copy new files
+          cp ../../v${VERSION}.tar.gz .
+          cp ../../vendor.tar.zst .
+          cp ../../rpm/rustnet.spec .
+          
+          # Update version in spec file
+          sed -i "s/^Version:.*/Version: $VERSION/" rustnet.spec
+
+          # Prepend a changelog entry. OBS has no rpmautospec, so the spec's
+          # %changelog is empty on SUSE and the changelog lives here instead.
+          STAMP="$(LC_ALL=C date -u '+%a %b %e %T %Z %Y')"
+          {
+            printf -- '-------------------------------------------------------------------\n'
+            printf '%s - %s@opensuse.org\n\n' "$STAMP" "${{ secrets.OBS_USER }}"
+            printf -- '- Update to version %s\n\n' "$VERSION"
+            [ -f rustnet.changes ] && cat rustnet.changes
+          } > rustnet.changes.new
+          mv rustnet.changes.new rustnet.changes
+
+          # Add new files, remove deleted ones
+          osc addremove
+          
+          # Commit to OBS
+          osc commit -m "Update to version $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,6 +396,7 @@ jobs:
       - publish-docker
       - update-copr
       - release-ppa
+      - release-obs
     steps:
       - name: All publish steps complete
         run: echo "Release pipeline fully published; safe to fire downstream triggers."
@@ -792,4 +793,10 @@ jobs:
     name: Release to PPA
     needs: publish-release
     uses: ./.github/workflows/ppa-release.yml
+    secrets: inherit
+
+  release-obs:
+    name: Release to OBS
+    needs: publish-release
+    uses: ./.github/workflows/obs-release.yml
     secrets: inherit

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -248,6 +248,23 @@ rustnet
 
 **Important:** The COPR only supports Fedora 42 and 43 due to the Rust 1.88+ requirement. CentOS and RHEL don't have recent enough Rust compilers in their repositories. For those distributions, use the [.rpm packages](#redhatfedoracentos-rpm-packages) from GitHub releases or [build from source](#building-from-source).
 
+#### openSUSE Tumbleweed (OBS)
+
+RustNet is built for openSUSE Tumbleweed (x86_64 and aarch64) via the [openSUSE Build Service](https://build.opensuse.org/package/show/home:domcyrus:rustnet/rustnet).
+
+```bash
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/domcyrus:/rustnet/openSUSE_Tumbleweed/home:domcyrus:rustnet.repo
+sudo zypper refresh
+sudo zypper install rustnet
+
+# Run with sudo
+sudo rustnet
+
+# Optional: Grant capabilities to run without sudo (modern kernel 5.8+)
+sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet
+rustnet
+```
+
 #### Homebrew Installation
 
 **On macOS:**

--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ sudo dnf copr enable domcyrus/rustnet
 sudo dnf install rustnet
 ```
 
+**openSUSE Tumbleweed:**
+```bash
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/domcyrus:/rustnet/openSUSE_Tumbleweed/home:domcyrus:rustnet.repo
+sudo zypper refresh
+sudo zypper install rustnet
+```
+
 **Arch Linux:**
 ```bash
 sudo pacman -S rustnet

--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -4,46 +4,83 @@ Name:    rustnet
 # renovate: datasource=github-releases depName=domcyrus/rustnet extractVersion=true
 Version: 1.3.0
 Release: 1%{?dist}
-Summary: A cross-platform network monitoring terminal UI tool built with Rust
+Summary: Per-process network monitoring TUI with deep packet inspection
 License: Apache-2.0
 URL:     https://github.com/domcyrus/%{name}
 Source0: %{url}/archive/refs/tags/v%{version}.tar.gz
+%if 0%{?suse_version}
+Source1: vendor.tar.zst
+%endif
 
+%if 0%{?suse_version}
+BuildRequires: cargo-packaging
+%else
 BuildRequires: cargo
+%endif
 BuildRequires: rust >= 1.88.0
 BuildRequires: libpcap-devel
+%if 0%{?suse_version}
+BuildRequires: libelf-devel
+%else
 BuildRequires: elfutils-libelf-devel
+%endif
 BuildRequires: clang
 BuildRequires: llvm
 
 Requires: libpcap
+%if 0%{?suse_version}
+Requires: libelf1
+%else
 Requires: elfutils-libelf
+%endif
 
 %description
-A cross-platform network monitoring tool built with Rust. RustNet provides
-real-time visibility into network connections with detailed state information,
-connection lifecycle management, deep packet inspection, and a terminal user
-interface.
+RustNet is a terminal UI that shows live per-process network activity:
+which application owns each TCP, UDP, and QUIC connection, what protocol
+it speaks, and how the connection is behaving in real time. It runs
+sandboxed by default and drops privileges immediately after libpcap
+initializes.
 
-Features include:
-- Real-time Network Monitoring for TCP, UDP, ICMP, and ARP connections
-- Deep Packet Inspection (DPI) for HTTP/HTTPS, DNS, SSH, and QUIC protocols
-- Connection lifecycle management with protocol-aware timeouts
-- Process identification and service name resolution
-- Cross-platform support (Linux, macOS, Windows, BSD)
-- Advanced filtering with vim/fzf-style search
-- eBPF-enhanced process detection (enabled by default with automatic fallback)
+Features:
+- Per-process attribution for TCP, UDP, and QUIC via eBPF on Linux,
+  PKTAP on macOS, and native APIs on Windows and FreeBSD
+- Deep packet inspection for HTTP, HTTPS/TLS (with SNI), DNS, SSH,
+  FTP, QUIC, MQTT, BitTorrent, STUN, NTP, mDNS, LLMNR, DHCP, SNMP,
+  SSDP, and NetBIOS
+- Security sandboxing: Landlock (Linux 5.13+), Seatbelt (macOS),
+  token privilege drop and job-object child blocking (Windows)
+- TCP analytics: retransmissions, out-of-order packets, and
+  fast-retransmit detection, per-connection and aggregate
+- Protocol-aware connection lifecycle with staleness indicators
+- Vim/fzf-style filtering on port, src, dst, sni, process, state,
+  proto, plus regex
+- GeoIP country lookups via local MaxMind GeoLite2 (no network calls)
+- Cross-platform: Linux, macOS, Windows, FreeBSD
 
 %prep
+%if 0%{?suse_version}
+%autosetup -n %{name}-%{version} -a 1
+%else
 %autosetup -n %{name}-%{version}
+%endif
 
 %build
+%if 0%{?suse_version}
+%{cargo_build}
+%else
 export RUSTFLAGS="%{build_rustflags}"
 # eBPF is now enabled by default, no need for explicit feature flag
 cargo build --release
+%endif
 
 %install
+%if 0%{?suse_version}
+%{cargo_install}
+# cargo_install may generate .crates.toml and .crates2.json, we don't want them
+rm -f %{buildroot}%{_prefix}/.crates.toml %{buildroot}%{_prefix}/.crates2.json
+%else
 install -Dpm 0755 target/release/rustnet -t %{buildroot}%{_bindir}/
+%endif
 install -Dpm 0644 assets/services -t %{buildroot}%{_datadir}/%{name}/
 install -Dpm 0644 README.md -t %{buildroot}%{_docdir}/%{name}/
 install -Dpm 0644 resources/packaging/linux/graphics/rustnet.png -t %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/
@@ -124,4 +161,8 @@ USAGE:
 EOF
 
 %changelog
+%if 0%{?suse_version}
+# OBS does not support rpmautospec; the changelog is maintained in rustnet.changes
+%else
 %autochangelog
+%endif


### PR DESCRIPTION
## Summary

Adds an OBS release leg parallel to the existing COPR and PPA flows. On tag push, the new `release-obs` job vendors deps, packs a source + vendor tarball, generates a `rustnet.changes` file (OBS has no rpmautospec), and pushes everything to `home:domcyrus:rustnet` on build.opensuse.org. OBS then builds for **Tumbleweed (x86_64)** and **Factory ARM (aarch64)** and publishes via download.opensuse.org.

The RPM spec gains SUSE-only `%if 0%{?suse_version}` conditionals — `cargo-packaging` macros, `Source1: vendor.tar.zst` (now bundles `.cargo/config.toml` so offline builds resolve crates), `libelf-devel`/`libelf1` — so the Fedora COPR path is untouched.

`Summary:` and `%description` are refreshed from the current README. The old wording mentioned ICMP/ARP and missed per-process attribution, sandboxing, and the full DPI protocol list. Both COPR and OBS now ship consistent metadata.

Install snippets added to `README.md` and `INSTALL.md`.

## Prerequisites (one-time, manual)

- OBS sub-project `home:domcyrus:rustnet` exists with package `rustnet` and the two repositories configured.
- GitHub secrets set: `OBS_USER`, `OBS_PASS`, `OBS_PROJECT=home:domcyrus:rustnet`.

## Test plan

- [ ] Trigger `Release to OBS` manually via workflow_dispatch on this branch — confirm vendor.tar.zst contains both `.cargo/config.toml` and `vendor/`.
- [ ] Confirm `osc commit` succeeds and files land in the OBS package.
- [ ] Watch the OBS Tumbleweed build go green; install via `zypper` and run `rustnet`.
- [ ] Confirm the Fedora COPR auto-rebuild still works on the next spec push (the conditional should leave its path untouched).