### PR TITLE
chore(release): prepare v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-This release redesigns the TUI around a calmer visual hierarchy. Many of the ideas
+## [1.4.0] - 2026-06-16
+
+This release redesigns the TUI around a calmer visual hierarchy and, under the hood,
+splits RustNet into a Cargo workspace of reusable library crates. Many of the TUI ideas
 came from a detailed UI review by [@joshka](https://github.com/joshka) (Ratatui
 maintainer) on our showcase submission
 ([ratatui/ratatui-website#1118](https://github.com/ratatui/ratatui-website/pull/1118)) —
@@ -16,24 +19,41 @@ thanks for the thoughtful feedback!
 ### Added
 - **Theme Presets**: New `--theme` flag. The default `muted` preset keeps a single
   cyan accent and reserves color for signals (state changes, staleness, live
-  bandwidth) and addresses; `--theme classic` restores the previous full-color palette
+  bandwidth) and addresses; `--theme classic` restores the previous full-color palette (#377)
 - **System Sidebar Toggle**: The System panel now has a fixed width and can be
-  hidden with the `i` key (auto-hidden on narrow terminals)
+  hidden with the `i` key (auto-hidden on narrow terminals) (#377)
 - **Details Continuity Strip**: The Details tab opens with a mini connection table
   of the selected row and its neighbors; `j`/`k` flips through them without leaving
-  the tab, following the grouped order when process grouping is enabled
+  the tab, following the grouped order when process grouping is enabled (#377)
+- **Direct-Jump Tab Shortcuts**: Jump straight to a tab with keys `1`-`5`, with
+  bracket cycle aliases (#318, thanks @obchain)
+- **Connection List Scrollbar**: A scrollbar appears on the connection list when it
+  overflows the viewport (#365)
+- **FTP Deep Packet Inspection**: Detect the FTP control channel and extract command
+  and response metadata (#266, thanks @0xghost42)
+- **DNS / mDNS / LLMNR Response IPs**: Populate `response_ips` from A/AAAA answer
+  records and extend the extraction to mDNS and LLMNR responses (#319, #333, #341, thanks @0xghost42)
+- **Log Identity Banner**: Emit a program identity banner and the module target on
+  every log line for easier diagnostics (#320, thanks @0xghost42)
+- **Landlock v6 IPC Scoping** (Linux): Best-effort Landlock that scopes abstract-socket
+  and signal IPC on kernels that support it, falling back gracefully on older ABIs (#363)
+- **`no_new_privs` Always Set + cargo-deny**: Always set `no_new_privs` at startup, and
+  adopt `cargo-deny` for supply-chain and license auditing in CI (#382)
+- **openSUSE OBS Release Pipeline**: Automated openSUSE Build Service releases (#356)
 
 ### Changed
 - **Stable Column Layout**: Column widths depend only on the terminal width — they
   no longer shift while scrolling. Narrow terminals hide low-priority columns
   instead of truncating cells; wide terminals distribute the spare width so the
-  table spans the full screen with the bandwidth column flush right
+  table spans the full screen with the bandwidth column flush right (#377)
 - **Merged Proto/App Column**: The Protocol column is merged into Application
   ("TCP·HTTPS"), and the status-dot column is gone — staleness now lives entirely
-  in the row styling
+  in the row styling (#377)
 - **Custom Tab Bar and Borderless Sections**: Numbered tab bar with an accent
   underline, a single-line filter prompt, and section headers in place of the
-  border-box-around-everything look
+  border-box-around-everything look (#377)
+- **Dependencies**: Routine dependency and GitHub Actions updates across the cycle
+  (Dependabot, ~18 PRs)
 
 ### Fixed
 - **Process attribution for short-lived and multithreaded processes** (Linux):
@@ -42,7 +62,59 @@ thanks for the thoughtful feedback!
   no longer show up as "Socket Thread" or "isc-net-0000"; PID-to-name
   resolution reads `/proc/<pid>/comm` on demand instead of waiting for the
   periodic scan; and new connections are enriched on a fast 250ms tick, so
-  process names appear almost immediately instead of after up to 2 seconds
+  process names appear almost immediately instead of after up to 2 seconds (#376)
+- **DLT_NULL Link Layer**: Strip the 4-byte address-family header before parsing
+  DLT_NULL/loopback captures (#394, thanks @0xghost42)
+- **Terminal Restore on Panic**: Restore the terminal via a chained panic hook so a
+  panic no longer leaves the terminal in raw mode (#364)
+- **Scrollbar Thumb**: The scrollbar thumb now reaches the bottom at max scroll (#366)
+- **Landlock `/sys` Access**: Allow read access to `/sys` so interface statistics work
+  under the Landlock sandbox (#370)
+- **Filter Mode Backspace**: Handle raw backspace characters in filter mode (#335, thanks @iccccccccccccc)
+- **eBPF Error Surfacing**: Classify libbpf errors and surface them in the TUI (#255, #258)
+- **Native Builds**: Skip cross-compile library paths on native builds (#259)
+- **RPM Packaging**: Own the directories and hicolor icon dirs the package creates, and
+  require `libcap-progs` on openSUSE so the `%post` `setcap` runs (#357, #358, #359, #360)
+
+### Performance
+- **Per-Packet Allocations**: Cut per-packet allocations and snapshot copy-on-write
+  copies on the hot path (#380)
+- **Core Types**: Add `Protocol::as_str()` and drop per-row/per-filter `to_string`
+  allocations (#392, thanks @obchain)
+- **Connection Table**: Borrow the process name in `process_text` instead of cloning (#390, thanks @obchain)
+- **Sparklines / Parsers**: Single-allocation sparkline getters, fewer redundant
+  collects in the HTTP and SSH parsers, and removed redundant clones in the render path
+  and sandbox init (#339, #345, #355, thanks @obchain)
+
+### Internal
+- **Cargo Workspace Split**: RustNet is now a four-crate workspace — `rustnet-core`
+  (packet parsing, protocol/DPI types, link-layer, connection merging, DNS/GeoIP/OUI
+  lookups), `rustnet-capture` (libpcap/Npcap capture backend), `rustnet-host`
+  (per-connection process attribution), and the `rustnet-monitor` binary. The three
+  libraries are now published to crates.io alongside the binary (#367)
+
+### Documentation
+- **Simplified Chinese**: Added a Simplified Chinese README translation and translated
+  the rest of the docs, plus zh-CN openSUSE Tumbleweed install instructions
+  (#263 thanks @whtis, #277 thanks @luojiyin1987, #361)
+- **Install / Packaging Docs**: Nix and NixOS instructions and nixpkgs/NixOS-module
+  notes, Homebrew core formula pointer, Repology packaging overview, a Mermaid
+  architecture diagram, and a PR template with tightened contributor guidelines
+  (#264, #270, #281, #285, #286, #311, #332, #369)
+- **Ubuntu 26.04 (Resolute) PPA**: Added the Resolute PPA build (#254, #256)
+
+### Contributors
+
+Special thanks to the contributors in this release:
+- [@0xghost42](https://github.com/0xghost42) — FTP DPI, DNS/mDNS/LLMNR response-IP
+  extraction, the log identity banner, the DLT_NULL fix, and many DPI/eBPF refactors
+  (#266, #278, #279, #289, #290, #307, #309, #319, #320, #333, #341, #394)
+- [@obchain](https://github.com/obchain) — performance and allocation cleanups across
+  the DPI parsers, render path, and core types, plus direct-jump tab shortcuts
+  (#292, #294, #296, #301, #303, #317, #318, #327, #339, #345, #355, #390, #392)
+- [@iccccccccccccc](https://github.com/iccccccccccccc) — raw backspace handling in filter mode (#335)
+- [@whtis](https://github.com/whtis) (HaiTao Wu) — Simplified Chinese README translation (#263)
+- [@luojiyin1987](https://github.com/luojiyin1987) (luo jiyin) — Simplified Chinese documentation translation (#277)
 
 ## [1.3.0] - 2026-05-05
 
@@ -502,7 +574,8 @@ Special thanks to the external contributors in this release:
 - Configurable refresh intervals and filtering options
 - Optional logging with multiple log levels
 
-[Unreleased]: https://github.com/domcyrus/rustnet/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/domcyrus/rustnet/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/domcyrus/rustnet/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/domcyrus/rustnet/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/domcyrus/rustnet/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/domcyrus/rustnet/compare/v1.0.0...v1.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "rustnet-monitor"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 
 [package]
 name = "rustnet-monitor"
-version = "1.3.0"
+version = "1.4.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -2,7 +2,7 @@
 
 Name:    rustnet
 # renovate: datasource=github-releases depName=domcyrus/rustnet extractVersion=true
-Version: 1.3.0
+Version: 1.4.0
 Release: 1%{?dist}
 Summary: Per-process network monitoring TUI with deep packet inspection
 License: Apache-2.0


### PR DESCRIPTION
Release prep for **v1.4.0**. Stacked on #395 (now merged), so this diff is just the version bump + changelog.

## Changes
- **Binary → 1.4.0**: `Cargo.toml` `[package]`, `rpm/rustnet.spec`, `Cargo.lock`. The library crates (`rustnet-core`/`-capture`/`-host`) stay at **0.2.0** — this release is their first crates.io publish.
- **CHANGELOG**: turned `[Unreleased]` into the `[1.4.0]` entry. The previous draft only covered the TUI redesign + one fix; this fills in everything that actually landed this cycle:
  - **Workspace split** into four crates (#367) — the three libraries are now published to crates.io.
  - FTP DPI (#266), DNS/mDNS/LLMNR response IPs (#319/#333/#341), log identity banner (#320), Landlock v6 IPC scoping (#363), `no_new_privs` + cargo-deny (#382), openSUSE OBS pipeline (#356), connection-list scrollbar (#365), direct-jump tab shortcuts (#318).
  - Fixes: DLT_NULL header (#394), panic terminal restore (#364), Landlock `/sys` (#370), filter backspace (#335), eBPF error surfacing (#255/#258), RPM packaging (#357–#360).
  - Performance: per-packet allocations + CoW snapshots (#380), `Protocol::as_str()` (#392), `process_text` borrow (#390), parser/sparkline allocs (#339/#345/#355).
  - i18n + install docs.
- **Contributors** section crediting this cycle's five new contributors: @0xghost42, @obchain, @iccccccccccccc, @whtis, @luojiyin1987 (plus @joshka's UI review).

## Verification
`./scripts/pre-release-check.sh 1.4.0` passes clean: version consistency, changelog entry + link, `[Unreleased]` empty, fmt/clippy/test, both `crates/rustnet-core/assets/{oui.gz,services}` validated against the Dockerfile, Docker image builds, and `Cargo.lock` up to date.

## After merge
1. Run **Test Platform Builds** on `main` (all platforms).
2. `cargo publish --dry-run` for all four crates; confirm `CRATES_IO_TOKEN` has publish-new scope (the three libraries are brand new on crates.io).
3. Tag `v1.4.0` → the release pipeline builds all platforms, publishes the four crates in dependency order, Docker, PPA/OBS/COPR/AUR/Homebrew/Chocolatey.

> Note: the `[1.4.0]` date is set to 2026-06-16 — update it if the tag is cut on a different day.