### PR TITLE
chore(deny): ignore quick-xml build-time DoS advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,16 @@ all-features = true
 # Vulnerabilities and unsound advisories are errors by default (v2 semantics).
 # Deny yanked crates so a withdrawn dependency pinned in Cargo.lock is caught.
 yanked = "deny"
+ignore = [
+    # quick-xml < 0.41.0 unbounded-allocation DoS when parsing untrusted XML.
+    # Only reachable via wayland-scanner (a build-time proc-macro) parsing the
+    # trusted, crate-bundled Wayland protocol XML files to generate code; it
+    # never parses attacker-controlled input at runtime. No upgrade path yet:
+    # wayland-scanner 0.31.8 pins quick-xml ^0.38.3. Revisit when wayland-scanner
+    # relaxes the requirement so quick-xml can move to >=0.41.0.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]
 
 [licenses]
 # Workspace license is Apache-2.0. Allow-list derived from the locked


### PR DESCRIPTION
## Problem

`cargo deny check advisories` fails on two new advisories against `quick-xml 0.38.4`:

- **RUSTSEC-2026-0194** — quick-xml < 0.41.0 unbounded allocation on duplicate-attribute scan
- **RUSTSEC-2026-0195** — quick-xml < 0.41.0 unbounded `NamespaceResolver` allocation

Both are fixed in `quick-xml >= 0.41.0`. This blocks the `build` job on every PR (e.g. #440) and the daily advisories-only run in `security.yml`.

## Why ignore rather than upgrade

`quick-xml` is reached **only** through `wayland-scanner`, a build-time proc-macro:

```
quick-xml v0.38.4
└── wayland-scanner v0.31.8 (proc-macro)
    └── … → wl-clipboard-rs → arboard → rustnet-monitor
```

`wayland-scanner` parses the trusted, crate-bundled Wayland protocol XML at build time to generate code — it never parses attacker-controlled input at runtime. Both advisories describe a runtime DoS from parsing untrusted XML, so neither is exploitable here.

There is no upgrade path yet: `wayland-scanner 0.31.8` pins `quick-xml ^0.38.3`, which excludes `0.41.0` (`cargo update -p quick-xml --precise 0.41.0` fails to resolve).

## Change

Add an `[advisories.ignore]` entry for both IDs in `deny.toml` with a justification and a note to revisit once `wayland-scanner` relaxes its requirement.

Verified locally: `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`.