### PR TITLE
fix(rpm): pull in libcap-progs so %post setcap runs on openSUSE

### DIFF
--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -31,6 +31,10 @@ Requires: libpcap
 Requires: hicolor-icon-theme
 %if 0%{?suse_version}
 Requires: libelf1
+# Pulled in so %post can run setcap (minimal Tumbleweed lacks it). Weak dep
+# because `sudo rustnet` still works without it. Mirrors the PPA's
+# `Recommends: libcap2-bin`.
+Recommends: libcap-progs
 %else
 Requires: elfutils-libelf
 %endif


### PR DESCRIPTION
## Summary

End-to-end install of `home:domcyrus:rustnet` on a fresh openSUSE Tumbleweed VM completes successfully but `rustnet` then fails with the "INSUFFICIENT PRIVILEGES" screen because `%post` can't find `setcap` — the minimal Tumbleweed image doesn't ship `libcap-progs`.

Mirrors the PPA's `Recommends: libcap2-bin` on the openSUSE side. zypper installs Recommends by default, so a plain `zypper install rustnet` now gets caps applied automatically. `sudo rustnet` still works for users who opt out of Recommends.

## Test plan

- [ ] Merge, re-dispatch Release to OBS, wait for the OBS rebuild.
- [ ] `zypper install rustnet` in a fresh Tumbleweed VM and confirm `getcap /usr/bin/rustnet` shows `cap_net_raw,cap_bpf,cap_perfmon=eip`.