### PR TITLE
fix(rpm): require libcap-progs on openSUSE, not just recommend

### DIFF
--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -31,10 +31,11 @@ Requires: libpcap
 Requires: hicolor-icon-theme
 %if 0%{?suse_version}
 Requires: libelf1
-# Pulled in so %post can run setcap (minimal Tumbleweed lacks it). Weak dep
-# because `sudo rustnet` still works without it. Mirrors the PPA's
-# `Recommends: libcap2-bin`.
-Recommends: libcap-progs
+# Pulled in so %post can run setcap (minimal Tumbleweed lacks it).
+# Hard Requires (not Recommends) because zypper doesn't pull in new
+# Recommends on `zypper update`, which would silently break the cap
+# auto-setup for existing users on upgrade.
+Requires: libcap-progs
 %else
 Requires: elfutils-libelf
 %endif


### PR DESCRIPTION
## Summary

Follow-up to #359. End-to-end test in an OrbStack openSUSE Tumbleweed VM showed that `Recommends: libcap-progs` works for fresh `zypper install rustnet`, but **not** for `zypper update`: zypper doesn't apply newly-added Recommends on upgrade, so existing users would silently lose the post-install setcap auto-setup added in the previous spec bump.

Switching to `Requires:` — `libcap-progs` is tiny, and the package is unusable as a non-root user without it (the in-binary INSUFFICIENT PRIVILEGES screen is what we're trying to avoid).

## Test plan

- [ ] Merge, dispatch, wait for OBS rebuild.
- [ ] `zypper update rustnet` on the orb VM, confirm `getcap /usr/bin/rustnet` reports the caps and `rustnet` runs without sudo.