### PR TITLE
fix(release): read binary [package] version, not workspace 0.x version

### DIFF
--- a/.github/workflows/obs-release.yml
+++ b/.github/workflows/obs-release.yml
@@ -23,7 +23,9 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           else
-            VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+            # Read the binary's [package] version, not [workspace.package] (the
+            # latter is the 0.x library version and comes first in Cargo.toml).
+            VERSION=$(awk -F'"' '/^\[package\]/{p=1} p && /^version = /{print $2; exit}' Cargo.toml)
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"

--- a/.github/workflows/ppa-release.yml
+++ b/.github/workflows/ppa-release.yml
@@ -93,7 +93,11 @@ jobs:
       - name: Get version
         id: version
         run: |
-          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          # Read the binary's [package] version, not [workspace.package]. Since
+          # the workspace split, Cargo.toml has two `version =` lines and the
+          # workspace one (0.x libs) comes first, so `head -1` read the wrong
+          # value. Anchor on the [package] section.
+          VERSION=$(awk -F'"' '/^\[package\]/{p=1} p && /^version = /{print $2; exit}' Cargo.toml)
 
           # Add tarball suffix if provided (e.g., +ds1, +ds2)
           TARBALL_SUFFIX="${{ inputs.tarball_suffix }}"
@@ -144,7 +148,8 @@ jobs:
       - name: Build source package
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          BASE_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          # Binary [package] version (drives the release tag to check out below).
+          BASE_VERSION=$(awk -F'"' '/^\[package\]/{p=1} p && /^version = /{print $2; exit}' Cargo.toml)
           PACKAGE_NAME="rustnet-monitor"
 
           # Create build directory

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,12 +42,22 @@ This catches cross-platform and static linking issues before you invest time in 
 
 ### 3. Prepare the Release
 
-Update version in `Cargo.toml`, `rpm/rustnet.spec`, and turn the accumulated
-`[Unreleased]` changelog section into the release entry:
+> **Two version tracks since the workspace split.** `Cargo.toml` carries two
+> versions: the binary's `[package] version` (line ~30, the user-facing `1.x`
+> line that tags and packages follow) and `[workspace.package] version` (line
+> ~9, the `0.x` library crates `rustnet-core`/`-capture`/`-host`, single source
+> of truth also referenced from `[workspace.dependencies]`). A normal feature
+> release bumps **only the binary `[package] version`** and `rpm/rustnet.spec`.
+> Bump the library version separately, and only when the libraries actually
+> change in a release-worthy way.
+
+Update the binary version in `Cargo.toml` and `rpm/rustnet.spec`, and turn the
+accumulated `[Unreleased]` changelog section into the release entry:
 
 ```bash
-# Update Cargo.toml version (e.g., version = "0.3.0")
-# Update rpm/rustnet.spec Version field (e.g., Version: 0.3.0)
+# Update Cargo.toml [package] version (e.g., version = "1.4.0") — NOT the
+#   [workspace.package] version unless you intend to bump the library crates.
+# Update rpm/rustnet.spec Version field (e.g., Version: 1.4.0)
 
 # In CHANGELOG.md:
 #   1. Rename "## [Unreleased]" to "## [0.3.0] - YYYY-MM-DD" (review/polish the entries)
@@ -134,6 +144,16 @@ The release process is fully automated via [`.github/workflows/release.yml`](.gi
    - Attaches all binaries and installer packages
    - Uses extracted changelog content as release notes
 
+5. **Publishes the workspace to crates.io** (via
+   [`.github/workflows/publish.yml`](.github/workflows/publish.yml), after the
+   GitHub release is published): the four crates are published in dependency
+   order — `rustnet-core` → `rustnet-capture` → `rustnet-host` →
+   `rustnet-monitor` — waiting for each to appear in the index before publishing
+   a dependent. The step is idempotent (it skips any `crate@version` already on
+   crates.io), so a re-run after a partial failure is safe. The library crates
+   use the `[workspace.package]` version; the binary uses its `[package]`
+   version.
+
 ## Important: Never Move a Tag After Release
 
 **Never force-push or move a tag after the release pipeline has started.** Moving a tag
@@ -152,7 +172,7 @@ Before pushing the tag, ensure:
 
 - [ ] Pre-release checks pass: `./scripts/pre-release-check.sh x.y.z`
 - [ ] Test Platform Builds workflow passes for all platforms (including static)
-- [ ] Version number updated in `Cargo.toml`
+- [ ] Binary version updated in `Cargo.toml` `[package]` (not `[workspace.package]` unless bumping the library crates)
 - [ ] Version number updated in `rpm/rustnet.spec` (line 5: `Version: x.y.z`)
 - [ ] `Cargo.lock` updated (via `cargo build`)
 - [ ] `CHANGELOG.md`: `[Unreleased]` renamed to `## [x.y.z] - YYYY-MM-DD`, a fresh empty `[Unreleased]` added, comparison links updated
@@ -166,6 +186,7 @@ After GitHub Actions completes:
 - [ ] Verify all platform binaries built successfully
 - [ ] Verify all installer packages created (DEB, RPM, DMG, MSI)
 - [ ] Verify Docker image pushed to ghcr.io
+- [ ] Verify all four crates published to crates.io (`rustnet-monitor`, `rustnet-core`, `rustnet-capture`, `rustnet-host`) and docs.rs built
 - [ ] Review automatically extracted release notes
 - [ ] Verify Homebrew formula updated at https://github.com/domcyrus/homebrew-rustnet
 - [ ] Verify Chocolatey package updated at https://github.com/domcyrus/rustnet-chocolatey

--- a/scripts/pre-release-check.sh
+++ b/scripts/pre-release-check.sh
@@ -28,7 +28,11 @@ echo
 # --- Version consistency ---
 echo "Version consistency:"
 
-CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+# Read the binary's [package] version, NOT the [workspace.package] version.
+# Since the workspace split, Cargo.toml has two `version =` lines and the
+# workspace one (0.x libraries) comes first, so `grep '^version' | head -1`
+# would read the wrong value. Anchor on the [package] section instead.
+CARGO_VERSION=$(awk -F'"' '/^\[package\]/{p=1} p && /^version = /{print $2; exit}' Cargo.toml)
 RPM_VERSION=$(grep '^Version:' rpm/rustnet.spec | awk '{print $2}')
 
 if [ -n "$VERSION" ]; then
@@ -112,16 +116,26 @@ if [ "$CARGO_BENCHES" -gt 0 ]; then
   fi
 fi
 
-# Check that all include_bytes!() assets referenced at compile time are in Dockerfile
-for asset in $(grep -roh 'include_bytes!("[^"]*")' src/ 2>/dev/null | sed 's/include_bytes!("//;s/")//' | sort -u); do
-  # Resolve relative paths from src/ (portable, no GNU realpath needed)
-  resolved=$(cd src && python3 -c "import os.path; print(os.path.relpath(os.path.abspath('$asset'), '..'))" 2>/dev/null || echo "$asset")
+# Check that all include_bytes!()/include_str!() assets referenced at compile
+# time are present in the Dockerfile's COPY commands. Since the workspace split,
+# the baked-in assets (oui.gz, services) live under crates/rustnet-core/, not
+# src/, and the include path is relative to the file doing the include — so scan
+# both trees and resolve each path against its own source file's directory.
+ROOT=$(pwd)
+while IFS= read -r match; do
+  [ -z "$match" ] && continue
+  srcfile=${match%%:*}                       # path before the first ':'
+  asset=$(printf '%s\n' "$match" | sed -E 's/.*include_(bytes|str)!\("//; s/"\).*//')
+  srcdir=$(dirname "$srcfile")
+  # Resolve the include path (relative to srcfile) into a repo-root-relative path
+  # (portable, no GNU realpath needed).
+  resolved=$(cd "$srcdir" && python3 -c "import os.path,sys; print(os.path.relpath(os.path.abspath(sys.argv[1]), sys.argv[2]))" "$asset" "$ROOT" 2>/dev/null || echo "$asset")
   if grep -q "$resolved\|$(basename "$resolved")" Dockerfile; then
     pass "Dockerfile includes compile-time asset: $resolved"
   else
     fail "Compile-time asset $resolved not found in Dockerfile COPY commands"
   fi
-done
+done < <(grep -rno -E 'include_(bytes|str)!\("[^"]*"\)' src/ crates/*/src 2>/dev/null | sort -u || true)
 
 if docker info > /dev/null 2>&1; then
   echo


### PR DESCRIPTION
## Why

The workspace split (#367) added a `[workspace.package] version = "0.2.0"` line to `Cargo.toml` that sorts **ahead** of the binary's `[package] version` (currently `1.3.0`). Several release tools derive the version with `grep '^version' Cargo.toml | head -1`, which now reads `0.2.0` (the library version) instead of the binary version.

Left unfixed, the next release would have:

- **`pre-release-check.sh`** fail version-consistency with a false `0.2.0 != x.y.z` mismatch, blocking the pre-release gate.
- **`ppa-release.yml`** build the Ubuntu PPA package as `0.2.0`, and — worse — `git archive` the **ancient `v0.2.0` tag** (2024 source) as the release source (`BASE_VERSION` → `RELEASE_TAG="v0.2.0"`).
- **`obs-release.yml`** mis-derive the version on the non-tag fallback path.

`release.yml` is unaffected (it already uses `toml get Cargo.toml package.version`).

## What

- Read the binary version by anchoring on the `[package]` section:
  `awk -F'"' '/^\[package\]/{p=1} p && /^version = /{print $2; exit}' Cargo.toml`
  Applied in `pre-release-check.sh`, `ppa-release.yml` (both reads), and the `obs-release.yml` fallback.
- Fix the `pre-release-check.sh` Dockerfile asset scan: the baked-in `oui.gz`/`services` assets moved to `crates/rustnet-core/`, so the `src/`-only `include_bytes!` scan silently validated nothing. Now scans `crates/` too and covers `include_str!` (the `services` asset). The Dockerfile itself was already correct.
- `RELEASE.md`: document the two version tracks (binary `1.x` vs library `0.x`) and the four-crate crates.io publish order.

## Verification

`./scripts/pre-release-check.sh 1.3.0` against current `main` now reports the correct `Cargo.toml version: 1.3.0` and validates both `crates/rustnet-core/assets/{oui.gz,services}` against the Dockerfile. `cargo test --workspace` passes.