### PR TITLE
security: stop auto-granting CAP_SYS_ADMIN eBPF fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -212,7 +212,7 @@ RustNet uses platform-specific APIs to associate network connections with proces
   - Multi-threaded applications show internal thread names
 - **Capability requirements:**
   - Modern Linux (5.8+): `CAP_NET_RAW` (packet capture), `CAP_BPF`, `CAP_PERFMON` (eBPF)
-  - Legacy Linux (pre-5.8): `CAP_NET_RAW` (packet capture), `CAP_SYS_ADMIN` (eBPF)
+  - Legacy Linux (pre-5.8): eBPF requires broad `CAP_SYS_ADMIN`; RustNet packages do not grant it automatically and fall back to procfs instead
   - Note: CAP_NET_ADMIN is NOT required (uses read-only, non-promiscuous packet capture)
 
 **Fallback Behavior:**

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -212,7 +212,7 @@ RustNet 使用平台特定的 API 将网络连接与进程关联：
   - 多线程应用显示内部线程名
 - **Linux capabilities 需求：**
   - 现代 Linux（5.8+）：`CAP_NET_RAW`（包捕获）、`CAP_BPF`、`CAP_PERFMON`（eBPF）
-  - 旧版 Linux（pre-5.8）：`CAP_NET_RAW`（包捕获）、`CAP_SYS_ADMIN`（eBPF）
+	  - 旧版 Linux（pre-5.8）：eBPF 需要宽泛的 `CAP_SYS_ADMIN`；RustNet 安装包不会自动授予它，并会回退到 procfs
   - 注意：不需要 CAP_NET_ADMIN（使用只读、非混杂包捕获）
 
 **回退行为：**

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,9 +95,9 @@ LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"
 # bounding set and can't be granted to a non-root user via file capabilities.
 # Enable eBPF by running as root with the extra caps (modern kernels 5.8+):
 #   docker run --user root --cap-add=BPF --cap-add=PERFMON rustnet
-# Older kernels use CAP_SYS_ADMIN instead of BPF+PERFMON:
-#   docker run --user root --cap-add=SYS_ADMIN rustnet
-# Without those, rustnet falls back to /proc-based process detection.
+# Legacy kernels require broad CAP_SYS_ADMIN for eBPF. RustNet does not
+# recommend granting it by default; without eBPF caps, rustnet falls back to
+# /proc-based process detection.
 # CAP_NET_ADMIN is NOT required (read-only, non-promiscuous capture).
 USER rustnet
 ENTRYPOINT ["rustnet"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -728,8 +728,8 @@ cargo build --release
 sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' ./target/release/rustnet
 ./target/release/rustnet
 
-# Legacy Linux (older kernels without CAP_BPF) - use CAP_SYS_ADMIN as fallback:
-sudo setcap 'cap_net_raw,cap_sys_admin+eip' ./target/release/rustnet
+# Packet capture only - eBPF falls back to procfs:
+sudo setcap 'cap_net_raw+eip' ./target/release/rustnet
 ./target/release/rustnet
 
 # Check TUI Statistics panel - should show "Process Detection: eBPF + procfs"
@@ -740,14 +740,14 @@ sudo setcap 'cap_net_raw,cap_sys_admin+eip' ./target/release/rustnet
 **Base capability (always required):**
 - `CAP_NET_RAW` - Raw socket access for read-only packet capture (non-promiscuous mode)
 
-**eBPF-specific capabilities (choose based on kernel version):**
-
-**Modern Linux (5.8+):**
+**eBPF-specific capabilities (Linux 5.8+):**
 - `CAP_BPF` - BPF program loading and map operations
 - `CAP_PERFMON` - Performance monitoring and tracing operations
 
 **Legacy Linux (pre-5.8):**
-- `CAP_SYS_ADMIN` - Required for BPF operations on older kernels without CAP_BPF support
+Older kernels require broad `CAP_SYS_ADMIN` for eBPF operations. RustNet does
+not recommend or automatically grant it. Use `CAP_NET_RAW` only and let process
+attribution fall back to procfs unless you explicitly accept the extra risk.
 
 **Note:** CAP_NET_ADMIN is NOT required. RustNet uses read-only packet capture without promiscuous mode.
 
@@ -803,8 +803,8 @@ getcap ~/.cargo/bin/rustnet
 # For system-wide installations:
 getcap $(which rustnet)
 
-# Modern (5.8+): Should show cap_net_raw,cap_bpf,cap_perfmon+eip
-# Legacy: Should show cap_net_raw,cap_sys_admin+eip
+# eBPF enabled: Should show cap_net_raw,cap_bpf,cap_perfmon+eip
+# Packet capture only: Should show cap_net_raw=eip
 
 # Test without sudo
 rustnet --help

--- a/INSTALL.zh-CN.md
+++ b/INSTALL.zh-CN.md
@@ -716,8 +716,8 @@ cargo build --release
 sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' ./target/release/rustnet
 ./target/release/rustnet
 
-# 旧版 Linux（无 CAP_BPF 的旧内核）- 使用 CAP_SYS_ADMIN 作为回退：
-sudo setcap 'cap_net_raw,cap_sys_admin+eip' ./target/release/rustnet
+# 仅包捕获（eBPF 会回退到 procfs）
+sudo setcap 'cap_net_raw+eip' ./target/release/rustnet
 ./target/release/rustnet
 
 # 检查 TUI 统计面板 - 应显示 "Process Detection: eBPF + procfs"
@@ -735,7 +735,8 @@ sudo setcap 'cap_net_raw,cap_sys_admin+eip' ./target/release/rustnet
 - `CAP_PERFMON` —— 性能监控和追踪操作
 
 **旧版 Linux（pre-5.8）：**
-- `CAP_SYS_ADMIN` —— 在没有 CAP_BPF 支持的老内核上进行 BPF 操作所需
+- eBPF 操作需要宽泛的 `CAP_SYS_ADMIN`。不建议默认授予它；请使用
+  `CAP_NET_RAW` 进行包捕获，并让 RustNet 回退到 procfs 进程检测，除非你明确接受该风险。
 
 **注意：** 不需要 CAP_NET_ADMIN。RustNet 使用不带混杂模式的只读数据包捕获。
 
@@ -792,7 +793,7 @@ getcap ~/.cargo/bin/rustnet
 getcap $(which rustnet)
 
 # 现代（5.8+）：应显示 cap_net_raw,cap_bpf,cap_perfmon+eip
-# 旧版：应显示 cap_net_raw,cap_sys_admin+eip
+# 如果 eBPF capability 不可用：应显示 cap_net_raw+eip
 
 # 不使用 sudo 测试
 rustnet --help

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -191,14 +191,16 @@ Instead of running as root, grant only the required capabilities:
 # Modern Linux (5.8+): packet capture + eBPF
 sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' $(which rustnet)
 
-# Legacy Linux (pre-5.8): packet capture + eBPF
-sudo setcap 'cap_net_raw,cap_sys_admin+eip' $(which rustnet)
-
 # Packet capture only (no eBPF process detection)
 sudo setcap cap_net_raw+eip $(which rustnet)
 ```
 
-After sandbox application, `CAP_NET_RAW` is dropped - the process retains only the minimum privileges needed.
+Legacy pre-5.8 kernels required `CAP_SYS_ADMIN` for eBPF operations. RustNet
+does not grant this broad capability automatically; use `CAP_NET_RAW` only and
+let eBPF fall back to procfs unless you explicitly accept the extra risk.
+
+After sandbox application, `CAP_NET_RAW` and eBPF-loading capabilities are
+dropped - the process retains only the minimum privileges needed.
 
 ## Read-Only Operation
 

--- a/SECURITY.zh-CN.md
+++ b/SECURITY.zh-CN.md
@@ -31,14 +31,14 @@ RustNet 处理不受信任的网络数据，因此纵深防御至关重要。本
 | 文件系统 | 5.13+ | 仅 `/proc` 可读（用于进程识别） |
 | 网络 | 6.4+ | 禁止 TCP bind/connect（RustNet 为被动模式） |
 | Linux capabilities | 任意 | pcap socket 打开后丢弃 `CAP_NET_RAW` |
-| Linux capabilities | 任意 | eBPF 程序加载后丢弃 `CAP_BPF`、`CAP_PERFMON` |
+| Linux capabilities | 任意 | eBPF 程序加载后丢弃 `CAP_BPF`、`CAP_PERFMON`、`CAP_SYS_ADMIN` |
 | 特权 | 3.5+ | `PR_SET_NO_NEW_PRIVS` 由 RustNet 自身设置——始终生效，即使使用 `--no-sandbox`——防止通过 setuid 二进制文件提升特权 |
 
 ### 工作原理
 
 1. **初始化阶段**：RustNet 加载 eBPF 程序、打开包捕获句柄、创建日志文件
 2. **特权锁定**：设置 `PR_SET_NO_NEW_PRIVS`（即使禁用沙箱也会应用）
-3. **Linux capabilities 剥离**：移除 `CAP_NET_RAW`、`CAP_BPF` 和 `CAP_PERFMON`
+3. **Linux capabilities 剥离**：移除 `CAP_NET_RAW`、`CAP_BPF`、`CAP_PERFMON` 和 `CAP_SYS_ADMIN`
 4. **Landlock**：限制文件系统和网络访问
 
 ### 安全收益
@@ -191,14 +191,14 @@ RustNet 需要特权访问来捕获网络数据包：
 # 现代 Linux（5.8+）：包捕获 + eBPF
 sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' $(which rustnet)
 
-# 旧版 Linux（pre-5.8）：包捕获 + eBPF
-sudo setcap 'cap_net_raw,cap_sys_admin+eip' $(which rustnet)
-
-# 仅包捕获（无 eBPF 进程检测）
+# 仅包捕获（eBPF 会回退到 procfs）
 sudo setcap cap_net_raw+eip $(which rustnet)
 ```
 
-沙箱应用后，`CAP_NET_RAW` 会被丢弃——进程仅保留所需的最小特权。
+旧版 pre-5.8 内核需要宽泛的 `CAP_SYS_ADMIN` 才能执行 eBPF 操作。RustNet
+的安装包不会自动授予该 capability；除非你明确接受该风险，否则请只授予
+`CAP_NET_RAW` 并使用 procfs 回退。沙箱应用后，`CAP_NET_RAW` 和 eBPF
+加载相关 capabilities 会被丢弃——进程仅保留所需的最小特权。
 
 ## 只读操作<a id="read-only-operation"></a>
 
@@ -237,7 +237,7 @@ RustNet 完全在本地运行：
 
 使用 eBPF 进行增强型进程检测时（Linux 默认）：
 
-- 需要额外的 Linux capabilities（`CAP_BPF`、`CAP_PERFMON`）
+- 现代内核需要额外的 Linux capabilities（`CAP_BPF`、`CAP_PERFMON`）
 - eBPF 程序在加载前由内核验证
 - 仅限只读操作（不修改数据包）
 - 如果 eBPF 失败，自动回退到 procfs

--- a/crates/rustnet-host/src/lib.rs
+++ b/crates/rustnet-host/src/lib.rs
@@ -42,7 +42,7 @@ pub enum DegradationReason {
     /// Missing CAP_PERFMON capability (Linux 5.8+)
     #[cfg(target_os = "linux")]
     MissingCapPerfmon,
-    /// Missing both CAP_BPF and CAP_PERFMON (and no CAP_SYS_ADMIN fallback)
+    /// Missing both CAP_BPF and CAP_PERFMON
     #[cfg(target_os = "linux")]
     MissingBpfCapabilities,
     /// eBPF feature not compiled in

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,15 +5,14 @@ set -e
 
 case "$1" in
     configure)
-        # Set capabilities for packet capture and eBPF support without requiring root/sudo
-        # This allows rustnet to run as a normal user with enhanced eBPF process detection
+        # Set narrow capabilities for packet capture and eBPF support without requiring root/sudo.
+        # If eBPF capabilities are unavailable, fall back to packet capture only;
+        # rustnet will degrade to procfs process detection rather than auto-grant CAP_SYS_ADMIN.
         if command -v setcap >/dev/null 2>&1; then
-            # Try modern capabilities first (Linux 5.8+)
             # CAP_NET_RAW: read-only packet capture (non-promiscuous mode)
             # CAP_BPF, CAP_PERFMON: eBPF support for enhanced process tracking
             setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet 2>/dev/null || \
-                # Fallback for older kernels without CAP_BPF/CAP_PERFMON
-                setcap 'cap_net_raw,cap_sys_admin+eip' /usr/bin/rustnet || true
+                setcap 'cap_net_raw+eip' /usr/bin/rustnet || true
         fi
 
         cat <<EOF
@@ -28,18 +27,18 @@ NETWORK PACKET CAPTURE PERMISSIONS:
   To verify permissions are set correctly:
     getcap /usr/bin/rustnet
 
-  Expected output (modern Linux 5.8+):
+  Expected output (Linux 5.8+ with eBPF support):
     /usr/bin/rustnet cap_net_raw,cap_bpf,cap_perfmon=eip
 
-  Or for legacy kernels (pre-5.8):
-    /usr/bin/rustnet cap_net_raw,cap_sys_admin=eip
+  Or, if eBPF capabilities were unavailable during install:
+    /usr/bin/rustnet cap_net_raw=eip
 
   If capabilities are not set, you can manually set them:
     # For modern Linux 5.8+ with eBPF support
     sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet
 
-    # Or for legacy kernels without CAP_BPF support
-    sudo setcap 'cap_net_raw,cap_sys_admin+eip' /usr/bin/rustnet
+    # Packet capture only (eBPF falls back to procfs)
+    sudo setcap 'cap_net_raw+eip' /usr/bin/rustnet
 
   Note: RustNet uses read-only packet capture (no promiscuous mode).
         CAP_NET_ADMIN is NOT required.

--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -104,15 +104,14 @@ install -Dpm 0644 resources/packaging/linux/rustnet.desktop -t %{buildroot}%{_da
 %{_datadir}/applications/rustnet.desktop
 
 %post
-# Set capabilities for packet capture and eBPF support without requiring root/sudo
-# This allows rustnet to run as a normal user with enhanced eBPF process detection
+# Set narrow capabilities for packet capture and eBPF support without requiring root/sudo.
+# If eBPF capabilities are unavailable, fall back to packet capture only;
+# rustnet will degrade to procfs process detection rather than auto-grant CAP_SYS_ADMIN.
 if command -v setcap >/dev/null 2>&1; then
-    # Try modern capabilities first (Linux 5.8+)
     # CAP_NET_RAW: read-only packet capture (non-promiscuous mode)
     # CAP_BPF, CAP_PERFMON: eBPF support for enhanced process tracking
     setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' %{_bindir}/rustnet 2>/dev/null || \
-        # Fallback for older kernels without CAP_BPF/CAP_PERFMON
-        setcap 'cap_net_raw,cap_sys_admin+eip' %{_bindir}/rustnet || :
+        setcap 'cap_net_raw+eip' %{_bindir}/rustnet || :
 fi
 
 %posttrans
@@ -128,18 +127,18 @@ NETWORK PACKET CAPTURE PERMISSIONS:
   To verify permissions are set correctly:
     getcap %{_bindir}/rustnet
 
-  Expected output (modern Linux 5.8+):
+  Expected output (Linux 5.8+ with eBPF support):
     %{_bindir}/rustnet cap_net_raw,cap_bpf,cap_perfmon=eip
 
-  Or for legacy kernels (pre-5.8):
-    %{_bindir}/rustnet cap_net_raw,cap_sys_admin=eip
+  Or, if eBPF capabilities were unavailable during install:
+    %{_bindir}/rustnet cap_net_raw=eip
 
   If capabilities are not set, you can manually set them:
     # For modern Linux 5.8+ with eBPF support
     sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' %{_bindir}/rustnet
 
-    # Or for legacy kernels without CAP_BPF support
-    sudo setcap 'cap_net_raw,cap_sys_admin+eip' %{_bindir}/rustnet
+    # Packet capture only (eBPF falls back to procfs)
+    sudo setcap 'cap_net_raw+eip' %{_bindir}/rustnet
 
   Note: RustNet uses read-only packet capture (no promiscuous mode).
         CAP_NET_ADMIN is NOT required.

--- a/src/network/privileges.rs
+++ b/src/network/privileges.rs
@@ -163,7 +163,6 @@ fn check_linux_privileges() -> Result<PrivilegeStatus> {
     let mut instructions = vec![
         "Run with sudo: sudo rustnet".to_string(),
         "Set capabilities (modern Linux 5.8+, with eBPF): sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' $(which rustnet)".to_string(),
-        "Set capabilities (legacy/older kernels, with eBPF): sudo setcap 'cap_net_raw,cap_sys_admin+eip' $(which rustnet)".to_string(),
         "Set capabilities (packet capture only, no eBPF): sudo setcap 'cap_net_raw+eip' $(which rustnet)".to_string(),
     ];
 


### PR DESCRIPTION
Drop the `cap_sys_admin` setcap fallback from package install (`debian/postinst`, `rpm/rustnet.spec`) and docs.

On pre-5.8 kernels eBPF process detection now degrades to procfs instead of auto-granting the broad capability. Properly-installed systems never receive `CAP_SYS_ADMIN`, removing its blast radius entirely.

Scope is limited to not *granting* the capability. Runtime per-thread cap-dropping was intentionally left out: with Linux per-thread caps it's fragile (asymmetric across capture/enrichment threads, ignores `--no-sandbox`, can break bpf() lookups on legacy kernels), and is unnecessary once the cap is never granted.