### PR TITLE
fix(rpm): own directories the package creates

### DIFF
--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -28,6 +28,7 @@ BuildRequires: clang
 BuildRequires: llvm
 
 Requires: libpcap
+Requires: hicolor-icon-theme
 %if 0%{?suse_version}
 Requires: libelf1
 %else
@@ -82,14 +83,14 @@ rm -f %{buildroot}%{_prefix}/.crates.toml %{buildroot}%{_prefix}/.crates2.json
 install -Dpm 0755 target/release/rustnet -t %{buildroot}%{_bindir}/
 %endif
 install -Dpm 0644 assets/services -t %{buildroot}%{_datadir}/%{name}/
-install -Dpm 0644 README.md -t %{buildroot}%{_docdir}/%{name}/
 install -Dpm 0644 resources/packaging/linux/graphics/rustnet.png -t %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/
 install -Dpm 0644 resources/packaging/linux/rustnet.desktop -t %{buildroot}%{_datadir}/applications/
 
 %files
 %license LICENSE
-%doc %{_docdir}/%{name}/README.md
+%doc README.md
 %{_bindir}/rustnet
+%dir %{_datadir}/%{name}
 %{_datadir}/%{name}/services
 %{_datadir}/icons/hicolor/256x256/apps/rustnet.png
 %{_datadir}/applications/rustnet.desktop


### PR DESCRIPTION
## Summary

OBS Tumbleweed build of #356 failed at `check-filelist` because five directories created in `%install` are not owned by any package:

```
rustnet-1.3.0-1.1.x86_64.rpm: directories not owned by a package:
 - /usr/share/doc/packages/rustnet
 - /usr/share/icons/hicolor
 - /usr/share/icons/hicolor/256x256
 - /usr/share/icons/hicolor/256x256/apps
 - /usr/share/rustnet
```

Three changes:

- Switch `README.md` handling to `%doc README.md` (canonical form) — rpm copies the file to `%{_docdir}/%{name}` *and* claims the directory. Drops the now-redundant `install -Dpm 0644 README.md ...` line.
- Add `%dir %{_datadir}/%{name}` so the package owns `/usr/share/rustnet/`.
- Add `Requires: hicolor-icon-theme` so the icon tree is owned by its canonical provider (works on both Fedora and openSUSE).

Universally valid — Fedora COPR builds unchanged.

## Test plan

- [ ] Merge, then re-dispatch `Release to OBS` from main.
- [ ] Watch the OBS Tumbleweed build go green this time.