### PR TITLE
fix(process): attribute short-lived and multithreaded processes correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to RustNet will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Process attribution for short-lived and multithreaded processes** (Linux):
+  eBPF socket tracking now records the process name (thread-group leader)
+  instead of the calling thread's name, so connections from e.g. firefox or dig
+  no longer show up as "Socket Thread" or "isc-net-0000"; PID-to-name
+  resolution reads `/proc/<pid>/comm` on demand instead of waiting for the
+  periodic scan; and new connections are enriched on a fast 250ms tick, so
+  process names appear almost immediately instead of after up to 2 seconds
+
 ## [1.3.0] - 2026-05-05
 
 The headline of this release is a major TUI refresh. The tabs, stats panel, and details view have all been redesigned, with new per-field colors, a status dot, and address scope labels making it easier to read connections at a glance.

--- a/crates/rustnet-host/src/linux/ebpf/programs/socket_tracker.bpf.c
+++ b/crates/rustnet-host/src/linux/ebpf/programs/socket_tracker.bpf.c
@@ -47,6 +47,20 @@ struct
     __type(value, struct conn_info);
 } socket_map SEC(".maps");
 
+// Minimal CO-RE view of task_struct with only the fields we touch.
+// Deliberately NOT vmlinux.h's task_struct: referencing the full
+// definition makes clang emit its complete BTF (hundreds of types,
+// including forward declarations), which older clang (e.g. v10 in the
+// Ubuntu 20.04 cross images) encodes in a way libbpf-cargo's skeleton
+// generator rejects ("Cannot get alignment of type with kind Fwd").
+// CO-RE relocation matching ignores the ___local suffix, so accesses
+// through this type resolve against the real kernel task_struct.
+struct task_struct___local
+{
+    struct task_struct___local *group_leader;
+    char comm[TASK_COMM_LEN];
+} __attribute__((preserve_access_index));
+
 // Helper to populate process information
 static __always_inline void get_process_info(struct conn_info *info)
 {
@@ -57,7 +71,18 @@ static __always_inline void get_process_info(struct conn_info *info)
     info->uid = uid_gid >> 32;
     info->timestamp = bpf_ktime_get_ns();
 
-    bpf_get_current_comm(&info->comm, sizeof(info->comm));
+    // Record the thread-group leader's comm (the process name, e.g.
+    // "firefox") rather than the current thread's comm (e.g. firefox's
+    // "Socket Thread"). For processes that exit before userspace ever
+    // resolves the PID via /proc, this comm is the only name we will
+    // ever have, so it must be the process-level one.
+    struct task_struct___local *task =
+        (struct task_struct___local *)bpf_get_current_task();
+    long err = BPF_CORE_READ_STR_INTO(&info->comm, task, group_leader, comm);
+    if (err <= 0 || info->comm[0] == '\0')
+    {
+        bpf_get_current_comm(&info->comm, sizeof(info->comm));
+    }
 }
 
 // TCP connect tracking - use tcp_connect for better address capture

--- a/crates/rustnet-host/src/linux/process.rs
+++ b/crates/rustnet-host/src/linux/process.rs
@@ -43,14 +43,35 @@ impl LinuxProcessLookup {
         })
     }
 
-    /// Get process name by PID from the cached procfs scan.
-    /// Returns None if PID not found (process may have exited or not yet scanned).
+    /// Get process name by PID. Tries the cached procfs scan first, then
+    /// falls back to reading `/proc/<pid>/comm` directly: the cache only
+    /// refreshes every few seconds, so a freshly started process — exactly
+    /// the case for short-lived tools like curl/dig — is often missing
+    /// from it while still being perfectly readable from /proc. One tiny
+    /// file read; the result is cached so repeated lookups stay cheap.
+    /// Returns None if the process has already exited and was never scanned.
     pub fn get_process_name_by_pid(&self, pid: u32) -> Option<String> {
-        self.pid_names
+        if let Some(name) = self
+            .pid_names
             .read()
             .expect("pid_names lock poisoned")
             .get(&pid)
             .cloned()
+        {
+            return Some(name);
+        }
+
+        let comm = fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+        let comm = comm.trim();
+        if comm.is_empty() {
+            return None;
+        }
+        let name = comm.to_string();
+        self.pid_names
+            .write()
+            .expect("pid_names lock poisoned")
+            .insert(pid, name.clone());
+        Some(name)
     }
 
     /// Build connection -> process mapping and PID -> name mapping

--- a/scripts/debug-attribution.sh
+++ b/scripts/debug-attribution.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Debug harness for the short-lived-process attribution race.
+#
+# Runs rustnet with debug logging IN THE FOREGROUND for ~20s (you will
+# see the TUI take over; it exits by itself), while a background loop
+# fires short-lived curl/dig processes. Captures the eBPF bpf_printk
+# stream from the kernel tracing pipe, then summarizes what the
+# process-lookup pipeline did for exactly those connections.
+#
+# Usage: scripts/debug-attribution.sh   (will sudo)
+
+OUT_DIR="/tmp/claude/attribution-debug"
+mkdir -p "${OUT_DIR}"
+rm -f "${OUT_DIR}"/*.log 2>/dev/null
+
+cd "$(dirname "$0")/.."
+
+sudo -v || exit 1
+
+# tracefs location differs across distros.
+TRACE_PIPE="/sys/kernel/tracing/trace_pipe"
+[[ -e "${TRACE_PIPE}" ]] || TRACE_PIPE="/sys/kernel/debug/tracing/trace_pipe"
+
+# Capture bpf_printk output (e.g. "map update failed") while the test runs.
+sudo sh -c "timeout 24 cat ${TRACE_PIPE}" > "${OUT_DIR}/bpf_trace.log" 2>"${OUT_DIR}/bpf_trace.err" &
+
+# Background traffic: short-lived processes, started after capture warms up.
+(
+    sleep 6
+    for i in 1 2 3; do
+        curl -s -o /dev/null --max-time 3 https://example.com
+        echo "curl #$i done ($(date +%H:%M:%S.%3N))" >> "${OUT_DIR}/traffic.log"
+        dig +short +time=1 +tries=1 "example.com" @1.1.1.1 >/dev/null 2>&1
+        echo "dig  #$i done ($(date +%H:%M:%S.%3N))" >> "${OUT_DIR}/traffic.log"
+        sleep 2
+    done
+) &
+TRAFFIC_PID=$!
+
+echo "Starting rustnet for 20s (TUI will take over this terminal)..."
+sleep 1
+sudo sh -c 'timeout 20 target/release/rustnet -l debug' || true
+
+# rustnet may have been killed mid-frame; restore the terminal.
+stty sane 2>/dev/null
+printf '\033[?1049l\033[?25h\033[?1000l\033[?1006l\n'
+
+wait ${TRAFFIC_PID} 2>/dev/null
+
+# The logs/ dir is created 0700 by the (privilege-dropped) rustnet
+# process, so globbing it needs sudo.
+LOG="$(sudo sh -c 'ls -t logs/rustnet_*.log 2>/dev/null' | head -1)"
+if [[ -z "${LOG}" ]]; then
+    echo "ERROR: no rustnet log produced; see ${OUT_DIR}/"
+    exit 1
+fi
+sudo cp "${LOG}" "${OUT_DIR}/rustnet-debug.log"
+sudo chown "$(id -u)" "${OUT_DIR}/rustnet-debug.log"
+LOG="${OUT_DIR}/rustnet-debug.log"
+
+echo ""
+echo "=== Summary (${LOG}) ==="
+echo "-- lookup outcome counts --"
+echo "  eBPF hits:            $(grep -c 'Enhanced lookup: eBPF hit' "${LOG}")"
+echo "  eBPF misses:          $(grep -c 'Enhanced lookup: eBPF miss' "${LOG}")"
+echo "  zero-source rescues:  $(grep -c 'succeeded with zero source' "${LOG}")"
+echo "  procfs name sets:     $(grep -c 'Set process name' "${LOG}")"
+echo ""
+echo "-- :443 (curl) lookup trace (first 30) --"
+grep -E "Trying eBPF|eBPF lookup (successful|missed)|Set process name" "${LOG}" | grep ":443" | head -30
+echo ""
+echo "-- 1.1.1.1 (dig) lookup trace (first 20) --"
+grep -E "Trying eBPF|eBPF lookup (successful|missed)|Set process name" "${LOG}" | grep "1\.1\.1\.1" | head -20
+echo ""
+echo "-- bpf_printk (kernel side) --"
+grep -cE "map update failed" "${OUT_DIR}/bpf_trace.log" | sed 's/^/  map update failures: /'
+wc -l < "${OUT_DIR}/bpf_trace.log" | sed 's/^/  total trace lines: /'
+echo ""
+echo "-- traffic timeline --"
+cat "${OUT_DIR}/traffic.log" 2>/dev/null
+echo ""
+echo "Full logs preserved in ${OUT_DIR}/"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1173,7 +1173,20 @@ impl App {
         // Signal that process detection (including eBPF loading) is complete.
         // The main thread waits for this before dropping eBPF capabilities.
         let _ = process_ready_tx.send(());
-        let interval = Duration::from_secs(2); // Use default interval
+
+        // Fast/slow enrichment cadence. Young connections are retried on a
+        // quick tick so their process name appears almost immediately (the
+        // eBPF map entry exists from the moment the socket connects — a
+        // slower cadence only buys a visible "-" in the UI). Older
+        // stragglers (e.g. NAT-translated container traffic the lookup can
+        // never resolve) are retried only on the full pass so the fast
+        // tick stays cheap, and fully attributed connections are skipped
+        // entirely.
+        let tick = Duration::from_millis(250);
+        let full_pass_interval = Duration::from_secs(2);
+        // Connections younger than this are retried on every fast tick.
+        const YOUNG_CONNECTION_SECS: u64 = 10;
+        let mut last_full_pass = Instant::now() - full_pass_interval;
 
         // Build and set the detection status from the process lookup implementation
         // Only set if not already detected as pktap (to handle race conditions)
@@ -1223,30 +1236,36 @@ impl App {
                 last_refresh = Instant::now();
             }
 
+            let full_pass = last_full_pass.elapsed() >= full_pass_interval;
+            if full_pass {
+                last_full_pass = Instant::now();
+            }
+
             // Enrich connections without process info
             let mut enriched = 0;
             for mut entry in tracker.connections().iter_mut() {
+                // Fully attributed — nothing to do (names are permanent).
+                if entry.process_name.is_some() && entry.pid.is_some() {
+                    continue;
+                }
+                // Fast ticks only retry young connections; older ones wait
+                // for the full pass.
+                if !full_pass {
+                    let young = entry
+                        .created_at
+                        .elapsed()
+                        .map(|age| age.as_secs() < YOUNG_CONNECTION_SECS)
+                        .unwrap_or(true);
+                    if !young {
+                        continue;
+                    }
+                }
+
                 // Allow partial enrichment - fill in missing pieces without overwriting existing data
                 if let Some((pid, name)) = process_lookup.get_process_for_connection(&entry) {
                     let mut did_enrich = false;
 
-                    // Only set process name if it's missing
-                    if let Some(existing_name) = &entry.process_name {
-                        // Check if the existing name differs significantly (for debugging)
-                        let existing_normalized = existing_name
-                            .split_whitespace()
-                            .collect::<Vec<&str>>()
-                            .join(" ");
-                        let new_normalized =
-                            name.split_whitespace().collect::<Vec<&str>>().join(" ");
-
-                        if existing_normalized != new_normalized {
-                            debug!(
-                                "⚠️  Process name differs: existing='{}' vs lsof='{}'",
-                                existing_name, name
-                            );
-                        }
-                    } else {
+                    if entry.process_name.is_none() {
                         entry.process_name = Some(name.clone());
                         did_enrich = true;
                         debug!(
@@ -1255,20 +1274,10 @@ impl App {
                             name
                         );
                     }
-
-                    // Only set PID if it's missing
                     if entry.pid.is_none() {
                         entry.pid = Some(pid);
                         did_enrich = true;
                         debug!("✓ Set PID for connection {}: {}", entry.key(), pid);
-                    } else if entry.pid != Some(pid) {
-                        // PID differs - log for debugging
-                        debug!(
-                            "⚠️  PID differs for {}: existing={:?} vs lsof={}",
-                            entry.key(),
-                            entry.pid,
-                            pid
-                        );
                     }
 
                     if did_enrich {
@@ -1281,7 +1290,7 @@ impl App {
                 debug!("Enriched {} connections with process info", enriched);
             }
 
-            thread::sleep(interval);
+            thread::sleep(tick);
         }
 
         Ok(())


### PR DESCRIPTION
Three fixes to Linux process attribution, found while investigating why connections from short-lived tools (curl, dig) often showed no process name:

- The eBPF socket tracker recorded the calling thread's comm (firefox's "Socket Thread", dig's "isc-net-0000"). It now records the thread-group leader's comm, so the map carries the real process name even for processes that exit before userspace resolves the PID.
- `get_process_name_by_pid` only consulted the procfs scan cache (5s refresh) — too slow for freshly started processes. It now falls back to reading `/proc/<pid>/comm` directly on a cache miss.
- The enrichment thread ran every 2s and re-looked-up every connection, including fully attributed ones. It now runs a 250ms tick that only retries young unattributed connections (full 2s pass for stragglers), so process names appear almost immediately at lower total lookup cost.

Validated with the included `scripts/debug-attribution.sh` harness: curl/dig connections are now attributed within the same second they appear, with correct process names instead of thread names.

Note: connections from containers (NAT-translated tuples) remain unattributable — separate issue to follow.