### PR TITLE
fix(release): pass -p rustnet-monitor to cargo wix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -761,9 +761,11 @@ jobs:
           Get-Command candle.exe -ErrorAction SilentlyContinue | Select-Object Source
           Get-Command light.exe -ErrorAction SilentlyContinue | Select-Object Source
 
-          # Create MSI package
+          # Create MSI package. `-p rustnet-monitor` is required since the
+          # workspace split: cargo-wix refuses to guess the package in a
+          # workspace ("Workspace detected. Please pass a package name.").
           Write-Host "Creating MSI package..."
-          cargo wix --no-build --nocapture --target ${{ matrix.target }}
+          cargo wix -p rustnet-monitor --no-build --nocapture --target ${{ matrix.target }}
 
           # Find and rename the MSI file
           $msiFiles = Get-ChildItem -Path "target\wix" -Filter "*.msi" -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Why

The v1.4.0 release pipeline failed at **Windows MSI packaging**:

```
Error[2] (Generic): Workspace detected. Please pass a package name.
→ No MSI file found in target\wix\
```

Since the workspace split (#367), `cargo wix` can no longer infer the single package, so the `package-windows` job fails (32-bit failed; 64-bit was fail-fast-cancelled). That failure gated **all** downstream publish jobs (crates.io, Docker, COPR, PPA, OBS, Homebrew, Chocolatey, AUR), so none ran.

This isn't caught by PR CI or `pre-release-check` because MSI packaging only runs in the release workflow.

## Fix

Scope the command to the binary crate:

```diff
-cargo wix --no-build --nocapture --target ${{ matrix.target }}
+cargo wix -p rustnet-monitor --no-build --nocapture --target ${{ matrix.target }}
```

The `[package.metadata.wix]` config lives in the root (`rustnet-monitor`) package, so `-p rustnet-monitor` selects the right package and metadata. The other packaging commands (`cargo deb`, `cargo generate-rpm`, `cargo build`) already default to the root package and succeeded.

## After merge

Per the agreed recovery: delete the partial v1.4.0 release + tag and re-tag v1.4.0 at the fixed `main` so the whole pipeline re-runs cleanly. (Nothing downstream consumed v1.4.0 — crates.io was skipped, not published — so this is a clean recreate.)