### PR TITLE
feat(sandbox): best-effort Landlock with v6 IPC scoping

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -76,6 +76,12 @@ pub struct SandboxInfo {
     /// Whether Landlock filesystem restrictions are applied
     #[cfg(target_os = "linux")]
     pub fs_restricted: bool,
+    /// Whether Landlock scope restrictions (abstract UNIX sockets + signals) are applied
+    #[cfg(target_os = "linux")]
+    pub scope_restricted: bool,
+    /// Effective Landlock ABI negotiated with the kernel (e.g. `Some(6)`), or `None`
+    #[cfg(target_os = "linux")]
+    pub landlock_abi: Option<u8>,
     // macOS-specific fields (Seatbelt)
     /// Whether Seatbelt sandbox was applied
     #[cfg(all(target_os = "macos", feature = "macos-sandbox"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,8 @@ fn main() -> Result<()> {
                     landlock_available: result.landlock_available,
                     fs_restricted: result.landlock_fs_applied,
                     net_restricted: result.landlock_net_applied,
+                    scope_restricted: result.landlock_scope_applied,
+                    landlock_abi: result.landlock_effective_abi,
                 });
             }
             Err(e) => {
@@ -253,6 +255,8 @@ fn main() -> Result<()> {
                     landlock_available: false,
                     fs_restricted: false,
                     net_restricted: false,
+                    scope_restricted: false,
+                    landlock_abi: None,
                 });
             }
         }

--- a/src/network/platform/linux/sandbox/landlock.rs
+++ b/src/network/platform/linux/sandbox/landlock.rs
@@ -8,8 +8,15 @@
 //!
 //! - Linux 5.13+: Filesystem access control (ABI v1)
 //! - Linux 5.19+: File referring/REFER (ABI v2)
-//! - Linux 6.2+: Truncate control (ABI v3)
-//! - Linux 6.4+: Network TCP bind/connect (ABI v4)
+//! - Linux 6.2+:  Truncate control (ABI v3)
+//! - Linux 6.7+:  Network TCP bind/connect (ABI v4)
+//! - Linux 6.12+: Scoping of abstract UNIX sockets and signals (ABI v6)
+//!
+//! We rely on the `landlock` crate's default best-effort compatibility: on
+//! older kernels any unsupported rights are silently dropped rather than
+//! causing an error. Filesystem rights are deliberately capped at ABI v4
+//! ([`ABI_FS`]) to avoid ABI v5's `IoctlDev` (which would break the TUI's
+//! terminal ioctls), while scoping uses ABI v6 ([`ABI_SCOPE`]).
 //!
 //! # What We Restrict
 //!
@@ -17,15 +24,36 @@
 //! - Filesystem: Only allow read access to specified paths (e.g., GeoIP databases)
 //! - Filesystem: Only allow write access to specified paths (logs)
 //! - Network: Block TCP bind and connect (RustNet is passive)
+//! - Scope: Deny connecting to abstract UNIX sockets created outside our domain
+//!   and deny sending signals to processes outside our domain (limits a
+//!   compromised process from reaching local IPC like D-Bus/X11 or signalling
+//!   other processes)
 
 use anyhow::{Context, Result};
 use landlock::{
     ABI, Access, AccessFs, AccessNet, BitFlags, LandlockStatus, PathBeneath, PathFd, Ruleset,
-    RulesetAttr, RulesetCreatedAttr, RulesetStatus,
+    RulesetAttr, RulesetCreatedAttr, RulesetStatus, Scope,
 };
 use std::path::Path;
 
 use super::{SandboxConfig, SandboxMode};
+
+/// Highest ABI whose *filesystem* rights we handle.
+///
+/// Capped at V4 on purpose: ABI v5 adds `AccessFs::IoctlDev`, and
+/// `AccessFs::from_all(V5+)` would handle it. Since we add no allow-rule for
+/// ioctls on the controlling terminal (a character device), handling IoctlDev
+/// would deny the ratatui/crossterm ioctls (e.g. `TIOCGWINSZ`, `TCSETS`) and
+/// break the TUI. V4's `from_all` covers all filesystem rights we want
+/// (read/write/truncate) without IoctlDev.
+const ABI_FS: ABI = ABI::V4;
+
+/// ABI used for scoping (abstract UNIX sockets + signals).
+///
+/// V6 (Linux 6.12+) is the first ABI with scoping. We stop at V6 rather than V7
+/// because V7 only adds audit-logging controls, which we don't use. The crate
+/// downgrades automatically (best effort) on kernels that support less.
+const ABI_SCOPE: ABI = ABI::V6;
 
 /// Result of Landlock application
 pub struct LandlockResult {
@@ -33,8 +61,33 @@ pub struct LandlockResult {
     pub fs_applied: bool,
     /// Whether network restrictions were applied
     pub net_applied: bool,
+    /// Whether scoping restrictions (abstract UNIX sockets + signals) were applied
+    pub scope_applied: bool,
+    /// Effective Landlock ABI the kernel negotiated (e.g. `Some(6)`), or `None`
+    /// when Landlock is unavailable / not enforced. This is the tier that is
+    /// actually in effect, which may be lower than what we requested.
+    pub effective_abi: Option<u8>,
     /// Human-readable message
     pub message: String,
+}
+
+/// Map a `landlock::ABI` to its numeric version for display/reporting.
+///
+/// The `landlock` 0.4.5 crate knows up to `V7`; `restrict_self` never reports an
+/// effective ABI above the crate's compiled-in maximum, so the catch-all is only
+/// future-proofing and not expected to trigger.
+fn abi_version(abi: ABI) -> u8 {
+    match abi {
+        ABI::Unsupported => 0,
+        ABI::V1 => 1,
+        ABI::V2 => 2,
+        ABI::V3 => 3,
+        ABI::V4 => 4,
+        ABI::V5 => 5,
+        ABI::V6 => 6,
+        ABI::V7 => 7,
+        _ => 0,
+    }
 }
 
 /// Check if Landlock is available by attempting a test restriction
@@ -54,13 +107,15 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<LandlockResult> {
         return Ok(LandlockResult {
             fs_applied: false,
             net_applied: false,
+            scope_applied: false,
+            effective_abi: None,
             message: "Sandbox disabled".to_string(),
         });
     }
 
-    // Use ABI V4 which includes network support
-    // The crate will automatically handle compatibility with older kernels
-    let abi = ABI::V4;
+    // Filesystem rights are capped at ABI v4 (see ABI_FS); the crate's default
+    // best-effort compatibility downgrades automatically on older kernels.
+    let abi = ABI_FS;
 
     // Build filesystem access rights for reading
     // We need read access to /proc for process identification
@@ -74,35 +129,42 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<LandlockResult> {
         | AccessFs::MakeReg
         | AccessFs::Truncate;
 
-    // Start building the ruleset
-    let ruleset = Ruleset::default()
+    // Start building the ruleset. `Ruleset::default()` uses the crate's
+    // best-effort compatibility, so requesting rights newer than the running
+    // kernel supports silently drops them instead of erroring.
+    let mut ruleset = Ruleset::default()
         .handle_access(AccessFs::from_all(abi))
         .context("Failed to handle filesystem access")?;
 
-    // Add network handling if requested
-    // This will be ignored on kernels that don't support it (< 6.4)
-    // Note: Landlock ABI V4 only supports TCP restrictions (BindTcp, ConnectTcp).
-    // UDP blocking is under active kernel development (ABI V5+) but not available yet.
-    // UDP exfiltration risk is accepted as low: Landlock restricts file reads,
-    // limiting what an attacker could exfiltrate even with UDP socket access.
-    let ruleset = if config.block_network {
-        // Try to handle network access - ignore errors for older kernels
-        match ruleset
+    // Add network + scope restrictions if requested (the passive-monitor profile).
+    //
+    // Network: handling BindTcp/ConnectTcp without adding any allow-rule denies
+    // all TCP bind/connect (kernel 6.7+, ABI v4). On older kernels best-effort
+    // drops these silently.
+    //
+    // Scope: denying abstract UNIX socket connects and signal sending to
+    // processes outside our domain (kernel 6.12+, ABI v6). This closes a local
+    // exfiltration / lateral-movement channel (D-Bus session bus, X11's
+    // `@/tmp/.X11-unix`, etc.) that RustNet never legitimately uses. Pathname
+    // UNIX sockets (nss/nscd/systemd-resolved, the reverse-DNS IPC path) are NOT
+    // abstract sockets and are unaffected.
+    //
+    // TODO(udp landlock): UDP restrictions (LANDLOCK_ACCESS_NET_CONNECT_UDP /
+    // SENDTO_UDP) are an RFC kernel patch series as of 2026-05 and not yet
+    // exposed by the `landlock` crate. When `AccessNet::ConnectUdp` / `SendtoUdp`
+    // land, add them to the chain below (they degrade via best effort too). Note
+    // the tension: a blanket UDP block breaks reverse DNS (glibc resolver,
+    // UDP/53) and the `UdpSocket::connect("8.8.8.8:53")` routing heuristic in
+    // capture.rs, so a UDP/53 allow-rule or reliance on `--no-resolve-dns` would
+    // be needed.
+    if config.block_network {
+        ruleset = ruleset
             .handle_access(AccessNet::BindTcp)
             .and_then(|r| r.handle_access(AccessNet::ConnectTcp))
-        {
-            Ok(r) => r,
-            Err(_) => {
-                // Network access handling failed, recreate without network
-                log::debug!("Network access handling not supported, continuing without");
-                Ruleset::default()
-                    .handle_access(AccessFs::from_all(abi))
-                    .context("Failed to handle filesystem access")?
-            }
-        }
-    } else {
-        ruleset
-    };
+            .context("Failed to handle TCP network access")?
+            .scope(Scope::from_all(ABI_SCOPE))
+            .context("Failed to handle scope restrictions")?;
+    }
 
     // Create the ruleset
     let mut ruleset_created = ruleset
@@ -156,9 +218,10 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<LandlockResult> {
         }
     }
 
-    // If network blocking is enabled, we DON'T add any NetPort rules
-    // This means all TCP bind/connect operations are blocked by default
-    // (We're handling the access types but not allowing any ports)
+    // If network blocking is enabled, we DON'T add any NetPort rules and no
+    // scope allow-rules. Handling the access/scope types without allowing any
+    // port (or any abstract socket) blocks all TCP bind/connect and all
+    // cross-domain abstract-socket connects / signals by default.
 
     // Apply the restrictions
     let status = ruleset_created
@@ -171,13 +234,31 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<LandlockResult> {
         RulesetStatus::FullyEnforced | RulesetStatus::PartiallyEnforced
     );
 
-    // Check if network restrictions were actually applied
+    // Check if network restrictions were actually applied. TCP net needs ABI v4
+    // (Linux 6.7+); scoping needs ABI v6 (Linux 6.12+). We read the effective ABI
+    // the kernel negotiated rather than what we requested.
     let net_applied = config.block_network
         && fs_applied
         && matches!(
             status.landlock,
             LandlockStatus::Available { effective_abi, .. } if effective_abi >= ABI::V4
         );
+
+    let scope_applied = config.block_network
+        && fs_applied
+        && matches!(
+            status.landlock,
+            LandlockStatus::Available { effective_abi, .. } if effective_abi >= ABI_SCOPE
+        );
+
+    // The ABI tier actually negotiated with the running kernel (only meaningful
+    // when Landlock is available and something was enforced).
+    let effective_abi = match status.landlock {
+        LandlockStatus::Available { effective_abi, .. } if fs_applied => {
+            Some(abi_version(effective_abi))
+        }
+        _ => None,
+    };
 
     let message = match (&status.ruleset, &status.landlock) {
         (RulesetStatus::FullyEnforced, _) => "Landlock fully enforced".to_string(),
@@ -193,15 +274,18 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<LandlockResult> {
 
     log::info!("Landlock: {}", message);
     log::info!(
-        "Landlock: filesystem={}, network={}, landlock_status={:?}",
+        "Landlock: filesystem={}, network={}, scope={}, landlock_status={:?}",
         fs_applied,
         net_applied,
+        scope_applied,
         status.landlock
     );
 
     Ok(LandlockResult {
         fs_applied,
         net_applied,
+        scope_applied,
+        effective_abi,
         message,
     })
 }
@@ -242,5 +326,24 @@ mod tests {
         let result = apply_landlock(&config).unwrap();
         assert!(!result.fs_applied);
         assert!(!result.net_applied);
+        assert!(!result.scope_applied);
+        assert_eq!(result.effective_abi, None);
+    }
+
+    #[test]
+    fn test_best_effort_does_not_panic() {
+        // Requesting the highest ABI plus network/scope must not error or panic
+        // regardless of the running kernel: best-effort silently drops any
+        // unsupported rights. On kernels without Landlock this returns a result
+        // with nothing applied; on modern kernels it enforces.
+        let config = SandboxConfig {
+            mode: SandboxMode::BestEffort,
+            block_network: true,
+            read_paths: vec![],
+            write_paths: vec![],
+        };
+        let result = apply_landlock(&config).expect("best-effort must not error");
+        // scope can only be reported applied when fs was applied too
+        assert!(result.fs_applied || !result.scope_applied);
     }
 }

--- a/src/network/platform/linux/sandbox/mod.rs
+++ b/src/network/platform/linux/sandbox/mod.rs
@@ -10,7 +10,9 @@
 //! After sandboxing is applied:
 //! - Filesystem: Only `/proc` and specified read paths (e.g., GeoIP databases) readable
 //! - Filesystem: Only specified write paths writable (e.g., logs, exports)
-//! - Network: TCP bind/connect blocked (kernel 6.4+)
+//! - Network: TCP bind/connect blocked (kernel 6.7+, ABI v4)
+//! - Scope: abstract UNIX socket connects + signals to outside processes blocked
+//!   (kernel 6.12+, ABI v6)
 //! - Capabilities: CAP_NET_RAW, CAP_BPF, CAP_PERFMON dropped
 //! - Privileges: PR_SET_NO_NEW_PRIVS set (no privilege escalation via execve)
 //!
@@ -22,8 +24,9 @@
 //! # Compatibility
 //!
 //! - Kernel 5.13+: Filesystem sandboxing
-//! - Kernel 6.4+: Network sandboxing (TCP bind/connect)
-//! - Older kernels: Graceful degradation (sandbox not applied)
+//! - Kernel 6.7+:  Network sandboxing (TCP bind/connect, ABI v4)
+//! - Kernel 6.12+: Scope sandboxing (abstract UNIX sockets + signals, ABI v6)
+//! - Older kernels: Graceful degradation (unsupported restrictions dropped)
 
 #[cfg(feature = "landlock")]
 pub mod capabilities;
@@ -73,6 +76,11 @@ pub struct SandboxResult {
     pub landlock_fs_applied: bool,
     /// Whether Landlock network restrictions were applied
     pub landlock_net_applied: bool,
+    /// Whether Landlock scope restrictions (abstract UNIX sockets + signals) were applied
+    pub landlock_scope_applied: bool,
+    /// Effective Landlock ABI negotiated with the kernel (e.g. `Some(6)`), or
+    /// `None` when Landlock is unavailable / not enforced
+    pub landlock_effective_abi: Option<u8>,
 }
 
 /// Status of sandbox application
@@ -115,6 +123,8 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
             landlock_available,
             landlock_fs_applied: false,
             landlock_net_applied: false,
+            landlock_scope_applied: false,
+            landlock_effective_abi: None,
         });
     }
 
@@ -126,6 +136,8 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
         landlock_available,
         landlock_fs_applied: false,
         landlock_net_applied: false,
+        landlock_scope_applied: false,
+        landlock_effective_abi: None,
     };
 
     let mut messages = Vec::new();
@@ -195,12 +207,17 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
         Ok(ll_result) => {
             result.landlock_fs_applied = ll_result.fs_applied;
             result.landlock_net_applied = ll_result.net_applied;
+            result.landlock_scope_applied = ll_result.scope_applied;
+            result.landlock_effective_abi = ll_result.effective_abi;
 
             if ll_result.fs_applied {
                 messages.push("Landlock filesystem restrictions applied".to_string());
             }
             if ll_result.net_applied {
                 messages.push("Landlock network restrictions applied".to_string());
+            }
+            if ll_result.scope_applied {
+                messages.push("Landlock scope restrictions applied".to_string());
             }
             if !ll_result.fs_applied && !ll_result.net_applied {
                 messages.push(format!("Landlock not applied: {}", ll_result.message));
@@ -266,5 +283,7 @@ pub fn apply_sandbox(_config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
         landlock_available: false,
         landlock_fs_applied: false,
         landlock_net_applied: false,
+        landlock_scope_applied: false,
+        landlock_effective_abi: None,
     })
 }

--- a/src/ui/tabs/overview.rs
+++ b/src/ui/tabs/overview.rs
@@ -1104,8 +1104,15 @@ fn draw_stats_panel(
         if sandbox_info.net_restricted {
             features.push("Net blocked");
         }
+        if sandbox_info.scope_restricted {
+            features.push("IPC scoped");
+        }
 
-        let available_indicator = if sandbox_info.landlock_available {
+        let available_indicator = if let Some(abi) = sandbox_info.landlock_abi {
+            // The negotiated ABI tells you which restriction tier is active:
+            // v4 = TCP block, v6 = + abstract-socket/signal scoping.
+            Span::styled(format!(" [Landlock ABI v{abi}]"), theme::fg(theme::muted()))
+        } else if sandbox_info.landlock_available {
             Span::styled(" [kernel supported]", theme::fg(theme::muted()))
         } else {
             Span::styled(" [kernel unsupported]", theme::fg(theme::muted()))


### PR DESCRIPTION
Request the highest applicable ABI with graceful fallback instead of a hardcoded v4: cap filesystem rights at v4 (avoid v5 IoctlDev breaking the TUI), add v6 scoping of abstract UNIX sockets and signals to limit local exfiltration, and surface the negotiated ABI in the Overview security panel.