### PR TITLE
feat(kubernetes): add pod/container attribution to PCAPNG comments and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - **Smart connection lifecycle**: Protocol-aware timeouts with white → yellow → red staleness indicators. Toggle `t` to keep historic (closed) connections visible for forensics.
 - **Vim/fzf-style filtering**: `port:`, `src:`, `dst:`, `sni:`, `process:`, `state:`, `proto:`, plus regex via `/(?i)pattern/`.
 - **GeoIP enrichment**: Country lookups via local MaxMind GeoLite2. No network calls.
+- **Kubernetes attribution** (optional `kubernetes` feature): connections mapped to their pod, namespace, and container, shown in the details pane, JSON/PCAPNG exports, and the `pod:`, `ns:`, `container:` filters. Enabled in the official Docker image; see [USAGE.md](USAGE.md#--kubernetes-mode-optional-feature).
 - **Cross-platform**: Linux, macOS, Windows, FreeBSD.
 
 ## Why RustNet?

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - **Smart connection lifecycle**: Protocol-aware timeouts with white → yellow → red staleness indicators. Toggle `t` to keep historic (closed) connections visible for forensics.
 - **Vim/fzf-style filtering**: `port:`, `src:`, `dst:`, `sni:`, `process:`, `state:`, `proto:`, plus regex via `/(?i)pattern/`.
 - **GeoIP enrichment**: Country lookups via local MaxMind GeoLite2. No network calls.
-- **Kubernetes attribution** (optional `kubernetes` feature): connections mapped to their pod, namespace, and container, shown in the details pane, JSON/PCAPNG exports, and the `pod:`, `ns:`, `container:` filters. Enabled in the official Docker image; see [USAGE.md](USAGE.md#--kubernetes-mode-optional-feature).
+- **Kubernetes attribution** (optional `kubernetes` feature): connections mapped to their pod, namespace, and container, shown in the details pane, JSON/PCAPNG exports, and the `pod:`, `ns:`, `container:` filters. Enabled in the official Docker image; on a cluster, use the [kubectl-rustnet](https://github.com/domcyrus/kubectl-rustnet) plugin to run it as an ephemeral debug pod. See [USAGE.md](USAGE.md#--kubernetes-mode-optional-feature).
 - **Cross-platform**: Linux, macOS, Windows, FreeBSD.
 
 ## Why RustNet?

--- a/USAGE.md
+++ b/USAGE.md
@@ -107,6 +107,8 @@ Options:
   -V, --version                          Print version
 ```
 
+Builds compiled with the optional `kubernetes` feature (including the official Docker image) additionally expose `--kubernetes <MODE>`. See [`--kubernetes`](#--kubernetes-mode-optional-feature) below.
+
 ### Option Details
 
 #### `-i, --interface <INTERFACE>`
@@ -269,6 +271,33 @@ Enable logging with the specified level. Logging is **disabled by default**.
 
 Log files are created in the `logs/` directory with timestamp: `rustnet_YYYY-MM-DD_HH-MM-SS.log`
 
+#### `--kubernetes <MODE>` (optional feature)
+
+Attribute connections to their owning Kubernetes pod and container. This flag only exists in builds compiled with the `kubernetes` cargo feature: the official Docker image (`ghcr.io/domcyrus/rustnet`) ships with it enabled, while native installs (cargo, Homebrew, deb/rpm) leave it off.
+
+**Modes:**
+
+- `auto` (default): Enable attribution only when RustNet itself is running inside a pod
+- `on`: Always enable (e.g. when running directly on a node)
+- `off`: Disable attribution
+
+When active, RustNet maps each connection's PID to its pod UID and container ID via cgroups (`/proc/<pid>/cgroup`) and resolves human-readable pod and container names from the kubelet log directories (`/var/log/containers`, `/var/log/pods`). This is runtime-agnostic and needs no CRI socket or kubelet credentials. Pod-owned sockets are attributed even when RustNet runs with `hostNetwork: true`, because the per-PID socket tables are network-namespace aware.
+
+Attribution is surfaced in:
+
+- The **Details tab**, as a "Kubernetes" section showing pod name, namespace, pod UID, container name, and container ID
+- **JSON logs** (`--json-log`) and the `--pcap-export` sidecar JSONL, as a `kubernetes` object per connection event
+- **PCAPNG packet comments** (`--pcapng-export`), as `pod=`, `ns=`, `pod_uid=`, `container=`, and `container_id=` fields
+- The `pod:`, `ns:`, and `container:` [filter keywords](#keyword-filters)
+
+```bash
+# Native build with the feature enabled
+cargo build --release --features kubernetes
+
+# Force attribution on outside a pod
+rustnet --kubernetes on
+```
+
 ## Keyboard Controls
 
 ### Navigation
@@ -381,6 +410,11 @@ Use keyword filters for targeted searches:
 | `app:` | `application:` | Detected application protocol | `app:ssh` matches SSH connections |
 | `state:` | | Protocol states | `state:established` matches established connections |
 | `proto:` | `protocol:` | Protocol type | `proto:tcp` matches TCP connections |
+| `pod:` | | Kubernetes pod name or UID * | `pod:nginx` matches nginx-86644db9cc-mf5lx |
+| `ns:` | `namespace:` | Kubernetes pod namespace * | `ns:kube-system` matches pods in kube-system |
+| `container:` | `cont:` | Kubernetes container name or ID * | `container:nginx` matches the nginx container |
+
+\* Requires a build with the `kubernetes` feature and active pod attribution. See [`--kubernetes`](#--kubernetes-mode-optional-feature).
 
 ### State Filtering
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -290,11 +290,16 @@ Attribution is surfaced in:
 - **PCAPNG packet comments** (`--pcapng-export`), as `pod=`, `ns=`, `pod_uid=`, `container=`, and `container_id=` fields
 - The `pod:`, `ns:`, and `container:` [filter keywords](#keyword-filters)
 
+**Running on a cluster:** the easiest way to use this is the [kubectl-rustnet](https://github.com/domcyrus/kubectl-rustnet) plugin (`kubectl krew install rustnet`). It launches RustNet as an ephemeral debug pod on a node using the official image, mounts the kubelet log directories read-only for name resolution, and cleans up the pod on exit. Since the plugin runs RustNet inside a pod, the default `auto` mode enables attribution without any flags.
+
 ```bash
+# On a Kubernetes cluster: run as an ephemeral debug pod via the plugin
+kubectl rustnet --node worker-3
+
 # Native build with the feature enabled
 cargo build --release --features kubernetes
 
-# Force attribution on outside a pod
+# Force attribution on outside a pod (e.g. directly on a node)
 rustnet --kubernetes on
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2701,6 +2701,24 @@ fn build_pcapng_comment(conn: &Connection) -> Option<String> {
     if let Some(pid) = conn.pid {
         fields.push(format!("pid={pid}"));
     }
+    #[cfg(feature = "kubernetes")]
+    if let Some(k8s) = &conn.k8s_info {
+        if let Some(name) = &k8s.pod_name {
+            fields.push(format!("pod={}", sanitize_comment_value(name)));
+        }
+        if let Some(ns) = &k8s.pod_namespace {
+            fields.push(format!("ns={}", sanitize_comment_value(ns)));
+        }
+        if let Some(uid) = &k8s.pod_uid {
+            fields.push(format!("pod_uid={}", sanitize_comment_value(uid)));
+        }
+        if let Some(name) = &k8s.container_name {
+            fields.push(format!("container={}", sanitize_comment_value(name)));
+        }
+        if let Some(id) = &k8s.container_id {
+            fields.push(format!("container_id={}", sanitize_comment_value(id)));
+        }
+    }
     if let Some(is_outgoing) = conn.connection_direction {
         fields.push(format!(
             "direction={}",
@@ -2863,6 +2881,40 @@ mod pcapng_export_tests {
             key,
             deadline,
         }
+    }
+
+    /// Kubernetes attribution must be carried into the per-packet comment so
+    /// annotated PCAPNG files are pod-aware without the sidecar JSONL.
+    #[cfg(feature = "kubernetes")]
+    #[test]
+    fn comment_includes_kubernetes_attribution() {
+        use crate::network::types::{K8sInfo, ProtocolState, TcpState};
+
+        let mut conn = Connection::new(
+            Protocol::Tcp,
+            SocketAddr::from(([10, 0, 0, 1], 4000)),
+            SocketAddr::from(([10, 0, 0, 2], 443)),
+            ProtocolState::Tcp(TcpState::Established),
+        );
+        conn.k8s_info = Some(K8sInfo {
+            pod_uid: Some("c3b4d893-473e-43c2-8013-8ee2955a4630".to_string()),
+            pod_name: Some("nginx-86644db9cc-mf5lx".to_string()),
+            pod_namespace: Some("demo-traffic".to_string()),
+            container_id: Some(
+                "c16c7605305c854d8582a1db3d5bb3c4b6c89a08e914223e9d500682b3fb0b1b".to_string(),
+            ),
+            container_name: Some("nginx".to_string()),
+            cgroup_path: None,
+        });
+
+        let comment = build_pcapng_comment(&conn).expect("k8s info alone must produce a comment");
+        assert!(comment.contains("pod=nginx-86644db9cc-mf5lx"));
+        assert!(comment.contains("ns=demo-traffic"));
+        assert!(comment.contains("pod_uid=c3b4d893-473e-43c2-8013-8ee2955a4630"));
+        assert!(comment.contains("container=nginx"));
+        assert!(comment.contains(
+            "container_id=c16c7605305c854d8582a1db3d5bb3c4b6c89a08e914223e9d500682b3fb0b1b"
+        ));
     }
 
     /// Records must leave the pending queue in arrival order: a keyless


### PR DESCRIPTION
Follow-up to #299 and #432:

- The native `--pcapng-export` packet comments now carry the Kubernetes attribution (`pod=`, `ns=`, `pod_uid=`, `container=`, `container_id=`), so annotated captures are pod-aware in Wireshark without the sidecar JSONL. `cgroup_path` is left out of comments (long, repeated per packet, derivable from pod UID + container ID); it stays in the JSON log and sidecar.
- Adds the missing docs for the `kubernetes` feature: `--kubernetes` option details and `pod:`/`ns:`/`container:` filter keywords in USAGE.md, plus a Features bullet in README.md.
- Recommends [kubectl-rustnet](https://github.com/domcyrus/kubectl-rustnet) as the cluster path for the feature (ephemeral debug pod, kubelet log mounts, `auto` mode) in both docs.

Tested with `cargo test` (default and `--features kubernetes`), clippy clean in both configurations, fmt unchanged. New unit test covers the comment fields.