### PR TITLE
Harden file writes against symlink and PATH attacks

### DIFF
--- a/crates/rustnet-core/src/network/parser.rs
+++ b/crates/rustnet-core/src/network/parser.rs
@@ -135,14 +135,8 @@ impl PacketParser {
     /// Create a new packet parser with default configuration
     /// Automatically detects local IP addresses from network interfaces
     pub fn new() -> Self {
-        let mut local_ips = std::collections::HashSet::new();
-        for iface in pnet_datalink::interfaces() {
-            for ip_network in iface.ips {
-                local_ips.insert(ip_network.ip());
-            }
-        }
         Self {
-            local_ips,
+            local_ips: collect_local_ips(),
             config: ParserConfig::default(),
             linktype: None,
             oui_lookup: None,
@@ -150,14 +144,8 @@ impl PacketParser {
     }
 
     pub fn with_config(config: ParserConfig) -> Self {
-        let mut local_ips = std::collections::HashSet::new();
-        for iface in pnet_datalink::interfaces() {
-            for ip_network in iface.ips {
-                local_ips.insert(ip_network.ip());
-            }
-        }
         Self {
-            local_ips,
+            local_ips: collect_local_ips(),
             config,
             linktype: None,
             oui_lookup: None,
@@ -671,6 +659,18 @@ impl PacketParser {
             }
         }
     }
+}
+
+fn collect_local_ips() -> std::collections::HashSet<IpAddr> {
+    let mut local_ips = std::collections::HashSet::new();
+    for iface in pnet_datalink::interfaces() {
+        for ip_network in iface.ips {
+            local_ips.insert(ip_network.ip());
+        }
+    }
+    local_ips.insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    local_ips.insert(IpAddr::V6(Ipv6Addr::LOCALHOST));
+    local_ips
 }
 
 #[cfg(test)]

--- a/crates/rustnet-host/src/freebsd/process.rs
+++ b/crates/rustnet-host/src/freebsd/process.rs
@@ -8,6 +8,8 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+const SOCKSTAT_PATH: &str = "/usr/bin/sockstat";
+
 pub struct FreeBSDProcessLookup {
     // Cache: ConnectionKey -> (pid, process_name)
     cache: RwLock<ProcessCache>,
@@ -73,7 +75,7 @@ impl FreeBSDProcessLookup {
         // -4: IPv4, -6: IPv6, -c: connected sockets, -l: listening sockets, -n: numeric
         let ipv6_flag = proto.ends_with('6');
 
-        let output = Command::new("sockstat")
+        let output = Command::new(SOCKSTAT_PATH)
             .arg(if ipv6_flag { "-6" } else { "-4" })
             .arg("-n") // numeric output
             .arg("-P")

--- a/crates/rustnet-host/src/macos/process.rs
+++ b/crates/rustnet-host/src/macos/process.rs
@@ -9,6 +9,8 @@ use std::net::SocketAddr;
 use std::process::Command;
 use std::sync::RwLock;
 
+const LSOF_PATH: &str = "/usr/sbin/lsof";
+
 pub struct MacOSProcessLookup {
     cache: RwLock<HashMap<ConnectionKey, (u32, String)>>,
 }
@@ -26,7 +28,7 @@ impl MacOSProcessLookup {
         info!("Running lsof to get network connections");
 
         // Run lsof to get network connections
-        let output = Command::new("lsof")
+        let output = Command::new(LSOF_PATH)
             .args(["-i", "-n", "-P", "+c", "0"])
             .output()?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -149,15 +149,66 @@ const MAX_PACKET_QUEUE: usize = 10_000;
 
 /// Open or create a file for appending with restrictive permissions (0o600 on Unix).
 ///
-/// Ensures log files containing connection metadata are not world-readable.
+/// Ensures log files containing connection metadata are not world-readable, and
+/// refuses to follow symlinks (`O_NOFOLLOW`) so a planted symlink can't redirect
+/// the privileged write elsewhere.
+///
+/// On failure this surfaces a single warning (rather than aborting the running
+/// monitor): the callers run in the per-event hot path, so silently dropping the
+/// error — as the previous `if let Ok(..)` did — would disable connection logging
+/// with no indication. We warn once to avoid per-event log spam.
 fn open_log_file(path: &str) -> std::io::Result<File> {
-    let file = OpenOptions::new().create(true).append(true).open(path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+    let result = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .custom_flags(libc::O_NOFOLLOW)
+                .mode(0o600)
+                .open(path)
+        }
+
+        #[cfg(not(unix))]
+        {
+            OpenOptions::new().create(true).append(true).open(path)
+        }
+    };
+
+    if let Err(ref e) = result {
+        static WARNED: AtomicBool = AtomicBool::new(false);
+        if !WARNED.swap(true, Ordering::Relaxed) {
+            // The log file is opened with O_NOFOLLOW, so a symlinked path is
+            // refused. Depending on privilege and `fs.protected_symlinks`, that
+            // surfaces as ELOOP (raw O_NOFOLLOW) or EACCES (kernel symlink
+            // protection denies first), so we mention symlinks for both rather
+            // than keying on a single errno.
+            #[cfg(unix)]
+            let symlink_hint = matches!(
+                e.raw_os_error(),
+                Some(code) if code == libc::ELOOP || code == libc::EACCES
+            );
+            #[cfg(not(unix))]
+            let symlink_hint = false;
+
+            if symlink_hint {
+                warn!(
+                    "Refusing to write log to '{}': {} (path may be a symlink; \
+                     symlinks are rejected via O_NOFOLLOW). Connection logging is disabled.",
+                    path, e
+                );
+            } else {
+                warn!(
+                    "Failed to open log file '{}': {}. Connection logging is disabled.",
+                    path, e
+                );
+            }
+        }
     }
-    Ok(file)
+
+    result
 }
 
 /// Helper function to log connection events as JSON
@@ -2080,5 +2131,86 @@ impl Drop for App {
         self.stop();
         // Give threads time to stop gracefully
         thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod open_log_file_tests {
+    use super::open_log_file;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+
+    /// Per-test scratch directory under the system temp dir, removed on drop.
+    /// Avoids a `tempfile` dependency; uniqueness comes from the pid + the
+    /// caller-supplied tag (test names are unique).
+    struct ScratchDir(PathBuf);
+
+    impl ScratchDir {
+        fn new(tag: &str) -> Self {
+            let dir =
+                std::env::temp_dir().join(format!("rustnet-log-test-{}-{}", std::process::id(), tag));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            ScratchDir(dir)
+        }
+
+        fn path(&self, name: &str) -> PathBuf {
+            self.0.join(name)
+        }
+    }
+
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn creates_file_with_0600_permissions() {
+        let dir = ScratchDir::new("perms");
+        let path = dir.path("events.log");
+
+        let file = open_log_file(path.to_str().unwrap()).expect("fresh open should succeed");
+        let mode = file.metadata().unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "new log file must be created mode 0o600");
+    }
+
+    #[test]
+    fn appends_rather_than_truncates() {
+        let dir = ScratchDir::new("append");
+        let path = dir.path("events.log");
+        let p = path.to_str().unwrap();
+
+        writeln!(open_log_file(p).unwrap(), "line1").unwrap();
+        writeln!(open_log_file(p).unwrap(), "line2").unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("line1"), "first write must be preserved");
+        assert!(contents.contains("line2"), "second write must be appended");
+    }
+
+    #[test]
+    fn refuses_symlinked_path() {
+        let dir = ScratchDir::new("symlink");
+        let target = dir.path("real_target.log");
+        let link = dir.path("evil.log");
+        std::fs::write(&target, b"").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let err = open_log_file(link.to_str().unwrap())
+            .expect_err("O_NOFOLLOW must refuse a symlinked path");
+
+        // As the symlink's owner (the test process), `fs.protected_symlinks`
+        // does not intervene, so this is the raw O_NOFOLLOW rejection: ELOOP.
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ELOOP),
+            "expected ELOOP from O_NOFOLLOW, got: {err}"
+        );
+
+        // The privileged write must not have been redirected through the link.
+        let target_contents = std::fs::read_to_string(&target).unwrap();
+        assert!(target_contents.is_empty(), "symlink target must be untouched");
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2148,8 +2148,11 @@ mod open_log_file_tests {
 
     impl ScratchDir {
         fn new(tag: &str) -> Self {
-            let dir =
-                std::env::temp_dir().join(format!("rustnet-log-test-{}-{}", std::process::id(), tag));
+            let dir = std::env::temp_dir().join(format!(
+                "rustnet-log-test-{}-{}",
+                std::process::id(),
+                tag
+            ));
             let _ = std::fs::remove_dir_all(&dir);
             std::fs::create_dir_all(&dir).unwrap();
             ScratchDir(dir)
@@ -2211,6 +2214,9 @@ mod open_log_file_tests {
 
         // The privileged write must not have been redirected through the link.
         let target_contents = std::fs::read_to_string(&target).unwrap();
-        assert!(target_contents.is_empty(), "symlink target must be untouched");
+        assert!(
+            target_contents.is_empty(),
+            "symlink target must be untouched"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,31 @@ fn main() -> Result<()> {
         info!("Using GeoIP City database: {}", city_path);
     }
 
+    // Pre-create the PCAP export file and its sidecar JSONL (needed for Landlock
+    // permissions). This must be done BEFORE the sandbox is applied so the files
+    // exist when adding rules: Landlock requires an open FD to scope a rule to a
+    // file, so a not-yet-existing path falls back to granting write on the whole
+    // parent directory. Pre-creating keeps the write rule file-scoped. The PCAP
+    // writer later reopens the path with truncation, so a zero-byte file is fine.
+    //
+    // Done before terminal setup: pre-creation can fail hard (see below), and we
+    // want the error to print to a normal terminal rather than into the TUI
+    // alt-screen (which would also leave the terminal in raw mode).
+    if let Some(ref pcap_path) = config.pcap_export_file {
+        let jsonl_path = format!("{}.connections.jsonl", pcap_path);
+        for (label, path) in [("PCAP", pcap_path.as_str()), ("sidecar JSONL", &jsonl_path)] {
+            // Fail hard rather than continue: if we can't safely create the file
+            // (e.g. the path is a symlink, rejected by O_NOFOLLOW), aborting now
+            // is the only way the protection is meaningful. The PCAP itself is
+            // later written by libpcap's pcap_dump_open, which does NOT honor
+            // O_NOFOLLOW, so a warn-and-continue here would let libpcap follow an
+            // attacker-controlled symlink and write the capture there anyway.
+            precreate_private_file(path).map_err(|e| {
+                anyhow::anyhow!("Failed to pre-create {} file '{}': {}", label, path, e)
+            })?;
+        }
+    }
+
     // Set up terminal
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = ui::setup_terminal(backend)?;
@@ -134,32 +159,6 @@ fn main() -> Result<()> {
     let mut app = app::App::new(config.clone())?;
     let process_ready_rx = app.start()?;
     info!("Application started");
-
-    // Pre-create the PCAP export file and its sidecar JSONL (needed for Landlock
-    // permissions). This must be done BEFORE the sandbox is applied so the files
-    // exist when adding rules: Landlock requires an open FD to scope a rule to a
-    // file, so a not-yet-existing path falls back to granting write on the whole
-    // parent directory. Pre-creating keeps the write rule file-scoped. The PCAP
-    // writer later reopens the path with truncation, so a zero-byte file is fine.
-    if let Some(ref pcap_path) = config.pcap_export_file {
-        let jsonl_path = format!("{}.connections.jsonl", pcap_path);
-        for (label, path) in [("PCAP", pcap_path.as_str()), ("sidecar JSONL", &jsonl_path)] {
-            match std::fs::File::create(path) {
-                Ok(_f) => {
-                    #[cfg(unix)]
-                    {
-                        use std::os::unix::fs::PermissionsExt;
-                        if let Err(e) = _f.set_permissions(std::fs::Permissions::from_mode(0o600)) {
-                            warn!("Failed to set {} file permissions: {}", label, e);
-                        }
-                    }
-                }
-                Err(e) => {
-                    warn!("Failed to pre-create {} file: {}", label, e);
-                }
-            }
-        }
-    }
 
     // Wait for process detection (including eBPF loading) to complete before
     // applying the sandbox, which drops CAP_BPF and CAP_PERFMON.
@@ -524,6 +523,26 @@ fn setup_logging(level: LevelFilter) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn precreate_private_file(path: &str) -> io::Result<fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .mode(0o600)
+            .open(path)
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::File::create(path)
+    }
 }
 
 /// Sort connections based on the specified column and direction


### PR DESCRIPTION
Hardens privileged file writes and external command lookups.

- Create log/pcap files atomically with `O_NOFOLLOW` + `0o600` (no create-then-chmod race, no symlink follow)
- Fail hard on unsafe pcap pre-create, moved before TUI setup so the error is visible and the terminal isn't left in raw mode
- Warn once when a log open is refused, instead of silently dropping logs
- Use absolute paths for `lsof` and `sockstat` to avoid `$PATH` hijacking

Adds unit tests for `open_log_file` (0o600, append, symlink rejection).