### PR TITLE
ci: retry artifact uploads on transient failures

### DIFF
--- a/.github/actions/upload-artifact-retry/action.yml
+++ b/.github/actions/upload-artifact-retry/action.yml
@@ -1,0 +1,47 @@
+name: 'Upload artifact with retry'
+description: 'Upload an artifact, retrying once on transient failures (e.g. CreateArtifact network timeouts)'
+
+inputs:
+  name:
+    description: 'Artifact name'
+    required: true
+  path:
+    description: 'File(s), directory or wildcard pattern to upload'
+    required: true
+  if-no-files-found:
+    description: 'Behavior if no files are found at the provided path (warn/error/ignore)'
+    required: false
+    default: 'warn'
+  retention-days:
+    description: 'Days after which the artifact expires (0 = repository default)'
+    required: false
+    default: '0'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload artifact (attempt 1)
+      id: attempt1
+      continue-on-error: true
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        retention-days: ${{ inputs.retention-days }}
+
+    - name: Wait before retry
+      if: steps.attempt1.outcome == 'failure'
+      shell: bash
+      run: sleep 30
+
+    - name: Upload artifact (attempt 2)
+      if: steps.attempt1.outcome == 'failure'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        retention-days: ${{ inputs.retention-days }}
+        # First attempt may have partially created the artifact before failing
+        overwrite: true

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -99,7 +99,7 @@ jobs:
       # For test builds: upload raw binary
       - name: Upload binary artifact
         if: ${{ !inputs.create-archives }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: ./.github/actions/upload-artifact-retry
         with:
           name: rustnet-${{ matrix.build }}
           path: target/${{ matrix.target }}/release/rustnet${{ contains(matrix.os, 'windows') && '.exe' || '' }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload release archive
         if: ${{ inputs.create-archives }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: ./.github/actions/upload-artifact-retry
         with:
           name: build-${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -318,7 +318,7 @@ jobs:
       - name: Upload binary artifact
         if: ${{ !inputs.create-archives }}
         continue-on-error: ${{ matrix.arch != 'x86_64' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: ./.github/actions/upload-artifact-retry
         with:
           name: rustnet-linux-static-${{ matrix.arch }}
           path: ${{ (matrix.arch == 'armv7-android' && 'target/armv7-unknown-linux-musleabihf/release/rustnet') || (matrix.arch == 'x86-android' && 'target/i686-unknown-linux-musl/release/rustnet') || 'target/release/rustnet' }}
@@ -345,7 +345,7 @@ jobs:
         # JS actions don't work in Alpine containers on ARM runners;
         # release.yml has dedicated upload-arm-static/upload-android-static jobs as fallback
         continue-on-error: ${{ contains(matrix.arch, 'aarch64') }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: ./.github/actions/upload-artifact-retry
         with:
           name: build-${{ matrix.target }}
           path: rustnet-${{ inputs.version }}-${{ matrix.target }}.tar.gz

--- a/.github/workflows/ppa-release.yml
+++ b/.github/workflows/ppa-release.yml
@@ -222,7 +222,7 @@ jobs:
           dput ${{ env.PPA }} ${CHANGES_FILE}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: ./.github/actions/upload-artifact-retry
         with:
           name: ppa-source-${{ matrix.ubuntu_release }}
           path: |


### PR DESCRIPTION
Artifact uploads occasionally fail with transient network errors (e.g. `Failed to CreateArtifact: ETIMEDOUT` on #448), discarding an otherwise successful build.

This adds a local composite action `upload-artifact-retry` that wraps the pinned `actions/upload-artifact@v7`: on failure it waits 30s and retries once with `overwrite: true`. Genuine errors (e.g. missing files) still fail the job after the second attempt.

All five upload sites in `build-platforms.yml` and `ppa-release.yml` now use it. Existing `continue-on-error` fallbacks for the Alpine/ARM jobs are unchanged.