### PR TITLE
fix(rpm): own hicolor icon directories explicitly

### DIFF
--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -92,6 +92,9 @@ install -Dpm 0644 resources/packaging/linux/rustnet.desktop -t %{buildroot}%{_da
 %{_bindir}/rustnet
 %dir %{_datadir}/%{name}
 %{_datadir}/%{name}/services
+%dir %{_datadir}/icons/hicolor
+%dir %{_datadir}/icons/hicolor/256x256
+%dir %{_datadir}/icons/hicolor/256x256/apps
 %{_datadir}/icons/hicolor/256x256/apps/rustnet.png
 %{_datadir}/applications/rustnet.desktop
 


### PR DESCRIPTION
## Summary

Follow-up to #357. The OBS Tumbleweed build still failed `check-filelist`:

```
rustnet-1.3.0-2.1.x86_64.rpm: directories not owned by a package:
 - /usr/share/icons/hicolor
 - /usr/share/icons/hicolor/256x256
 - /usr/share/icons/hicolor/256x256/apps
```

`Requires: hicolor-icon-theme` doesn't satisfy this lint — it inspects directories owned by the packages in the build set, not the full runtime dep tree. Explicit `%dir` entries co-own the directories alongside hicolor-icon-theme (RPM supports multi-owner dirs; this is the openSUSE convention for any package that installs into the hicolor tree).

## Test plan

- [ ] Merge, re-dispatch Release to OBS.
- [ ] Confirm OBS Tumbleweed build succeeds.