### PR TITLE
perf: cut per-packet allocations and snapshot CoW copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf2048e0e979efb2ca7b91c4f1a8d77c91853e9b987c94c555668a8994915ad"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "rustnet-capture"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "log",
@@ -2447,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "rustnet-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -2459,11 +2465,12 @@ dependencies = [
  "maxminddb",
  "pnet_datalink",
  "ring",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "rustnet-host"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "libbpf-cargo",
@@ -2498,6 +2505,7 @@ dependencies = [
  "pcap",
  "ratatui",
  "regex-lite",
+ "rustc-hash",
  "rustnet-capture",
  "rustnet-core",
  "rustnet-host",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 # `<field>.workspace = true`. The binary keeps its own `version` (it tracks the
 # user-facing 1.x release line, independent of the 0.x library crates).
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 authors = ["domcyrus"]
 edition = "2024"
 rust-version = "1.88.0" # Let-chains require Rust 1.88.0+
@@ -19,9 +19,9 @@ license = "Apache-2.0"
 # instead of one edit per member manifest. Members reference these with
 # `<dep>.workspace = true`.
 [workspace.dependencies]
-rustnet-core = { version = "0.1.0", path = "crates/rustnet-core" }
-rustnet-capture = { version = "0.1.0", path = "crates/rustnet-capture" }
-rustnet-host = { version = "0.1.0", path = "crates/rustnet-host" }
+rustnet-core = { version = "0.2.0", path = "crates/rustnet-core" }
+rustnet-capture = { version = "0.2.0", path = "crates/rustnet-capture" }
+rustnet-host = { version = "0.2.0", path = "crates/rustnet-host" }
 anyhow = "1.0"
 log = "0.4"
 
@@ -210,6 +210,7 @@ eula = false
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 insta = { version = "1", features = ["filters"] }
+rustc-hash = "2"
 
 [[bench]]
 name = "packet_parsing"
@@ -225,6 +226,10 @@ harness = false
 
 [[bench]]
 name = "rate_tracker"
+harness = false
+
+[[bench]]
+name = "tracker_ingest"
 harness = false
 
 [profile.release]

--- a/benches/connection_merge.rs
+++ b/benches/connection_merge.rs
@@ -31,7 +31,6 @@ fn make_connection_with_samples(n_samples: usize) -> Connection {
 /// Create a minimal ParsedPacket for merge benchmarking.
 fn make_parsed_packet() -> rustnet_monitor::network::parser::ParsedPacket {
     rustnet_monitor::network::parser::ParsedPacket {
-        connection_key: "TCP:192.168.1.100:54321-TCP:93.184.216.34:443".to_string(),
         protocol: Protocol::Tcp,
         local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321),
         remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
@@ -89,12 +88,24 @@ fn bench_merge(c: &mut Criterion) {
     group.finish();
 }
 
+/// Compare the old String key construction (kept as a baseline) against the
+/// compact `ConnectionKey` the tracker uses now: build + hash, no allocation.
 fn bench_connection_key_format(c: &mut Criterion) {
+    use std::hash::BuildHasher;
+
     let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321);
     let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
 
-    c.bench_function("connection_key_format", |b| {
+    // Baseline: what every parsed packet used to allocate.
+    c.bench_function("connection_key_format_string", |b| {
         b.iter(|| format!("TCP:{}-TCP:{}", local, remote));
+    });
+
+    // Now: construct the Copy key and hash it with the tracker's FxHash.
+    let parsed = make_parsed_packet();
+    let hasher = rustc_hash::FxBuildHasher;
+    c.bench_function("connection_key_struct_fxhash", |b| {
+        b.iter(|| hasher.hash_one(parsed.connection_key()));
     });
 }
 

--- a/benches/rate_tracker.rs
+++ b/benches/rate_tracker.rs
@@ -50,9 +50,13 @@ fn bench_rate_update(c: &mut Criterion) {
             },
         );
 
-        // Shared owner: simulates the case right after a snapshot clone,
-        // where two Arcs point to the same VecDeque. The first `update()`
-        // after a clone triggers a full VecDeque copy via Arc::make_mut.
+        // Shared owner: simulates the case right after a full clone, where
+        // two Arcs point to the same VecDeque while the snapshot is alive
+        // (in the app the UI holds it for a full refresh interval). The
+        // first `update()` then triggers a full VecDeque copy via
+        // Arc::make_mut. The snapshot is threaded through the routine and
+        // returned so it stays alive during the update and its drop isn't
+        // measured.
         group.bench_with_input(
             BenchmarkId::new("after_snapshot_clone", n_samples),
             &n_samples,
@@ -60,14 +64,41 @@ fn bench_rate_update(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let conn = make_connection_with_samples(n);
-                        let _snapshot = conn.clone(); // create shared Arc
-                        conn
+                        let snapshot = conn.clone(); // shared Arc, kept alive
+                        (conn, snapshot)
                     },
-                    |mut conn| {
+                    |(mut conn, snapshot)| {
                         conn.bytes_sent += 100;
                         conn.bytes_received += 200;
                         conn.rate_tracker
                             .update(conn.bytes_sent, conn.bytes_received);
+                        (conn, snapshot)
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+
+        // Detached snapshot: what the snapshot thread actually does now —
+        // snapshot_clone() drops the sample buffer, so the live tracker
+        // stays unique owner and the next update takes the fast path even
+        // while the snapshot is alive.
+        group.bench_with_input(
+            BenchmarkId::new("after_snapshot_clone_detached", n_samples),
+            &n_samples,
+            |b, &n| {
+                b.iter_batched(
+                    || {
+                        let conn = make_connection_with_samples(n);
+                        let snapshot = conn.snapshot_clone(); // no shared samples
+                        (conn, snapshot)
+                    },
+                    |(mut conn, snapshot)| {
+                        conn.bytes_sent += 100;
+                        conn.bytes_received += 200;
+                        conn.rate_tracker
+                            .update(conn.bytes_sent, conn.bytes_received);
+                        (conn, snapshot)
                     },
                     criterion::BatchSize::SmallInput,
                 );
@@ -83,7 +114,9 @@ fn bench_rate_update(c: &mut Criterion) {
 fn bench_refresh_rates(c: &mut Criterion) {
     let mut group = c.benchmark_group("refresh_rates");
 
-    for n_samples in [0, 100, 1000, 5000] {
+    // 20000 = the sample cap: with O(1) window totals the curve must stay
+    // flat instead of growing with the sample count.
+    for n_samples in [0, 100, 1000, 5000, 20000] {
         group.bench_with_input(
             BenchmarkId::new("unique_owner", n_samples),
             &n_samples,
@@ -139,6 +172,29 @@ fn bench_snapshot_then_update(c: &mut Criterion) {
                         // Step 1: snapshot clone (simulates UI snapshot)
                         let _snapshot: Vec<Connection> = conns.to_vec();
                         // Step 2: mutate originals (simulates incoming packets)
+                        for conn in &mut conns {
+                            conn.bytes_sent += 100;
+                            conn.bytes_received += 200;
+                            conn.rate_tracker
+                                .update(conn.bytes_sent, conn.bytes_received);
+                        }
+                    },
+                    criterion::BatchSize::LargeInput,
+                );
+            },
+        );
+
+        // Same cycle but with snapshot_clone(): the snapshot detaches from
+        // the sample buffers, so step 2 never pays the CoW deep copy.
+        group.bench_with_input(
+            BenchmarkId::new("snapshot_clone_all_then_update_all", n_conns),
+            &connections,
+            |b, connections| {
+                b.iter_batched(
+                    || connections.clone(),
+                    |mut conns| {
+                        let _snapshot: Vec<Connection> =
+                            conns.iter().map(|c| c.snapshot_clone()).collect();
                         for conn in &mut conns {
                             conn.bytes_sent += 100;
                             conn.bytes_received += 200;

--- a/benches/snapshot.rs
+++ b/benches/snapshot.rs
@@ -52,6 +52,23 @@ fn bench_snapshot(c: &mut Criterion) {
             },
         );
 
+        // Benchmark: snapshot_clone (drops rate samples) + collect — what
+        // start_snapshot_provider actually does now, leaving the live
+        // connections as unique owners of their sample buffers.
+        group.bench_with_input(
+            BenchmarkId::new("snapshot_clone_and_collect", n_conns),
+            &connections,
+            |b, connections| {
+                b.iter(|| {
+                    let snapshot: Vec<Connection> = connections
+                        .iter()
+                        .map(|entry| entry.value().snapshot_clone())
+                        .collect();
+                    snapshot
+                });
+            },
+        );
+
         // Benchmark: clone + collect + sort by created_at
         group.bench_with_input(
             BenchmarkId::new("clone_collect_sort", n_conns),

--- a/benches/tracker_ingest.rs
+++ b/benches/tracker_ingest.rs
@@ -1,0 +1,101 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rustnet_monitor::network::parser::{ParsedPacket, TcpFlags, TcpHeaderInfo};
+use rustnet_monitor::network::tracker::ConnectionTracker;
+use rustnet_monitor::network::types::*;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::SystemTime;
+
+/// Build a synthetic TCP data packet for one of `n_connections` flows.
+///
+/// Flows are distinguished by client port so the workload exercises the
+/// tracker's key hashing and DashMap sharding the same way live traffic does.
+fn make_packet(flow: u16, seq: u32) -> ParsedPacket {
+    let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 10000 + flow);
+    let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
+    ParsedPacket {
+        protocol: Protocol::Tcp,
+        local_addr,
+        remote_addr,
+        tcp_header: Some(TcpHeaderInfo {
+            seq,
+            ack: seq.wrapping_add(1),
+            window: 65535,
+            flags: TcpFlags {
+                syn: false,
+                ack: true,
+                fin: false,
+                rst: false,
+                psh: true,
+                urg: false,
+            },
+            payload_len: 1400,
+        }),
+        protocol_state: ProtocolState::Tcp(TcpState::Established),
+        is_outgoing: true,
+        packet_len: 1400,
+        dpi_result: None,
+        process_name: None,
+        process_id: None,
+    }
+}
+
+/// Interleaved packet stream: `flows` connections sending `packets_per_flow`
+/// packets round-robin, mimicking concurrent flows rather than one flow at a
+/// time.
+fn make_workload(flows: u16, packets_per_flow: u32) -> Vec<ParsedPacket> {
+    let mut packets = Vec::with_capacity(flows as usize * packets_per_flow as usize);
+    for round in 0..packets_per_flow {
+        for flow in 0..flows {
+            packets.push(make_packet(flow, round * 1460));
+        }
+    }
+    packets
+}
+
+/// The canonical per-packet ingest cost: parse results folded into a fresh
+/// tracker (mix of connection creation and in-place merge). This is the
+/// before/after number for connection-key, timestamp, and limit-check work
+/// on the packet path.
+fn bench_tracker_ingest(c: &mut Criterion) {
+    let now = SystemTime::now();
+
+    let mut group = c.benchmark_group("tracker_ingest");
+    for (flows, per_flow) in [(100u16, 100u32), (1000, 50)] {
+        let packets = make_workload(flows, per_flow);
+        group.throughput(Throughput::Elements(packets.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("fresh_tracker", format!("{flows}x{per_flow}")),
+            &packets,
+            |b, packets| {
+                b.iter(|| {
+                    let tracker = ConnectionTracker::new();
+                    for p in packets {
+                        tracker.ingest_at(p, now);
+                    }
+                    tracker
+                });
+            },
+        );
+    }
+    group.finish();
+
+    // Steady state: every packet updates an existing connection (no creation).
+    let mut group = c.benchmark_group("tracker_ingest_steady");
+    let packets = make_workload(1000, 1);
+    let tracker = ConnectionTracker::new();
+    for p in &packets {
+        tracker.ingest_at(p, now);
+    }
+    group.throughput(Throughput::Elements(packets.len() as u64));
+    group.bench_function("existing_connections_1000", |b| {
+        b.iter(|| {
+            for p in &packets {
+                tracker.ingest_at(p, now);
+            }
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_tracker_ingest);
+criterion_main!(benches);

--- a/crates/rustnet-core/Cargo.toml
+++ b/crates/rustnet-core/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 anyhow.workspace = true
 log.workspace = true
 dashmap = "6.2"
+rustc-hash = "2"
 crossbeam = "0.8"
 dns-lookup = "3.0"
 pnet_datalink = "0.35"

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -956,7 +956,6 @@ mod tests {
         use crate::network::protocol::tcp::{TcpFlags, TcpHeaderInfo};
 
         ParsedPacket {
-            connection_key: "test".to_string(),
             protocol: Protocol::Tcp,
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 12345),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),

--- a/crates/rustnet-core/src/network/parser.rs
+++ b/crates/rustnet-core/src/network/parser.rs
@@ -17,7 +17,6 @@ pub use crate::network::protocol::tcp::{TcpFlags, TcpHeaderInfo};
 /// Result of parsing a packet
 #[derive(Debug)]
 pub struct ParsedPacket {
-    pub connection_key: String,
     pub protocol: Protocol,
     pub local_addr: SocketAddr,
     pub remote_addr: SocketAddr,
@@ -28,6 +27,16 @@ pub struct ParsedPacket {
     pub dpi_result: Option<DpiResult>, // DPI results if available
     pub process_name: Option<String>,  // Process name from PKTAP metadata
     pub process_id: Option<u32>,       // Process ID from PKTAP metadata
+}
+
+impl ParsedPacket {
+    /// The flow identity this packet belongs to, derived from protocol and
+    /// addresses. `ConnectionKey` is `Copy`, so this costs nothing on the
+    /// per-packet path (no allocation, unlike the former `String` key field).
+    #[inline]
+    pub fn connection_key(&self) -> ConnectionKey {
+        ConnectionKey::new(self.protocol, self.local_addr, self.remote_addr)
+    }
 }
 
 /// Configuration for packet parsing
@@ -487,7 +496,6 @@ impl PacketParser {
         };
 
         Some(ParsedPacket {
-            connection_key: format!("ARP:{}-ARP:{}", local_addr, remote_addr),
             protocol: Protocol::Arp,
             local_addr,
             remote_addr,

--- a/crates/rustnet-core/src/network/protocol/icmp.rs
+++ b/crates/rustnet-core/src/network/protocol/icmp.rs
@@ -41,7 +41,6 @@ pub fn parse(
     };
 
     Some(ParsedPacket {
-        connection_key: format!("ICMP:{}-ICMP:{}", local_addr, remote_addr),
         protocol: Protocol::Icmp,
         local_addr,
         remote_addr,
@@ -90,7 +89,6 @@ pub fn parse_v6(
     };
 
     Some(ParsedPacket {
-        connection_key: format!("ICMP:{}-ICMP:{}", local_addr, remote_addr),
         protocol: Protocol::Icmp,
         local_addr,
         remote_addr,

--- a/crates/rustnet-core/src/network/protocol/igmp.rs
+++ b/crates/rustnet-core/src/network/protocol/igmp.rs
@@ -59,7 +59,6 @@ pub fn parse(
     };
 
     Some(ParsedPacket {
-        connection_key: format!("IGMP:{}-IGMP:{}", local_addr, remote_addr),
         protocol: Protocol::Igmp,
         local_addr,
         remote_addr,

--- a/crates/rustnet-core/src/network/protocol/tcp.rs
+++ b/crates/rustnet-core/src/network/protocol/tcp.rs
@@ -132,7 +132,6 @@ pub fn parse(
     };
 
     Some(ParsedPacket {
-        connection_key: format!("TCP:{}-TCP:{}", local_addr, remote_addr),
         protocol: Protocol::Tcp,
         local_addr,
         remote_addr,

--- a/crates/rustnet-core/src/network/protocol/udp.rs
+++ b/crates/rustnet-core/src/network/protocol/udp.rs
@@ -44,7 +44,6 @@ pub fn parse(
     };
 
     Some(ParsedPacket {
-        connection_key: format!("UDP:{}-UDP:{}", local_addr, remote_addr),
         protocol: Protocol::Udp,
         local_addr,
         remote_addr,

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -44,9 +44,39 @@ use crate::network::merge::{create_connection_from_packet, merge_packet_into_con
 use crate::network::parser::ParsedPacket;
 use crate::network::types::{ApplicationProtocol, Connection, ConnectionKey, Protocol, RttTracker};
 use dashmap::DashMap;
+use rustc_hash::FxBuildHasher;
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime};
+
+/// The active connection table: flow key -> connection.
+///
+/// Keys are compact `Copy` structs, and the map uses FxHash — with a small
+/// fixed-size key, hashing is a handful of multiplies instead of SipHash over
+/// a formatted string. (Hash-flooding resistance isn't needed here: the table
+/// is bounded by `max_connections` and keyed by addresses, not attacker-chosen
+/// bytes of arbitrary length.)
+pub type ConnectionMap = DashMap<ConnectionKey, Connection, FxBuildHasher>;
+
+/// The historic (recently-closed) connection table.
+pub type HistoricMap = DashMap<HistoricKey, Connection, FxBuildHasher>;
+
+/// Identity of an archived (closed) connection: the flow key plus the
+/// connection's creation time, so multiple closed connections that reused the
+/// same 4-tuple don't clobber each other. (Replaces the former
+/// `"<key>:<created_at_nanos>"` string suffix.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HistoricKey {
+    pub key: ConnectionKey,
+    pub created_nanos: u128,
+}
+
+impl std::fmt::Display for HistoricKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.key, self.created_nanos)
+    }
+}
 
 /// Tuning knobs for a [`ConnectionTracker`].
 #[derive(Debug, Clone)]
@@ -86,7 +116,9 @@ impl Default for TrackerConfig {
 #[derive(Debug, Clone)]
 pub struct IngestOutcome {
     /// The (possibly QUIC-coalesced) key under which the connection is stored.
-    pub key: String,
+    /// `Copy`, and its `Display` form matches the historical string key
+    /// (`"TCP:1.2.3.4:80-TCP:5.6.7.8:443"`).
+    pub key: ConnectionKey,
     /// `true` if this packet created a new connection entry.
     pub created: bool,
     /// `true` if the packet was dropped because `max_connections` was reached
@@ -105,11 +137,18 @@ pub struct IngestOutcome {
 /// A live, lifecycle-managed table of network connections built from parsed
 /// packets. See the [module docs](self) for the intended usage.
 pub struct ConnectionTracker {
-    connections: DashMap<String, Connection>,
-    historic: DashMap<String, Connection>,
+    connections: ConnectionMap,
+    historic: HistoricMap,
     rtt: Mutex<RttTracker>,
-    quic_map: Mutex<HashMap<String, String>>,
+    quic_map: Mutex<HashMap<String, ConnectionKey>>,
     config: TrackerConfig,
+    /// Active-connection count maintained by `ingest_at`/`cleanup`/`clear`.
+    /// Lets the per-packet `max_connections` check be a single atomic load
+    /// instead of a `DashMap::len()` (which read-locks every shard) plus an
+    /// extra `contains_key` lookup. May transiently lag `connections.len()`
+    /// by a few entries under concurrent ingest near the limit — acceptable
+    /// for a flood-protection bound.
+    active_count: AtomicUsize,
 }
 
 impl ConnectionTracker {
@@ -121,11 +160,12 @@ impl ConnectionTracker {
     /// Create a tracker with custom [`TrackerConfig`].
     pub fn with_config(config: TrackerConfig) -> Self {
         Self {
-            connections: DashMap::new(),
-            historic: DashMap::new(),
+            connections: ConnectionMap::with_hasher(FxBuildHasher),
+            historic: HistoricMap::with_hasher(FxBuildHasher),
             rtt: Mutex::new(RttTracker::new()),
             quic_map: Mutex::new(HashMap::new()),
             config,
+            active_count: AtomicUsize::new(0),
         }
     }
 
@@ -147,23 +187,22 @@ impl ConnectionTracker {
     /// the packet's capture timestamp so `created_at`/`last_activity` and the
     /// `cleanup` timeout sweep operate on trace time, not real time.
     pub fn ingest_at(&self, parsed: &ParsedPacket, now: SystemTime) -> IngestOutcome {
-        let mut key = parsed.connection_key.clone();
+        let mut key = parsed.connection_key();
 
         // Track RTT for TCP connections using SYN/SYN-ACK timing.
         let mut measured_rtt: Option<Duration> = None;
         if parsed.protocol == Protocol::Tcp
             && let Some(tcp_header) = &parsed.tcp_header
         {
-            let conn_key = ConnectionKey::new(parsed.local_addr, parsed.remote_addr);
             if tcp_header.flags.syn && !tcp_header.flags.ack {
                 if let Ok(mut tracker) = self.rtt.lock() {
-                    tracker.record_syn(conn_key);
+                    tracker.record_syn(key);
                 }
             } else if tcp_header.flags.syn
                 && tcp_header.flags.ack
                 && let Ok(mut tracker) = self.rtt.lock()
             {
-                measured_rtt = tracker.record_syn_ack(&conn_key);
+                measured_rtt = tracker.record_syn_ack(&key);
             }
         }
 
@@ -176,20 +215,24 @@ impl ConnectionTracker {
             && let Ok(mut mapping) = self.quic_map.lock()
         {
             if let Some(existing_key) = mapping.get(conn_id_hex) {
-                key = existing_key.clone();
+                key = *existing_key;
             } else {
                 // Prevent unbounded growth of QUIC connection-ID mappings.
                 if mapping.len() >= self.config.max_quic_mappings {
                     mapping.clear();
                 }
-                mapping.insert(conn_id_hex.clone(), key.clone());
+                mapping.insert(conn_id_hex.clone(), key);
             }
         }
 
         // Prevent unbounded growth from port scans or connection floods. Only
-        // limit new connections; existing ones always get updated.
-        if !self.connections.contains_key(&key)
-            && self.connections.len() >= self.config.max_connections
+        // limit new connections; existing ones always get updated. The fast
+        // path is a single atomic load; only when at the cap do we pay a
+        // lookup to distinguish update-existing from drop-new. (Never call
+        // `len()` here or while holding an entry guard — it read-locks every
+        // shard.)
+        if self.active_count.load(Ordering::Relaxed) >= self.config.max_connections
+            && !self.connections.contains_key(&key)
         {
             return IngestOutcome {
                 key,
@@ -205,7 +248,7 @@ impl ConnectionTracker {
         let mut created = false;
         let mut deltas = (0u64, 0u64, 0u64);
         self.connections
-            .entry(key.clone())
+            .entry(key)
             .and_modify(|conn| {
                 deltas = merge_packet_into_connection(conn, parsed, now);
                 if let Some(rtt) = measured_rtt
@@ -222,6 +265,9 @@ impl ConnectionTracker {
                 }
                 conn
             });
+        if created {
+            self.active_count.fetch_add(1, Ordering::Relaxed);
+        }
 
         IngestOutcome {
             key,
@@ -243,47 +289,56 @@ impl ConnectionTracker {
     /// pre-archive form) so callers can emit close events or export them.
     pub fn cleanup(&self, now: SystemTime) -> Vec<Connection> {
         let mut removed: Vec<Connection> = Vec::new();
-        let mut removed_keys: Vec<String> = Vec::new();
-        let mut to_archive: Vec<(String, Connection)> = Vec::new();
+        let mut removed_keys: Vec<ConnectionKey> = Vec::new();
+        let mut to_archive: Vec<(HistoricKey, Connection)> = Vec::new();
+        let keep_historic = self.config.keep_historic;
 
         self.connections.retain(|key, conn| {
             let should_keep = !conn.should_cleanup(now);
             if !should_keep {
-                removed_keys.push(key.clone());
+                removed_keys.push(*key);
                 removed.push(conn.clone());
 
                 // Archive a historic copy. The historic key includes created_at
                 // so multiple closed connections sharing a 4-tuple don't clobber
-                // each other.
-                let mut historic = conn.clone();
-                historic.is_historic = true;
-                historic.closed_at = Some(now);
-                let historic_key = format!(
-                    "{}:{}",
-                    key,
-                    conn.created_at
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_nanos()
-                );
-                to_archive.push((historic_key, historic));
+                // each other. snapshot_clone: historic connections never refresh
+                // their rates, so don't pin the (potentially large) sample
+                // buffer in the archive.
+                if keep_historic {
+                    let mut historic = conn.snapshot_clone();
+                    historic.is_historic = true;
+                    historic.closed_at = Some(now);
+                    let historic_key = HistoricKey {
+                        key: *key,
+                        created_nanos: conn
+                            .created_at
+                            .duration_since(SystemTime::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_nanos(),
+                    };
+                    to_archive.push((historic_key, historic));
+                }
             }
             should_keep
         });
+        if !removed.is_empty() {
+            self.active_count
+                .fetch_sub(removed.len(), Ordering::Relaxed);
+        }
 
-        if self.config.keep_historic {
+        if keep_historic {
             for (key, conn) in to_archive {
                 self.historic.insert(key, conn);
             }
 
             // Enforce max_historic by evicting oldest-closed first.
             if self.historic.len() > self.config.max_historic {
-                let mut entries: Vec<(String, SystemTime)> = self
+                let mut entries: Vec<(HistoricKey, SystemTime)> = self
                     .historic
                     .iter()
                     .map(|entry| {
                         let closed = entry.value().closed_at.unwrap_or(entry.value().created_at);
-                        (entry.key().clone(), closed)
+                        (*entry.key(), closed)
                     })
                     .collect();
                 entries.sort_by_key(|(_, closed)| *closed);
@@ -305,6 +360,14 @@ impl ConnectionTracker {
     }
 
     /// A point-in-time copy of the active connections.
+    ///
+    /// Note: this is a full clone, including each connection's rate-sample
+    /// buffer — the buffer is shared via `Arc`, so the *next* per-packet
+    /// update on a live connection pays a copy-on-write deep copy. Callers
+    /// that only need the cached `current_*_rate_bps` fields (any read-only
+    /// view) should prefer [`Connection::snapshot_clone`] over the entries of
+    /// [`connections`](Self::connections) to keep the packet path allocation-
+    /// free.
     pub fn snapshot(&self) -> Vec<Connection> {
         self.connections
             .iter()
@@ -338,6 +401,7 @@ impl ConnectionTracker {
     /// Drop all active and historic connections and reset RTT/QUIC state.
     pub fn clear(&self) {
         self.connections.clear();
+        self.active_count.store(0, Ordering::Relaxed);
         self.historic.clear();
         if let Ok(mut tracker) = self.rtt.lock() {
             tracker.clear();
@@ -357,13 +421,15 @@ impl ConnectionTracker {
     /// Use this for in-place enrichment (e.g. attaching process, DNS, or GeoIP
     /// information via `iter_mut`) or custom reads. Lifecycle changes should go
     /// through [`ingest`](Self::ingest) and [`cleanup`](Self::cleanup) so the
-    /// connection-count limit, RTT, and QUIC coalescing stay consistent.
-    pub fn connections(&self) -> &DashMap<String, Connection> {
+    /// connection-count limit, RTT, and QUIC coalescing stay consistent —
+    /// inserting or removing entries directly desyncs the internal counter
+    /// backing the `max_connections` check.
+    pub fn connections(&self) -> &ConnectionMap {
         &self.connections
     }
 
     /// Direct access to the historic (recently-closed) connection table.
-    pub fn historic(&self) -> &DashMap<String, Connection> {
+    pub fn historic(&self) -> &HistoricMap {
         &self.historic
     }
 
@@ -463,6 +529,39 @@ mod tests {
         // The existing flow still updates despite the limit.
         let a2 = tracker.ingest(&parse(&udp_frame(40000, 53)));
         assert!(!a2.dropped && !a2.created);
+    }
+
+    #[test]
+    fn connection_limit_recovers_after_cleanup() {
+        let tracker = ConnectionTracker::with_config(TrackerConfig {
+            max_connections: 1,
+            ..TrackerConfig::default()
+        });
+        assert!(tracker.ingest(&parse(&udp_frame(40000, 53))).created);
+        assert!(tracker.ingest(&parse(&udp_frame(40001, 53))).dropped);
+
+        // Expire everything; the limit accounting must follow the removals.
+        tracker.cleanup(SystemTime::now() + Duration::from_secs(86_400));
+        assert_eq!(tracker.len(), 0);
+
+        let c = tracker.ingest(&parse(&udp_frame(40002, 53)));
+        assert!(
+            c.created && !c.dropped,
+            "slot freed by cleanup must be reusable"
+        );
+        assert_eq!(tracker.len(), 1);
+    }
+
+    #[test]
+    fn connection_limit_recovers_after_clear() {
+        let tracker = ConnectionTracker::with_config(TrackerConfig {
+            max_connections: 1,
+            ..TrackerConfig::default()
+        });
+        assert!(tracker.ingest(&parse(&udp_frame(40000, 53))).created);
+        tracker.clear();
+        let b = tracker.ingest(&parse(&udp_frame(40001, 53)));
+        assert!(b.created && !b.dropped, "clear() must reset the limit");
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -1390,24 +1390,46 @@ impl Default for TrafficHistory {
 }
 
 // ============================================================================
-// RTT Tracking Types (for latency measurement)
+// Connection Key
 // ============================================================================
 
-/// Key for tracking pending SYN packets
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// Compact identity of a flow: protocol plus local/remote socket addresses.
+///
+/// Used as the connection-table key (and for matching pending TCP SYNs in RTT
+/// tracking). `Copy` and fixed-size, so per-packet key construction, hashing,
+/// and map lookups involve no heap allocation. The `Display` form matches the
+/// historical string key format (`"TCP:1.2.3.4:80-TCP:5.6.7.8:443"`) so log
+/// output is unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ConnectionKey {
+    pub protocol: Protocol,
     pub local_addr: SocketAddr,
     pub remote_addr: SocketAddr,
 }
 
 impl ConnectionKey {
-    pub fn new(local_addr: SocketAddr, remote_addr: SocketAddr) -> Self {
+    pub fn new(protocol: Protocol, local_addr: SocketAddr, remote_addr: SocketAddr) -> Self {
         Self {
+            protocol,
             local_addr,
             remote_addr,
         }
     }
 }
+
+impl std::fmt::Display for ConnectionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}-{}:{}",
+            self.protocol, self.local_addr, self.protocol, self.remote_addr
+        )
+    }
+}
+
+// ============================================================================
+// RTT Tracking Types (for latency measurement)
+// ============================================================================
 
 /// Tracks pending SYN packets and recent RTT measurements
 #[derive(Debug)]
@@ -1603,6 +1625,11 @@ pub struct RateTracker {
     // Keep track of last byte counts for delta calculation
     last_bytes_sent: u64,
     last_bytes_received: u64,
+    // Running sums of the deltas currently held in `samples`, maintained on
+    // every push/pop. Keeps rate calculation O(1) instead of summing the
+    // whole window (up to `max_samples` entries) per refresh.
+    window_sent_total: u64,
+    window_received_total: u64,
 }
 
 impl RateTracker {
@@ -1620,6 +1647,8 @@ impl RateTracker {
             max_samples: 20_000,
             last_bytes_sent: 0,
             last_bytes_received: 0,
+            window_sent_total: 0,
+            window_received_total: 0,
         }
     }
 
@@ -1650,11 +1679,18 @@ impl RateTracker {
             delta_sent,
             delta_received,
         });
+        self.window_sent_total += delta_sent;
+        self.window_received_total += delta_received;
 
         // Lightweight overflow guard: drop oldest samples if we exceed the cap.
         // Full time-based pruning happens in prune() every ~1s.
         while samples.len() > self.max_samples {
-            samples.pop_front();
+            if let Some(old) = samples.pop_front() {
+                self.window_sent_total = self.window_sent_total.saturating_sub(old.delta_sent);
+                self.window_received_total = self
+                    .window_received_total
+                    .saturating_sub(old.delta_received);
+            }
         }
 
         // Update last values for next delta calculation
@@ -1667,19 +1703,41 @@ impl RateTracker {
     /// Called periodically (via `refresh_rates`) rather than per-packet.
     pub fn prune(&mut self) {
         let cutoff_time = self.last_update - self.window_duration;
+
+        // Fast path: nothing to prune. Checked through `&self.samples` so a
+        // no-op refresh never touches `Arc::make_mut` (which would deep-copy
+        // a shared buffer) or the pop loop.
+        let needs_prune = self.samples.len() > self.max_samples
+            || self
+                .samples
+                .front()
+                .is_some_and(|oldest| oldest.timestamp < cutoff_time);
+        if !needs_prune {
+            return;
+        }
+
         let samples = Arc::make_mut(&mut self.samples);
 
         while let Some(oldest) = samples.front() {
-            if oldest.timestamp < cutoff_time {
-                samples.pop_front();
-            } else {
+            if oldest.timestamp >= cutoff_time {
                 break;
+            }
+            if let Some(old) = samples.pop_front() {
+                self.window_sent_total = self.window_sent_total.saturating_sub(old.delta_sent);
+                self.window_received_total = self
+                    .window_received_total
+                    .saturating_sub(old.delta_received);
             }
         }
 
         // Limit total samples to prevent memory bloat
         while samples.len() > self.max_samples {
-            samples.pop_front();
+            if let Some(old) = samples.pop_front() {
+                self.window_sent_total = self.window_sent_total.saturating_sub(old.delta_sent);
+                self.window_received_total = self
+                    .window_received_total
+                    .saturating_sub(old.delta_received);
+            }
         }
     }
 
@@ -1695,19 +1753,18 @@ impl RateTracker {
 
     /// Get the incoming rate in bytes per second at a specific timestamp
     fn get_incoming_rate_bps_at(&self, now: Instant) -> f64 {
-        self.calculate_rate_from_deltas_at(now, |sample| sample.delta_received)
+        self.calculate_rate_from_deltas_at(now, self.window_received_total)
     }
 
     /// Get the outgoing rate in bytes per second at a specific timestamp
     fn get_outgoing_rate_bps_at(&self, now: Instant) -> f64 {
-        self.calculate_rate_from_deltas_at(now, |sample| sample.delta_sent)
+        self.calculate_rate_from_deltas_at(now, self.window_sent_total)
     }
 
-    /// Calculate rate using delta values for accurate sliding window calculation
-    fn calculate_rate_from_deltas_at<F>(&self, now: Instant, delta_getter: F) -> f64
-    where
-        F: Fn(&RateSample) -> u64,
-    {
+    /// Calculate rate from the running window total — O(1), no walk over the
+    /// sample buffer. `total_bytes` is the maintained sum of all deltas
+    /// currently in `samples` (each represents bytes transferred).
+    fn calculate_rate_from_deltas_at(&self, now: Instant, total_bytes: u64) -> f64 {
         if self.samples.is_empty() {
             return 0.0;
         }
@@ -1741,12 +1798,33 @@ impl RateTracker {
             return 0.0;
         }
 
-        // Sum ALL deltas in the window - each represents bytes transferred
-        let total_bytes: u64 = self.samples.iter().map(delta_getter).sum();
-
         // Simple sliding window average: total bytes over time span
         // No decay - just pure average like iftop's 10-second column
         total_bytes as f64 / time_span
+    }
+
+    /// Clone carrying the rate metadata but an empty sample buffer.
+    ///
+    /// A regular `clone()` shares the sample buffer via `Arc`, which forces
+    /// the next per-packet `update()` on the live tracker into an
+    /// `Arc::make_mut` deep copy of the whole window (up to `max_samples`
+    /// entries). Read-only consumers (UI snapshots, historic archives) never
+    /// look at raw samples — they read the cached `current_*_rate_bps`
+    /// fields on [`Connection`] — so they should use this instead and leave
+    /// the live tracker as the buffer's unique owner.
+    pub fn clone_without_samples(&self) -> Self {
+        Self {
+            samples: Arc::new(VecDeque::new()),
+            window_duration: self.window_duration,
+            last_update: self.last_update,
+            max_samples: self.max_samples,
+            last_bytes_sent: self.last_bytes_sent,
+            last_bytes_received: self.last_bytes_received,
+            // Zeroed alongside the empty buffer so the invariant
+            // `window totals == sum(samples)` holds for the copy.
+            window_sent_total: 0,
+            window_received_total: 0,
+        }
     }
 
     // Test-only methods for deterministic testing with controlled timestamps
@@ -1961,6 +2039,20 @@ impl Connection {
                 "{:?}:{}-{:?}:{}",
                 self.protocol, self.local_addr, self.protocol, self.remote_addr
             )
+        }
+    }
+
+    /// Cheap clone for read-only snapshots (UI, historic archive).
+    ///
+    /// Identical to `clone()` except the rate-tracker sample buffer is
+    /// dropped, so the live connection stays the unique owner of its
+    /// samples and the next per-packet rate update avoids a copy-on-write
+    /// deep copy. Consumers must read the cached `current_*_rate_bps`
+    /// fields rather than recompute rates from samples.
+    pub fn snapshot_clone(&self) -> Self {
+        Self {
+            rate_tracker: self.rate_tracker.clone_without_samples(),
+            ..self.clone()
         }
     }
 
@@ -2487,6 +2579,125 @@ mod tests {
         assert_eq!(tracker.get_incoming_rate_bps(), 0.0);
         assert_eq!(tracker.get_outgoing_rate_bps(), 0.0);
         // Test single update - need at least 2 samples for rate
+    }
+
+    #[test]
+    fn test_rate_tracker_clone_without_samples_detaches_buffer() {
+        let mut tracker = RateTracker::new();
+        let start = Instant::now();
+        for i in 0..10_u64 {
+            tracker.update_at_time(start + Duration::from_millis(i * 100), i * 1000, i * 500);
+        }
+
+        let detached = tracker.clone_without_samples();
+
+        // The detached copy has no samples but keeps the rate metadata.
+        assert!(detached.samples.is_empty());
+        assert_eq!(detached.last_bytes_sent, tracker.last_bytes_sent);
+        assert_eq!(detached.last_bytes_received, tracker.last_bytes_received);
+        assert_eq!(detached.window_duration, tracker.window_duration);
+
+        // The live tracker stays unique owner of its buffer, so the next
+        // per-packet update takes the in-place fast path (no CoW deep copy).
+        assert_eq!(Arc::strong_count(&tracker.samples), 1);
+    }
+
+    #[test]
+    fn test_connection_snapshot_clone_preserves_cached_fields() {
+        let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321);
+        let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
+        let mut conn = Connection::new(
+            Protocol::Tcp,
+            local,
+            remote,
+            ProtocolState::Tcp(TcpState::Established),
+        );
+        conn.bytes_sent = 1234;
+        conn.bytes_received = 5678;
+        conn.update_rates();
+        conn.current_incoming_rate_bps = 42.0;
+        conn.current_outgoing_rate_bps = 24.0;
+
+        let snap = conn.snapshot_clone();
+
+        assert_eq!(snap.bytes_sent, 1234);
+        assert_eq!(snap.bytes_received, 5678);
+        assert_eq!(snap.current_incoming_rate_bps, 42.0);
+        assert_eq!(snap.current_outgoing_rate_bps, 24.0);
+        assert_eq!(snap.local_addr, conn.local_addr);
+        assert_eq!(snap.remote_addr, conn.remote_addr);
+
+        // The snapshot must not share the sample buffer with the original.
+        assert_eq!(Arc::strong_count(&conn.rate_tracker.samples), 1);
+        assert!(snap.rate_tracker.samples.is_empty());
+    }
+
+    #[test]
+    fn test_rate_tracker_window_totals_match_brute_force_across_prunes() {
+        let window = Duration::from_millis(500);
+        let mut tracker = RateTracker::with_window_duration(window);
+        let start = Instant::now();
+
+        let mut bytes_sent = 0u64;
+        let mut bytes_recv = 0u64;
+        for i in 0..50u64 {
+            bytes_sent += 100 + i;
+            bytes_recv += 50 + i;
+            tracker.update_at_time(
+                start + Duration::from_millis(i * 40),
+                bytes_sent,
+                bytes_recv,
+            );
+            if i % 10 == 9 {
+                tracker.prune();
+            }
+        }
+        tracker.prune();
+
+        let brute_sent: u64 = tracker.samples.iter().map(|s| s.delta_sent).sum();
+        let brute_recv: u64 = tracker.samples.iter().map(|s| s.delta_received).sum();
+        assert_eq!(tracker.window_sent_total, brute_sent);
+        assert_eq!(tracker.window_received_total, brute_recv);
+    }
+
+    #[test]
+    fn test_rate_tracker_cap_eviction_keeps_totals_in_sync() {
+        let mut tracker = RateTracker::new();
+        tracker.max_samples = 8;
+        let start = Instant::now();
+
+        let mut sent = 0u64;
+        let mut recv = 0u64;
+        for i in 0..20u64 {
+            sent += 10 * (i + 1);
+            recv += 5 * (i + 1);
+            tracker.update_at_time(start + Duration::from_millis(i * 100), sent, recv);
+        }
+
+        assert!(tracker.samples.len() <= 8, "cap must be enforced");
+        let brute_sent: u64 = tracker.samples.iter().map(|s| s.delta_sent).sum();
+        let brute_recv: u64 = tracker.samples.iter().map(|s| s.delta_received).sum();
+        assert_eq!(tracker.window_sent_total, brute_sent);
+        assert_eq!(tracker.window_received_total, brute_recv);
+    }
+
+    #[test]
+    fn test_rate_tracker_prune_noop_avoids_cow() {
+        let mut tracker = RateTracker::new();
+        let start = Instant::now();
+        tracker.update_at_time(start, 100, 50);
+        tracker.update_at_time(start + Duration::from_millis(100), 200, 100);
+
+        // Share the buffer (as a full clone would), then prune with nothing
+        // prunable: the fast path must not deep-copy via Arc::make_mut.
+        let shared = tracker.clone();
+        tracker.prune();
+        assert_eq!(
+            Arc::strong_count(&tracker.samples),
+            2,
+            "no-op prune must not detach the shared buffer"
+        );
+        drop(shared);
     }
 
     #[test]
@@ -3211,11 +3422,12 @@ mod tests {
     fn test_rtt_tracker_record_syn() {
         let mut tracker = RttTracker::new();
         let key = ConnectionKey::new(
+            Protocol::Tcp,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 12345),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
         );
 
-        tracker.record_syn(key.clone());
+        tracker.record_syn(key);
         assert_eq!(tracker.pending_syns.len(), 1);
         assert!(tracker.pending_syns.contains_key(&key));
     }
@@ -3224,6 +3436,7 @@ mod tests {
     fn test_rtt_tracker_record_syn_ack_no_match() {
         let mut tracker = RttTracker::new();
         let key = ConnectionKey::new(
+            Protocol::Tcp,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 12345),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
         );
@@ -3240,14 +3453,14 @@ mod tests {
         let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
 
         // Record SYN (outgoing: local -> remote)
-        let syn_key = ConnectionKey::new(local, remote);
+        let syn_key = ConnectionKey::new(Protocol::Tcp, local, remote);
         tracker.record_syn(syn_key);
 
         // Simulate some delay
         std::thread::sleep(Duration::from_millis(10));
 
         // Record SYN-ACK (same key - parser normalizes to local,remote)
-        let syn_ack_key = ConnectionKey::new(local, remote);
+        let syn_ack_key = ConnectionKey::new(Protocol::Tcp, local, remote);
         let rtt = tracker.record_syn_ack(&syn_ack_key);
 
         assert!(rtt.is_some());
@@ -3266,8 +3479,8 @@ mod tests {
         // Record multiple RTT measurements
         for port in 12345..12348 {
             let local_with_port = SocketAddr::new(local.ip(), port);
-            let key = ConnectionKey::new(local_with_port, remote);
-            tracker.record_syn(key.clone());
+            let key = ConnectionKey::new(Protocol::Tcp, local_with_port, remote);
+            tracker.record_syn(key);
             std::thread::sleep(Duration::from_millis(5));
             tracker.record_syn_ack(&key);
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -421,6 +421,12 @@ pub struct App {
     /// Current connections snapshot for UI
     connections_snapshot: Arc<RwLock<Vec<Connection>>>,
 
+    /// Bumped by the snapshot thread after each snapshot write. Lets the UI
+    /// loop skip re-cloning and re-sorting an unchanged snapshot (the
+    /// snapshot refreshes every `refresh_interval` ms, the UI ticks every
+    /// 200ms — without this, most ticks redo identical work).
+    snapshot_generation: Arc<AtomicU64>,
+
     /// Whether to include historic connections in the snapshot
     show_historic: Arc<AtomicBool>,
 
@@ -558,6 +564,7 @@ impl App {
             should_stop: Arc::new(AtomicBool::new(false)),
             tracker: Arc::new(ConnectionTracker::new()),
             connections_snapshot: Arc::new(RwLock::new(Vec::new())),
+            snapshot_generation: Arc::new(AtomicU64::new(0)),
             show_historic: Arc::new(AtomicBool::new(false)),
             service_lookup: Arc::new(service_lookup),
             oui_lookup,
@@ -1031,6 +1038,11 @@ impl App {
                     // packet that panics a DPI parser cannot take down the
                     // whole pcap_rx thread and leave the monitor running
                     // blind.
+                    // One wall-clock read per batch instead of per packet.
+                    // Batches hold ≤100 packets and flush at least every
+                    // 100ms, so the timestamp skew is far below any
+                    // connection timeout or rate window.
+                    let batch_time = SystemTime::now();
                     let mut parsed_count = 0;
                     for packet_data in &batch {
                         let parse_result =
@@ -1042,6 +1054,7 @@ impl App {
                                 update_connection(
                                     &tracker,
                                     parsed,
+                                    batch_time,
                                     &stats,
                                     &json_log_path,
                                     dns_resolver.as_deref(),
@@ -1290,6 +1303,7 @@ impl App {
     /// Start snapshot provider thread for UI updates
     fn start_snapshot_provider(&self, tracker: Arc<ConnectionTracker>) -> Result<()> {
         let snapshot = Arc::clone(&self.connections_snapshot);
+        let snapshot_generation = Arc::clone(&self.snapshot_generation);
         let should_stop = Arc::clone(&self.should_stop);
         let stats = Arc::clone(&self.stats);
         let service_lookup = Arc::clone(&self.service_lookup);
@@ -1341,7 +1355,10 @@ impl App {
                         .connections()
                         .iter()
                         .filter_map(|entry| {
-                            let mut conn = entry.value().clone();
+                            // snapshot_clone: leave the live tracker as unique
+                            // owner of its rate samples, otherwise the next
+                            // per-packet update pays an Arc::make_mut deep copy.
+                            let mut conn = entry.value().snapshot_clone();
                             if enrich_and_filter(&mut conn, &service_lookup, filter_localhost)
                                 && conn.is_active()
                             {
@@ -1358,7 +1375,7 @@ impl App {
                             .historic()
                             .iter()
                             .filter_map(|entry| {
-                                let mut conn = entry.value().clone();
+                                let mut conn = entry.value().snapshot_clone();
                                 if enrich_and_filter(&mut conn, &service_lookup, filter_localhost) {
                                     Some(conn)
                                 } else {
@@ -1374,8 +1391,10 @@ impl App {
 
                     let filtered_count = snapshot_data.len();
 
-                    // Update snapshot
+                    // Update snapshot and publish the new generation so the
+                    // UI loop knows there is fresh data to re-sort.
                     *snapshot.write().unwrap() = snapshot_data;
+                    snapshot_generation.fetch_add(1, Ordering::Release);
 
                     // Update stats (only count active connections)
                     stats
@@ -1415,13 +1434,21 @@ impl App {
 
                     // Refresh rates for connections that may still have non-zero rates.
                     // Skip connections idle >30s whose rates are already zero.
+                    let sweep_start = Instant::now();
+                    let mut refreshed = 0usize;
                     for mut entry in tracker.connections().iter_mut() {
                         let conn = entry.value_mut();
                         let idle_secs = conn.last_activity.elapsed().unwrap_or_default().as_secs();
                         if idle_secs <= 30 || conn.has_nonzero_rates() {
                             conn.refresh_rates();
+                            refreshed += 1;
                         }
                     }
+                    debug!(
+                        "State refresh sweep took {:?} for {} refreshed connections",
+                        sweep_start.elapsed(),
+                        refreshed
+                    );
 
                     // Run every 1 second to balance responsiveness with performance
                     thread::sleep(Duration::from_secs(1));
@@ -1700,39 +1727,40 @@ impl App {
         self.get_filtered_connections("")
     }
 
+    /// Generation of the current snapshot; bumped on every snapshot rebuild.
+    /// The UI loop compares this against the last generation it consumed to
+    /// skip re-cloning and re-sorting unchanged data.
+    pub fn snapshot_generation(&self) -> u64 {
+        self.snapshot_generation.load(Ordering::Acquire)
+    }
+
     /// Get filtered connections for UI display
     pub fn get_filtered_connections(&self, filter_query: &str) -> Vec<Connection> {
-        let connections = self.connections_snapshot.read().unwrap().clone();
-
         // Filter out DNS PTR queries/responses when reverse DNS is enabled
         let hide_ptr_lookups = self.dns_resolver.is_some() && !self.config.show_ptr_lookups;
-
-        let connections: Vec<Connection> = if hide_ptr_lookups {
-            connections
-                .into_iter()
-                .filter(|conn| {
-                    // Hide DNS PTR queries/responses (used for reverse DNS lookups)
-                    if let Some(ref dpi) = conn.dpi_info
-                        && let ApplicationProtocol::Dns(ref dns_info) = dpi.application
-                        && dns_info.query_type == Some(DnsQueryType::PTR)
-                    {
-                        return false;
-                    }
-                    true
-                })
-                .collect()
+        let filter = if filter_query.trim().is_empty() {
+            None
         } else {
-            connections
+            Some(ConnectionFilter::parse(filter_query))
         };
 
-        if filter_query.trim().is_empty() {
-            return connections;
-        }
-
-        let filter = ConnectionFilter::parse(filter_query);
-        connections
-            .into_iter()
-            .filter(|conn| filter.matches(conn))
+        // Filter by reference under the read guard and clone only the
+        // matches, instead of cloning the whole snapshot first.
+        let snapshot = self.connections_snapshot.read().unwrap();
+        snapshot
+            .iter()
+            .filter(|conn| {
+                // Hide DNS PTR queries/responses (used for reverse DNS lookups)
+                if hide_ptr_lookups
+                    && let Some(ref dpi) = conn.dpi_info
+                    && let ApplicationProtocol::Dns(ref dns_info) = dpi.application
+                    && dns_info.query_type == Some(DnsQueryType::PTR)
+                {
+                    return false;
+                }
+                filter.as_ref().is_none_or(|f| f.matches(conn))
+            })
+            .cloned()
             .collect()
     }
 
@@ -1884,6 +1912,7 @@ impl App {
     /// Seed the UI snapshot directly. Tests only.
     #[cfg(test)]
     pub(crate) fn set_connections_snapshot_for_test(&self, snapshot: Vec<Connection>) {
+        self.snapshot_generation.fetch_add(1, Ordering::Release);
         *self.connections_snapshot.write().unwrap() = snapshot;
     }
 
@@ -1991,11 +2020,12 @@ impl App {
 fn update_connection(
     tracker: &ConnectionTracker,
     parsed: ParsedPacket,
+    now: SystemTime,
     stats: &AppStats,
     json_log_path: &Option<String>,
     dns_resolver: Option<&DnsResolver>,
 ) {
-    let outcome = tracker.ingest(&parsed);
+    let outcome = tracker.ingest_at(&parsed, now);
 
     // Fold TCP anomaly counts into the global statistics.
     if outcome.retransmits > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -540,12 +540,24 @@ where
     let mut stats = app.get_stats();
     let mut needs_data_refresh = true;
     let mut needs_regroup = false;
+    let mut last_seen_generation = u64::MAX; // force the first refresh
 
     loop {
         // Refresh connection data only when needed:
-        // - On timer tick (every 200ms) for live updates
+        // - On timer tick (every 200ms), but only if the snapshot actually
+        //   changed since we last consumed it (it rebuilds every
+        //   refresh-interval ms, so most ticks would re-clone and re-sort
+        //   identical data)
         // - When an event changes filter, sort, or data source
-        if needs_data_refresh || last_tick.elapsed() >= tick_rate {
+        let tick_elapsed = last_tick.elapsed() >= tick_rate;
+        let snapshot_generation = app.snapshot_generation();
+        if tick_elapsed {
+            // Keep counters (packets processed/dropped, etc.) live on every
+            // tick even when the connection list is unchanged.
+            stats = app.get_stats();
+            last_tick = std::time::Instant::now();
+        }
+        if needs_data_refresh || (tick_elapsed && snapshot_generation != last_seen_generation) {
             connections = if ui_state.filter_query.is_empty() && !ui_state.filter_mode {
                 app.get_connections()
             } else {
@@ -561,8 +573,7 @@ where
             } else {
                 Vec::new()
             };
-            stats = app.get_stats();
-            last_tick = std::time::Instant::now();
+            last_seen_generation = snapshot_generation;
             needs_data_refresh = false;
             needs_regroup = false;
         } else if needs_regroup {


### PR DESCRIPTION
Replace the per-packet String connection key with a compact Copy struct (FxHash-keyed tracker maps), stamp ingest once per batch, and turn the connection-limit check into an atomic load. Detach UI/historic snapshot clones from the rate-sample buffer so per-packet updates never pay an `Arc::make_mut` deep copy, compute window rates from running totals, and skip UI re-sorts when the snapshot generation is unchanged.

Steady-state ingest drops from ~179ns to ~109ns per packet; post-snapshot rate updates go from O(samples) (up to ~12.5us) to ~150ns flat. Adds a tracker_ingest bench and fixes the rate_tracker bench to keep the snapshot alive during the timed update.

Bumps the library crates to 0.2.0 (breaking: `ParsedPacket.connection_key` field removed, `IngestOutcome.key` and tracker map types changed).

Closes #379.