### PR TITLE
feat(ui): pane scrolling and filled area traffic chart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -831,7 +831,7 @@ where
                                                 }
                                             }
                                         }
-                                        ui_state.selected_connection_key = Some(key);
+                                        ui_state.set_connection_key(Some(key));
                                     }
                                     ui::ClickAction::CopyField { label, value } => {
                                         copy_to_clipboard(

--- a/src/ui/actions.rs
+++ b/src/ui/actions.rs
@@ -7,11 +7,11 @@
 
 use std::time::Instant;
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use log::info;
 
 use crate::app::App;
-use crate::ui::{Effect, HandlerContext, UIState};
+use crate::ui::{Effect, HandlerContext, PaneScroll, UIState};
 
 /// Connection-list navigation + copy that's meaningful on both
 /// Overview and Details. Navigation flips which connection has
@@ -97,6 +97,45 @@ pub fn try_handle_connection_nav(
     }
 }
 
+/// Shared key handling for read-only scrollable panes (Help,
+/// Interfaces): line, page, and top/bottom movement on the usual
+/// vim-style keys. Claims only those keys; everything else falls
+/// through to the caller's global handling.
+pub fn try_handle_pane_scroll(
+    key: KeyEvent,
+    page_size: usize,
+    scroll: &mut PaneScroll,
+) -> Option<Vec<Effect>> {
+    let page = page_size.max(1) as u16;
+    match (key.code, key.modifiers) {
+        (KeyCode::Up, _) | (KeyCode::Char('k'), _) => scroll.scroll_up(1),
+        (KeyCode::Down, _) | (KeyCode::Char('j'), _) => scroll.scroll_down(1),
+        (KeyCode::PageUp, _) | (KeyCode::Char('b'), KeyModifiers::CONTROL) => {
+            scroll.scroll_up(page)
+        }
+        (KeyCode::PageDown, _) | (KeyCode::Char('f'), KeyModifiers::CONTROL) => {
+            scroll.scroll_down(page)
+        }
+        (KeyCode::Char('g'), KeyModifiers::NONE) | (KeyCode::Home, _) => scroll.scroll_to_top(),
+        (KeyCode::Char('G'), _) | (KeyCode::Char('g'), KeyModifiers::SHIFT) | (KeyCode::End, _) => {
+            scroll.scroll_to_bottom()
+        }
+        _ => return None,
+    }
+    Some(Vec::new())
+}
+
+/// Shared wheel handling for scrollable panes (Details info panes,
+/// Help, Interfaces).
+pub fn try_handle_pane_wheel(mouse: MouseEvent, scroll: &mut PaneScroll) -> Option<Vec<Effect>> {
+    match mouse.kind {
+        MouseEventKind::ScrollUp => scroll.scroll_up(1),
+        MouseEventKind::ScrollDown => scroll.scroll_down(1),
+        _ => return None,
+    }
+    Some(Vec::new())
+}
+
 /// Handle the 'x' (clear all connections) key with two-press
 /// confirmation. First press flips `clear_confirmation` on; the
 /// second press (while it's on) actually clears.
@@ -109,7 +148,7 @@ pub fn clear_all_with_confirmation(ui_state: &mut UIState, app: &App) -> bool {
         app.clear_all_connections();
         ui_state.clear_confirmation = false;
         ui_state.show_historic = false;
-        ui_state.selected_connection_key = None;
+        ui_state.set_connection_key(None);
         ui_state.clipboard_message = Some(("All connections cleared".to_string(), Instant::now()));
         true
     } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -93,8 +93,8 @@ pub fn set_no_color(enabled: bool) {
 
 mod state;
 pub use state::{
-    ClickAction, ClickableRegions, GroupedRow, SortColumn, UIState, compute_grouped_rows,
-    compute_scroll_offset,
+    ClickAction, ClickableRegions, GroupedRow, PaneScroll, SortColumn, UIState,
+    compute_grouped_rows, compute_scroll_offset,
 };
 pub(crate) use widgets::tabs_bar::{HELP_TAB_INDEX, TAB_COUNT};
 
@@ -107,7 +107,10 @@ mod clipboard;
 pub use clipboard::copy_to_clipboard;
 
 mod actions;
-pub use actions::{clear_all_with_confirmation, try_handle_connection_nav};
+pub use actions::{
+    clear_all_with_confirmation, try_handle_connection_nav, try_handle_pane_scroll,
+    try_handle_pane_wheel,
+};
 
 mod component;
 pub use component::{Component, DrawContext as ComponentContext, Effect, HandlerContext};
@@ -601,8 +604,9 @@ mod snapshot_tests {
     #[test]
     fn help_tab() {
         use crate::ui::tabs::help::draw_help;
+        let ui_state = UIState::default();
         let output = render(100, 50, |f| {
-            draw_help(f, f.area()).expect("draw_help");
+            draw_help(f, &ui_state, f.area()).expect("draw_help");
         });
         insta::assert_snapshot!(output);
     }

--- a/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__details_tab_tcp_https.snap
+++ b/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__details_tab_tcp_https.snap
@@ -1,6 +1,6 @@
 ---
 source: src/ui/mod.rs
-assertion_line: 909
+assertion_line: 913
 expression: output
 ---
  rustnet    1 Overview   2 Details   3 Interfaces   4 Graph   5 Help                                                                        
@@ -12,12 +12,12 @@ expression: output
   sshd (1500)              10.0.0.5:51022               192.168.1.10:22     ssh        TCP                          ESTABLISHED          -/-
                                                                                                                                             
 ▎ firefox → 140.82.121.4:443 · click a field to copy                                                                                        
-Protocol              TCP                                              TCP Analytics                                                        
-Status                Active (last seen <T> ago)                        TCP Retransmits       0                                              
-Local Address         192.168.1.10:51234                               Out-of-Order Packets  0                                              
-Remote Address        140.82.121.4:443                                 Duplicate ACKs        0                                              
-Scope                 PUBLIC                                           Fast Retransmits      0                                              
-State                 ESTABLISHED                                      Window Size           0                                              
+Protocol              TCP                                             TCP Analytics                                                         
+Status                Active (last seen <T> ago)                       TCP Retransmits       0                                               
+Local Address         192.168.1.10:51234                              Out-of-Order Packets  0                                               
+Remote Address        140.82.121.4:443                                Duplicate ACKs        0                                               
+Scope                 PUBLIC                                          Fast Retransmits      0                                               
+State                 ESTABLISHED                                     Window Size           0                                               
 Process               firefox                                                                                                               
 PID                   2001                                                                                                                  
 Service               https                                                                                                                 
@@ -42,4 +42,4 @@ Packets Sent          12
 Packets Received      234                                                                                                                   
 Current Rate (In)     -                                                                                                                     
 Current Rate (Out)    -                                                                                                                     
- 'h' help | 1-5 jump | Tab/[/] cycle | j/k prev/next | 'c' copy remote addr | Esc back
+ 'h' help | 1-5 jump | Tab/[/] cycle | j/k prev/next | Ctrl-d/u scroll | 'c' copy remote addr | Esc back

--- a/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__help_tab.snap
+++ b/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__help_tab.snap
@@ -1,55 +1,55 @@
 ---
 source: src/ui/mod.rs
-assertion_line: 572
+assertion_line: 611
 expression: output
 ---
 ╭Help──────────────────────────────────────────────────────────────────────────────────────────────╮
-│RustNet Monitor - Network Connection Monitor                                                      │
-│                                                                                                  │
-│q Quit application (press twice to confirm)                                                       │
-│Ctrl+C Quit immediately                                                                           │
-│x Clear all connections (press twice to confirm)                                                  │
-│Tab, ] Next tab                                                                                   │
-│Shift+Tab, [ Previous tab                                                                         │
-│1-5 Jump directly to a tab (1=Overview, 2=Details, 3=Interfaces, 4=Graph, 5=Help)                 │
-│↑/k, ↓/j Navigate connections (wraps around)                                                      │
-│g, G Jump to first/last connection (vim-style)                                                    │
-│Page Up/Down, Ctrl+B/F Navigate connections by page                                               │
-│c Copy remote address to clipboard                                                                │
-│p Toggle between service names and port numbers                                                   │
-│d Toggle between hostnames and IP addresses (when --resolve-dns)                                  │
-│s Cycle through sort columns (Bandwidth, Process, etc.)                                           │
-│S Toggle sort direction (ascending/descending)                                                    │
-│a Toggle process grouping (aggregate by process)                                                  │
-│Space Expand/collapse group (when grouping enabled)                                               │
-│←/→ or h/l Collapse/expand group                                                                  │
-│t Toggle display of historic (closed) connections                                                 │
-│i Toggle the System info sidebar                                                                  │
-│r Reset view (grouping, sort, filter)                                                             │
-│Enter View connection details                                                                     │
-│Esc Return to overview                                                                            │
-│h Toggle this help screen                                                                         │
-│/ Enter filter mode on Overview (use ↑/↓ to navigate while typing)                                │
-│                                                                                                  │
-│Tabs:                                                                                             │
-│Overview Connection list with mini traffic graph                                                  │
-│Details Full details for selected connection                                                      │
-│Interfaces Network interface statistics                                                           │
-│Graph Traffic charts and protocol distribution                                                    │
-│Help This help screen                                                                             │
-│                                                                                                  │
-│Mouse Controls:                                                                                   │
-│Click tab Switch between tabs                                                                     │
-│Click row Select connection                                                                       │
-│Scroll wheel Navigate connection list                                                             │
-│Double-click row Open connection details                                                          │
-│Double-click group Expand/collapse process group                                                  │
-│Click field (Details) Copy field value to clipboard                                               │
-│                                                                                                  │
-│Connection Colors:                                                                                │
-│White Active connection (< 75% of timeout)                                                        │
-│Yellow Stale connection (75-90% of timeout)                                                       │
-│Red Critical - will be removed soon (> 90% of timeout)                                            │
-│                                                                                                  │
-│Filter Examples:                                                                                  │
+│RustNet Monitor - Network Connection Monitor                                                      █
+│                                                                                                  █
+│q Quit application (press twice to confirm)                                                       █
+│Ctrl+C Quit immediately                                                                           █
+│x Clear all connections (press twice to confirm)                                                  █
+│Tab, ] Next tab                                                                                   █
+│Shift+Tab, [ Previous tab                                                                         █
+│1-5 Jump directly to a tab (1=Overview, 2=Details, 3=Interfaces, 4=Graph, 5=Help)                 █
+│↑/k, ↓/j Navigate connections (wraps around)                                                      █
+│g, G Jump to first/last connection (vim-style)                                                    █
+│Page Up/Down, Ctrl+B/F Navigate connections by page                                               █
+│Ctrl+D/U Scroll the Details info panes                                                            █
+│c Copy remote address to clipboard                                                                █
+│p Toggle between service names and port numbers                                                   █
+│d Toggle between hostnames and IP addresses (when --resolve-dns)                                  █
+│s Cycle through sort columns (Bandwidth, Process, etc.)                                           █
+│S Toggle sort direction (ascending/descending)                                                    █
+│a Toggle process grouping (aggregate by process)                                                  █
+│Space Expand/collapse group (when grouping enabled)                                               █
+│←/→ or h/l Collapse/expand group                                                                  █
+│t Toggle display of historic (closed) connections                                                 █
+│i Toggle the System info sidebar                                                                  █
+│r Reset view (grouping, sort, filter)                                                             █
+│Enter View connection details                                                                     █
+│Esc Return to overview                                                                            █
+│h Toggle this help screen                                                                         █
+│/ Enter filter mode on Overview (use ↑/↓ to navigate while typing)                                █
+│                                                                                                  █
+│Tabs:                                                                                             █
+│Overview Connection list with mini traffic graph                                                  █
+│Details Full details for selected connection                                                      █
+│Interfaces Network interface statistics                                                           █
+│Graph Traffic charts and protocol distribution                                                    █
+│Help This help screen                                                                             █
+│                                                                                                  █
+│Mouse Controls:                                                                                   █
+│Click tab Switch between tabs                                                                     █
+│Click row Select connection                                                                       █
+│Scroll wheel Navigate connection list / scroll Details, Interfaces, Help                          █
+│Double-click row Open connection details                                                          █
+│Double-click group Expand/collapse process group                                                  ║
+│Click field (Details) Copy field value to clipboard                                               ║
+│                                                                                                  ║
+│Connection Colors:                                                                                ║
+│White Active connection (< 75% of timeout)                                                        ║
+│Yellow Stale connection (75-90% of timeout)                                                       ║
+│Red Critical - will be removed soon (> 90% of timeout)                                            ║
+│                                                                                                  ║
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__interfaces_tab.snap
+++ b/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__interfaces_tab.snap
@@ -1,6 +1,6 @@
 ---
 source: src/ui/mod.rs
-assertion_line: 965
+assertion_line: 969
 expression: output
 ---
  rustnet    1 Overview   2 Details   3 Interfaces   4 Graph   5 Help                                                                        
@@ -32,4 +32,4 @@ eth0            512.00 KB/s  128.00 KB/s    1200000     800000         0        
                                                                                                                                             
                                                                                                                                             
                                                                                                                                             
- 'h' help | 1-5 jump | Tab/[/] cycle | Esc back to Overview
+ 'h' help | 1-5 jump | Tab/[/] cycle | j/k scroll | Esc back to Overview

--- a/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__status_bar_details_tab.snap
+++ b/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__status_bar_details_tab.snap
@@ -1,6 +1,6 @@
 ---
 source: src/ui/mod.rs
-assertion_line: 693
+assertion_line: 697
 expression: output
 ---
- 'h' help | 1-5 jump | Tab/[/] cycle | j/k prev/next | 'c' copy remote addr | Esc back
+ 'h' help | 1-5 jump | Tab/[/] cycle | j/k prev/next | Ctrl-d/u scroll | 'c' copy remote addr | Esc back

--- a/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__status_bar_help_tab.snap
+++ b/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__status_bar_help_tab.snap
@@ -1,6 +1,6 @@
 ---
 source: src/ui/mod.rs
-assertion_line: 693
+assertion_line: 707
 expression: output
 ---
- 'h' help | 1-5 jump | Tab/[/] cycle | Esc back to Overview
+ 'h' help | 1-5 jump | Tab/[/] cycle | j/k scroll | Esc back to Overview

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -3,11 +3,53 @@
 //! looking at and acting on. No rendering happens here; tabs and widgets
 //! read these to know what to draw.
 
+use std::cell::Cell;
 use std::collections::HashSet;
 
 use ratatui::layout::Rect;
 
 use crate::network::types::{Connection, Protocol};
+
+/// Scroll state for a pane that only learns its content and viewport
+/// size at render time (Details info panes, Help text, Interfaces
+/// table). Event handlers mutate `offset`; the draw path reports the
+/// real maximum through [`Self::clamp_for_render`] — a `Cell`, because
+/// drawing only holds `&UIState` — so the next scroll input clamps
+/// against what is actually on screen.
+#[derive(Debug, Default)]
+pub struct PaneScroll {
+    offset: u16,
+    max: Cell<u16>,
+}
+
+impl PaneScroll {
+    pub fn scroll_up(&mut self, lines: u16) {
+        self.offset = self.offset.saturating_sub(lines);
+    }
+
+    pub fn scroll_down(&mut self, lines: u16) {
+        self.offset = self.offset.saturating_add(lines).min(self.max.get());
+    }
+
+    pub fn scroll_to_top(&mut self) {
+        self.offset = 0;
+    }
+
+    pub fn scroll_to_bottom(&mut self) {
+        self.offset = self.max.get();
+    }
+
+    pub fn reset(&mut self) {
+        self.offset = 0;
+    }
+
+    /// Record this render's maximum scroll offset and return the
+    /// (clamped) offset to draw with.
+    pub fn clamp_for_render(&self, max: u16) -> u16 {
+        self.max.set(max);
+        self.offset.min(max)
+    }
+}
 
 /// Sort column options for the connections table.
 /// Protocol (TCP/UDP) has no dedicated column anymore — it's merged into
@@ -203,6 +245,12 @@ pub struct UIState {
     pub scroll_offset: usize,
     /// Scroll offset for grouped connection list (persisted for stable scrolling)
     pub grouped_scroll_offset: usize,
+    /// Scroll state for the Details info panes (reset when the selection changes)
+    pub details_scroll: PaneScroll,
+    /// Scroll state for the Help tab text
+    pub help_scroll: PaneScroll,
+    /// Scroll state for the Interfaces table
+    pub interfaces_scroll: PaneScroll,
 }
 
 impl Default for UIState {
@@ -231,6 +279,9 @@ impl Default for UIState {
             visible_rows: 10,
             scroll_offset: 0,
             grouped_scroll_offset: 0,
+            details_scroll: PaneScroll::default(),
+            help_scroll: PaneScroll::default(),
+            interfaces_scroll: PaneScroll::default(),
         }
     }
 }
@@ -261,6 +312,16 @@ pub fn compute_scroll_offset(
 }
 
 impl UIState {
+    /// Set the selected connection key, resetting the Details pane
+    /// scroll when the selection actually changes so a newly selected
+    /// record always starts at the top.
+    pub fn set_connection_key(&mut self, key: Option<String>) {
+        if self.selected_connection_key != key {
+            self.details_scroll.reset();
+        }
+        self.selected_connection_key = key;
+    }
+
     /// Get the current selected connection index, if any
     pub fn get_selected_index(&self, connections: &[Connection]) -> Option<usize> {
         if let Some(ref selected_key) = self.selected_connection_key {
@@ -277,7 +338,7 @@ impl UIState {
     /// Set the selected connection to the one at the given index
     pub fn set_selected_by_index(&mut self, connections: &[Connection], index: usize) {
         if let Some(conn) = connections.get(index) {
-            self.selected_connection_key = Some(conn.key());
+            self.set_connection_key(Some(conn.key()));
         }
     }
 
@@ -405,7 +466,7 @@ impl UIState {
     pub fn ensure_valid_selection(&mut self, connections: &[Connection]) {
         if connections.is_empty() {
             log::debug!("ensure_valid_selection: connections list is empty, clearing selection");
-            self.selected_connection_key = None;
+            self.set_connection_key(None);
             return;
         }
 
@@ -601,14 +662,14 @@ impl UIState {
             match row {
                 GroupedRow::Group { process_name, .. } => {
                     self.selected_group = Some(process_name.clone());
-                    self.selected_connection_key = None;
+                    self.set_connection_key(None);
                 }
                 GroupedRow::Connection {
                     process_name,
                     connection,
                     ..
                 } => {
-                    self.selected_connection_key = Some(connection.key());
+                    self.set_connection_key(Some(connection.key()));
                     self.selected_group = Some(process_name.clone());
                 }
             }
@@ -679,7 +740,7 @@ impl UIState {
     pub fn ensure_valid_grouped_selection(&mut self, grouped_rows: &[GroupedRow]) {
         if grouped_rows.is_empty() {
             self.selected_group = None;
-            self.selected_connection_key = None;
+            self.set_connection_key(None);
             return;
         }
 
@@ -849,5 +910,47 @@ mod tests {
         assert_eq!(ui.selected_tab, TAB_COUNT - 1);
         ui.prev_tab();
         assert_eq!(ui.selected_tab, TAB_COUNT - 2);
+    }
+
+    #[test]
+    fn pane_scroll_clamps_to_render_reported_max() {
+        let mut scroll = PaneScroll::default();
+        // Before any render the max is 0, so scrolling down is a no-op.
+        scroll.scroll_down(5);
+        assert_eq!(scroll.clamp_for_render(10), 0);
+
+        // After a render reported max=10, downward scrolling sticks to it.
+        scroll.scroll_down(25);
+        assert_eq!(scroll.clamp_for_render(10), 10);
+
+        // A shorter record (smaller max) clamps the draw offset without
+        // mutating the handler-side state.
+        assert_eq!(scroll.clamp_for_render(3), 3);
+
+        scroll.scroll_up(1);
+        assert_eq!(scroll.clamp_for_render(10), 9);
+
+        scroll.scroll_to_bottom();
+        assert_eq!(scroll.clamp_for_render(10), 10);
+        scroll.scroll_to_top();
+        assert_eq!(scroll.clamp_for_render(10), 0);
+    }
+
+    #[test]
+    fn details_scroll_resets_when_selection_changes() {
+        let mut ui = UIState::default();
+        ui.details_scroll.clamp_for_render(20);
+        ui.details_scroll.scroll_down(7);
+
+        // Same key: scroll position survives (e.g. periodic refresh).
+        ui.set_connection_key(Some("a".to_string()));
+        ui.details_scroll.clamp_for_render(20);
+        ui.details_scroll.scroll_down(7);
+        ui.set_connection_key(Some("a".to_string()));
+        assert_eq!(ui.details_scroll.clamp_for_render(20), 7);
+
+        // New key: the new record starts at the top.
+        ui.set_connection_key(Some("b".to_string()));
+        assert_eq!(ui.details_scroll.clamp_for_render(20), 0);
     }
 }

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -23,7 +23,8 @@ use crate::ui::{
     connection_table::{build_header, column_constraints, connection_row, select_columns},
     dpi_color,
     format::{format_bytes, format_rate},
-    section_header, state_color, theme, try_handle_connection_nav,
+    section_header, state_color, theme, try_handle_connection_nav, try_handle_pane_wheel,
+    widgets::scrollbar::draw_scrollbar,
 };
 
 /// Padded width for detail labels so values line up vertically.
@@ -35,6 +36,11 @@ const DETAIL_LABEL_WIDTH: usize = 22;
 /// single column. With label width 22 plus reasonable values, ~50 cells
 /// per side is the readable floor.
 const DETAILS_SPLIT_MIN_WIDTH: u16 = 100;
+
+/// Rows scrolled per Ctrl+D / Ctrl+U press in the info panes. A fixed
+/// step rather than a half page — the pane height isn't known in the
+/// key handler, and a small constant feels consistent across sizes.
+const DETAILS_SCROLL_STEP: u16 = 5;
 
 /// Details tab. Pulls DNS resolver per-render from the app — no
 /// per-tab state today.
@@ -52,6 +58,22 @@ impl Component for DetailsTab {
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut HandlerContext<'_>) -> Option<Vec<Effect>> {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        // Ctrl+D / Ctrl+U scroll the info panes when the record is
+        // taller than the pane (j/k etc. stay reserved for flipping
+        // between connections).
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
+                ctx.ui_state.details_scroll.scroll_down(DETAILS_SCROLL_STEP);
+                return Some(Vec::new());
+            }
+            (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
+                ctx.ui_state.details_scroll.scroll_up(DETAILS_SCROLL_STEP);
+                return Some(Vec::new());
+            }
+            _ => {}
+        }
         // In grouped mode, flip through the grouped view's connection
         // sequence, skipping group headers — a header has no record to
         // show on this tab. Falls through to the shared flat-list
@@ -67,14 +89,13 @@ impl Component for DetailsTab {
 
     fn handle_mouse(
         &mut self,
-        _mouse: MouseEvent,
-        _ctx: &mut HandlerContext<'_>,
+        mouse: MouseEvent,
+        ctx: &mut HandlerContext<'_>,
     ) -> Option<Vec<Effect>> {
-        // No tab-specific mouse handling beyond what the global
-        // ClickableRegions dispatch in main.rs already does (the
-        // 'click a field to copy' CopyField regions are registered
-        // during draw and routed there).
-        None
+        // Scroll wheel scrolls the info panes. Click events are still
+        // dispatched by main.rs through ClickableRegions (the 'click a
+        // field to copy' CopyField regions registered during draw).
+        try_handle_pane_wheel(mouse, &mut ctx.ui_state.details_scroll)
     }
 }
 
@@ -121,7 +142,9 @@ fn line_is_blank(line: &Line<'_>) -> bool {
 
 /// Register one click-to-copy region per non-empty field row in a Details
 /// pane. `inner` is the pane's *content* rect (the panes are borderless,
-/// so callers pass the area the text actually renders into).
+/// so callers pass the area the text actually renders into); `scroll` is
+/// the pane's current scroll offset, so regions land on the rows the
+/// fields actually occupy on screen.
 /// `skip_placeholder_values` mirrors the existing connection-info
 /// behavior of skipping NONE_PLACEHOLDER / empty values.
 fn register_detail_clicks(
@@ -129,13 +152,18 @@ fn register_detail_clicks(
     inner: Rect,
     fields: &[Option<(String, String)>],
     skip_placeholder_values: bool,
+    scroll: u16,
 ) {
     for (line_idx, entry) in fields.iter().enumerate() {
         if let Some((label, value)) = entry {
             if skip_placeholder_values && (value == NONE_PLACEHOLDER || value.is_empty()) {
                 continue;
             }
-            let row_y = inner.y + line_idx as u16;
+            // Rows scrolled off the top have no on-screen position.
+            let Some(visible_idx) = (line_idx as u16).checked_sub(scroll) else {
+                continue;
+            };
+            let row_y = inner.y + visible_idx;
             if row_y >= inner.y + inner.height {
                 break;
             }
@@ -1453,32 +1481,58 @@ pub(in crate::ui) fn draw_connection_details(
         }
     }
 
+    // Reserve the two rightmost columns of the info area (blank gap +
+    // scrollbar) and split the panes inside the remainder.
+    let panes_area = Rect::new(
+        info_area.x,
+        info_area.y,
+        info_area.width.saturating_sub(2),
+        info_area.height,
+    );
     let info_chunks: Vec<Rect> = if split_horizontally {
         Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .spacing(2)
-            .split(info_area)
+            .split(panes_area)
             .to_vec()
     } else {
-        vec![info_area]
+        vec![panes_area]
     };
+
+    // Both panes share one scroll offset (Ctrl+D/U, mouse wheel) so
+    // they stay row-aligned; the taller pane bounds it.
+    let content_rows = details_text.len().max(right_text.len());
+    let max_scroll = (content_rows as u16).saturating_sub(info_area.height);
+    let scroll = ui_state.details_scroll.clamp_for_render(max_scroll);
 
     let left_para = Paragraph::new(details_text)
         .style(Style::default())
         // trim:false preserves any leading whitespace in labels rather than
         // collapsing it, which keeps the fixed-width label padding intact.
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
     f.render_widget(left_para, info_chunks[0]);
-    register_detail_clicks(click_regions, info_chunks[0], &detail_fields, true);
+    register_detail_clicks(click_regions, info_chunks[0], &detail_fields, true, scroll);
 
     if info_chunks.len() == 2 && !right_text.is_empty() {
         let right_para = Paragraph::new(right_text)
             .style(Style::default())
-            .wrap(Wrap { trim: false });
+            .wrap(Wrap { trim: false })
+            .scroll((scroll, 0));
         f.render_widget(right_para, info_chunks[1]);
-        register_detail_clicks(click_regions, info_chunks[1], &right_fields, true);
+        register_detail_clicks(click_regions, info_chunks[1], &right_fields, true, scroll);
     }
+
+    // Scrollbar on the right edge of the info area; hidden when the
+    // record fits.
+    draw_scrollbar(
+        f,
+        info_area,
+        content_rows,
+        scroll as usize,
+        info_area.height as usize,
+    );
 
     // Traffic details - also track fields for click-to-copy
     let mut traffic_text: Vec<Line> = Vec::new();
@@ -1555,7 +1609,7 @@ pub(in crate::ui) fn draw_connection_details(
         .wrap(Wrap { trim: false });
 
     f.render_widget(traffic, traffic_area);
-    register_detail_clicks(click_regions, traffic_area, &traffic_fields, false);
+    register_detail_clicks(click_regions, traffic_area, &traffic_fields, false, 0);
 
     Ok(())
 }

--- a/src/ui/tabs/graph.rs
+++ b/src/ui/tabs/graph.rs
@@ -610,6 +610,3 @@ fn draw_tcp_states(f: &mut Frame, connections: &[Connection], area: Rect) {
     let paragraph = Paragraph::new(lines);
     f.render_widget(paragraph, inner);
 }
-
-
-

--- a/src/ui/tabs/graph.rs
+++ b/src/ui/tabs/graph.rs
@@ -141,18 +141,29 @@ fn draw_traffic_chart(f: &mut Frame, history: &TrafficHistory, area: Rect) {
         .fold(0.0f64, |a, b| a.max(b))
         .max(1024.0); // Minimum 1 KB/s scale
 
-    let datasets = vec![
-        Dataset::default()
-            .marker(symbols::Marker::Braille)
-            .graph_type(GraphType::Line)
-            .style(theme::fg(theme::rx()))
-            .data(&rx_data),
-        Dataset::default()
-            .marker(symbols::Marker::Braille)
-            .graph_type(GraphType::Line)
-            .style(theme::fg(theme::tx()))
-            .data(&tx_data),
-    ];
+    let rx_dataset = Dataset::default()
+        .marker(symbols::Marker::Braille)
+        .graph_type(GraphType::Area)
+        .fill_to_y(0.0)
+        .style(theme::fg(theme::rx()))
+        .data(&rx_data);
+    let tx_dataset = Dataset::default()
+        .marker(symbols::Marker::Braille)
+        .graph_type(GraphType::Area)
+        .fill_to_y(0.0)
+        .style(theme::fg(theme::tx()))
+        .data(&tx_data);
+
+    // The fills are opaque (terminals can't alpha-blend), so draw the
+    // larger series first: the smaller one then layers fully visible in
+    // front while the larger still shows wherever it exceeds it.
+    let rx_total: f64 = rx_data.iter().map(|(_, y)| *y).sum();
+    let tx_total: f64 = tx_data.iter().map(|(_, y)| *y).sum();
+    let datasets = if rx_total >= tx_total {
+        vec![rx_dataset, tx_dataset]
+    } else {
+        vec![tx_dataset, rx_dataset]
+    };
 
     let chart = Chart::new(datasets)
         .x_axis(
@@ -191,10 +202,17 @@ fn draw_connections_sparkline(f: &mut Frame, history: &TrafficHistory, area: Rec
         return;
     }
 
-    // Layout: sparkline + current count label
+    // Layout: sparkline + current count label. The two blank rows in
+    // between mirror the traffic chart's axis line + time-label rows,
+    // so the sparkline's bottom aligns with the chart's plot area and
+    // the count label lines up with the chart's RX/TX legend.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Min(1),    // sparkline, level with the chart's data rows
+            Constraint::Length(2), // blank: chart's axis + label rows
+            Constraint::Length(1), // count label, level with the chart legend
+        ])
         .split(inner);
 
     let width = inner.width as usize;
@@ -208,7 +226,7 @@ fn draw_connections_sparkline(f: &mut Frame, history: &TrafficHistory, area: Rec
     // Current connection count label (active connections only)
     let current_count = conn_data.last().copied().unwrap_or(0);
     let label = Paragraph::new(format!("{} active connections", current_count));
-    f.render_widget(label, chunks[1]);
+    f.render_widget(label, chunks[2]);
 }
 
 /// Draw application protocol distribution
@@ -592,3 +610,6 @@ fn draw_tcp_states(f: &mut Frame, connections: &[Connection], area: Rect) {
     let paragraph = Paragraph::new(lines);
     f.render_widget(paragraph, inner);
 }
+
+
+

--- a/src/ui/tabs/help.rs
+++ b/src/ui/tabs/help.rs
@@ -1,7 +1,9 @@
-//! Static help/legend tab — a paragraph of keybinds, mouse
-//! controls, colors, and filter examples. No state, no inputs.
+//! Help/legend tab — a scrollable paragraph of keybinds, mouse
+//! controls, colors, and filter examples. Scroll position lives in
+//! `UIState::help_scroll`.
 
 use anyhow::Result;
+use crossterm::event::{KeyEvent, MouseEvent};
 use ratatui::{
     Frame,
     layout::Rect,
@@ -10,10 +12,13 @@ use ratatui::{
     widgets::{Paragraph, Wrap},
 };
 
-use crate::ui::{ClickableRegions, Component, ComponentContext, panel_block, theme};
+use crate::ui::{
+    ClickableRegions, Component, ComponentContext, Effect, HandlerContext, UIState, panel_block,
+    theme, try_handle_pane_scroll, try_handle_pane_wheel, widgets::scrollbar::draw_scrollbar,
+};
 
-/// Stateless help tab. Zero-sized — held in the tabs vec like any
-/// other Component, even though it never mutates.
+/// Help tab. Zero-sized — the scroll offset it responds to lives in
+/// `UIState`, not here.
 pub(in crate::ui) struct HelpTab;
 
 impl Component for HelpTab {
@@ -21,14 +26,26 @@ impl Component for HelpTab {
         &mut self,
         f: &mut Frame,
         area: Rect,
-        _ctx: &ComponentContext<'_>,
+        ctx: &ComponentContext<'_>,
         _click_regions: &mut ClickableRegions,
     ) -> Result<()> {
-        draw_help(f, area)
+        draw_help(f, ctx.ui_state, area)
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, ctx: &mut HandlerContext<'_>) -> Option<Vec<Effect>> {
+        try_handle_pane_scroll(key, ctx.ui_state.visible_rows, &mut ctx.ui_state.help_scroll)
+    }
+
+    fn handle_mouse(
+        &mut self,
+        mouse: MouseEvent,
+        ctx: &mut HandlerContext<'_>,
+    ) -> Option<Vec<Effect>> {
+        try_handle_pane_wheel(mouse, &mut ctx.ui_state.help_scroll)
     }
 }
 
-pub(in crate::ui) fn draw_help(f: &mut Frame, area: Rect) -> Result<()> {
+pub(in crate::ui) fn draw_help(f: &mut Frame, ui_state: &UIState, area: Rect) -> Result<()> {
     let help_text: Vec<Line> = vec![
         Line::from(vec![
             Span::styled("RustNet Monitor ", theme::bold_fg(theme::ok())),
@@ -72,6 +89,10 @@ pub(in crate::ui) fn draw_help(f: &mut Frame, area: Rect) -> Result<()> {
         Line::from(vec![
             Span::styled("Page Up/Down, Ctrl+B/F ", theme::fg(theme::key())),
             Span::raw("Navigate connections by page"),
+        ]),
+        Line::from(vec![
+            Span::styled("Ctrl+D/U ", theme::fg(theme::key())),
+            Span::raw("Scroll the Details info panes"),
         ]),
         Line::from(vec![
             Span::styled("c ", theme::fg(theme::key())),
@@ -172,7 +193,7 @@ pub(in crate::ui) fn draw_help(f: &mut Frame, area: Rect) -> Result<()> {
         ]),
         Line::from(vec![
             Span::styled("  Scroll wheel ", theme::fg(theme::key())),
-            Span::raw("Navigate connection list"),
+            Span::raw("Navigate connection list / scroll Details, Interfaces, Help"),
         ]),
         Line::from(vec![
             Span::styled("  Double-click row ", theme::fg(theme::key())),
@@ -239,13 +260,33 @@ pub(in crate::ui) fn draw_help(f: &mut Frame, area: Rect) -> Result<()> {
         Line::from(""),
     ];
 
+    // Scroll against the unwrapped line count. A handful of lines can
+    // wrap on very narrow terminals, making the true maximum slightly
+    // larger, but staying off the unstable rendered-line-info APIs is
+    // worth the last row or two of scroll range.
+    let total_lines = help_text.len();
+    let block = panel_block("Help");
+    let inner = block.inner(area);
+    let max_scroll = (total_lines as u16).saturating_sub(inner.height);
+    let scroll = ui_state.help_scroll.clamp_for_render(max_scroll);
+
     let help = Paragraph::new(help_text)
-        .block(panel_block("Help"))
+        .block(block)
         .style(Style::default())
         .wrap(Wrap { trim: true })
+        .scroll((scroll, 0))
         .alignment(ratatui::layout::Alignment::Left);
 
     f.render_widget(help, area);
+
+    // Scrollbar over the right border, spanning the inner rows.
+    draw_scrollbar(
+        f,
+        Rect::new(area.x, inner.y, area.width, inner.height),
+        total_lines,
+        scroll as usize,
+        inner.height as usize,
+    );
 
     Ok(())
 }

--- a/src/ui/tabs/help.rs
+++ b/src/ui/tabs/help.rs
@@ -33,7 +33,11 @@ impl Component for HelpTab {
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut HandlerContext<'_>) -> Option<Vec<Effect>> {
-        try_handle_pane_scroll(key, ctx.ui_state.visible_rows, &mut ctx.ui_state.help_scroll)
+        try_handle_pane_scroll(
+            key,
+            ctx.ui_state.visible_rows,
+            &mut ctx.ui_state.help_scroll,
+        )
     }
 
     fn handle_mouse(

--- a/src/ui/tabs/interfaces.rs
+++ b/src/ui/tabs/interfaces.rs
@@ -1,8 +1,10 @@
 //! Interfaces tab — full table of per-NIC counters (RX/TX rate,
 //! packets, errors, drops, collisions) sorted with the active
-//! capture interface first. Read-only, no input handling.
+//! capture interface first. Read-only apart from scrolling, which
+//! matters on Docker/VM hosts with dozens of bridge interfaces.
 
 use anyhow::Result;
+use crossterm::event::{KeyEvent, MouseEvent};
 use ratatui::{
     Frame,
     layout::{Constraint, Rect},
@@ -13,11 +15,14 @@ use ratatui::{
 
 use crate::app::App;
 use crate::ui::{
-    ClickableRegions, Component, ComponentContext, format::format_bytes, section_header, theme,
+    ClickableRegions, Component, ComponentContext, Effect, HandlerContext, UIState,
+    format::format_bytes, section_header, theme, try_handle_pane_scroll, try_handle_pane_wheel,
+    widgets::scrollbar::draw_scrollbar,
 };
 
-/// Read-only interfaces tab. Stateless for now; the table is rebuilt
-/// from the App's interface-stats DashMap every render.
+/// Interfaces tab. The table is rebuilt from the App's
+/// interface-stats DashMap every render; the scroll offset lives in
+/// `UIState::interfaces_scroll`.
 pub(in crate::ui) struct InterfacesTab;
 
 impl Component for InterfacesTab {
@@ -28,11 +33,32 @@ impl Component for InterfacesTab {
         ctx: &ComponentContext<'_>,
         _click_regions: &mut ClickableRegions,
     ) -> Result<()> {
-        draw_interface_stats(f, ctx.app, area)
+        draw_interface_stats(f, ctx.app, ctx.ui_state, area)
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, ctx: &mut HandlerContext<'_>) -> Option<Vec<Effect>> {
+        try_handle_pane_scroll(
+            key,
+            ctx.ui_state.visible_rows,
+            &mut ctx.ui_state.interfaces_scroll,
+        )
+    }
+
+    fn handle_mouse(
+        &mut self,
+        mouse: MouseEvent,
+        ctx: &mut HandlerContext<'_>,
+    ) -> Option<Vec<Effect>> {
+        try_handle_pane_wheel(mouse, &mut ctx.ui_state.interfaces_scroll)
     }
 }
 
-pub(in crate::ui) fn draw_interface_stats(f: &mut Frame, app: &App, area: Rect) -> Result<()> {
+pub(in crate::ui) fn draw_interface_stats(
+    f: &mut Frame,
+    app: &App,
+    ui_state: &UIState,
+    area: Rect,
+) -> Result<()> {
     let mut stats = app.get_interface_stats();
     let rates = app.get_interface_rates();
 
@@ -103,9 +129,28 @@ pub(in crate::ui) fn draw_interface_stats(f: &mut Frame, app: &App, area: Rect) 
         ]));
     }
 
-    // Create table
+    let inner = section_header(
+        f,
+        area,
+        ratatui::text::Span::styled(
+            " Interface Statistics",
+            Style::default().add_modifier(ratatui::style::Modifier::BOLD),
+        ),
+    );
+
+    // Window the rows against the scroll offset so hosts with dozens of
+    // bridge/veth interfaces can reach them all. The viewport excludes
+    // the table's header row.
+    let total_rows = rows.len();
+    let viewport = inner.height.saturating_sub(1) as usize;
+    let max_scroll = (total_rows as u16).saturating_sub(viewport as u16);
+    let scroll = ui_state.interfaces_scroll.clamp_for_render(max_scroll) as usize;
+    let windowed: Vec<Row> = rows.into_iter().skip(scroll).collect();
+
+    // Create table; reserve the two rightmost columns for a blank gap
+    // plus the scrollbar, mirroring the Overview table.
     let table = Table::new(
-        rows,
+        windowed,
         [
             Constraint::Length(14), // Interface
             Constraint::Length(12), // RX Bytes
@@ -137,15 +182,22 @@ pub(in crate::ui) fn draw_interface_stats(f: &mut Frame, app: &App, area: Rect) 
     })
     .style(Style::default());
 
-    let area = section_header(
-        f,
-        area,
-        ratatui::text::Span::styled(
-            " Interface Statistics",
-            Style::default().add_modifier(ratatui::style::Modifier::BOLD),
-        ),
+    let table_area = Rect::new(
+        inner.x,
+        inner.y,
+        inner.width.saturating_sub(2),
+        inner.height,
     );
-    f.render_widget(table, area);
+    f.render_widget(table, table_area);
+
+    // Scrollbar tracks the row region (below the header row).
+    let rows_area = Rect::new(
+        inner.x,
+        inner.y + 1,
+        inner.width,
+        inner.height.saturating_sub(1),
+    );
+    draw_scrollbar(f, rows_area, total_rows, scroll, viewport);
 
     Ok(())
 }

--- a/src/ui/tabs/overview.rs
+++ b/src/ui/tabs/overview.rs
@@ -9,10 +9,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{
-        Block, Borders, Cell, Padding, Paragraph, Row, Scrollbar, ScrollbarOrientation,
-        ScrollbarState, Sparkline, Table, Wrap,
-    },
+    widgets::{Block, Borders, Cell, Padding, Paragraph, Row, Sparkline, Table, Wrap},
 };
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
@@ -32,6 +29,7 @@ use crate::ui::{
     section_header,
     state::ProcessGroupStats,
     theme, try_handle_connection_nav,
+    widgets::scrollbar::draw_scrollbar,
 };
 
 /// Overview tab — connection list + stats sidebar. Reads every
@@ -414,44 +412,6 @@ fn draw_overview(
     Ok(())
 }
 
-/// Render a vertical scrollbar on the right edge of the table's row
-/// region when the row list overflows the viewport. `position` is the
-/// scroll offset of the topmost visible row; `viewport` is the number
-/// of rows currently visible. No-op when everything fits. Styled to
-/// match the section rules (and NO_COLOR-aware via `theme::fg`).
-fn draw_table_scrollbar(
-    f: &mut Frame,
-    area: Rect,
-    total_rows: usize,
-    position: usize,
-    viewport: usize,
-) {
-    if total_rows <= viewport {
-        return;
-    }
-    // ratatui sizes the thumb against `(content_length - 1) + viewport`, so the
-    // thumb only reaches the track bottom when `position == content_length - 1`
-    // (last row scrolled to the *top* of the viewport). Our `position` is a
-    // scroll offset clamped to `total_rows - viewport` (last row at the *bottom*
-    // of the viewport), so reporting `total_rows` as the content length leaves
-    // the thumb short by `viewport - 1` rows. Reporting the number of distinct
-    // scroll positions instead makes the thumb track the visible window
-    // `[position, position + viewport)` over `[0, total_rows)` and sit flush at
-    // the bottom when fully scrolled.
-    let scroll_positions = total_rows - viewport + 1;
-    let mut scrollbar_state = ScrollbarState::new(scroll_positions)
-        .position(position)
-        .viewport_content_length(viewport);
-    // Thumb in the default foreground so it matches the table content;
-    // only the track recedes into the chrome gray.
-    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-        .begin_symbol(None)
-        .end_symbol(None)
-        .track_style(theme::fg(theme::border()))
-        .thumb_style(Style::default());
-    f.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
-}
-
 fn draw_connections_list(
     f: &mut Frame,
     ui_state: &UIState,
@@ -508,7 +468,7 @@ fn draw_connections_list(
         area.width,
         area.height.saturating_sub(header_height),
     );
-    draw_table_scrollbar(f, rows_area, connections.len(), scroll_offset, visible_rows);
+    draw_scrollbar(f, rows_area, connections.len(), scroll_offset, visible_rows);
 
     // Register click regions for visible connection rows
     click_regions.scroll_area = Some(area);
@@ -656,7 +616,7 @@ fn draw_grouped_connections_list(
         area.width,
         area.height.saturating_sub(header_height),
     );
-    draw_table_scrollbar(
+    draw_scrollbar(
         f,
         rows_area,
         grouped_rows.len(),
@@ -1449,48 +1409,6 @@ mod tests {
         assert!(is_filter_backspace_char('\u{7f}', KeyModifiers::NONE));
         assert!(is_filter_backspace_char('h', KeyModifiers::CONTROL));
         assert!(!is_filter_backspace_char('h', KeyModifiers::NONE));
-    }
-
-    /// Render `draw_table_scrollbar` into a test buffer and report whether
-    /// any non-space glyph landed in the rightmost column (the scrollbar
-    /// track/thumb sits on the right border).
-    fn scrollbar_renders(total_rows: usize, position: usize, viewport: usize) -> bool {
-        use ratatui::Terminal;
-        use ratatui::backend::TestBackend;
-        use ratatui::layout::Rect;
-
-        let backend = TestBackend::new(20, 12);
-        let mut terminal = Terminal::new(backend).expect("test terminal");
-        terminal
-            .draw(|f| {
-                super::draw_table_scrollbar(
-                    f,
-                    Rect::new(0, 0, 20, 12),
-                    total_rows,
-                    position,
-                    viewport,
-                )
-            })
-            .expect("draw scrollbar");
-        let buffer = terminal.backend().buffer();
-        let right_x = 19;
-        (0..12).any(|y| buffer[(right_x, y)].symbol() != " ")
-    }
-
-    #[test]
-    fn scrollbar_hidden_when_content_fits() {
-        // 5 rows, 10-row viewport: nothing to scroll, no bar drawn.
-        assert!(!scrollbar_renders(5, 0, 10));
-        // Exactly fits is also a no-op.
-        assert!(!scrollbar_renders(10, 0, 10));
-    }
-
-    #[test]
-    fn scrollbar_shown_when_content_overflows() {
-        // 100 rows, 10-row viewport: bar must render on the right edge.
-        assert!(scrollbar_renders(100, 0, 10));
-        // Still drawn when scrolled into the middle of the list.
-        assert!(scrollbar_renders(100, 45, 10));
     }
 
     #[test]

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -4,5 +4,6 @@
 
 pub(super) mod filter_input;
 pub(super) mod loading;
+pub(super) mod scrollbar;
 pub(super) mod status_bar;
 pub(super) mod tabs_bar;

--- a/src/ui/widgets/scrollbar.rs
+++ b/src/ui/widgets/scrollbar.rs
@@ -1,0 +1,89 @@
+//! Shared vertical scrollbar for panes whose content can overflow:
+//! the Overview connection table, the Details info panes, the Help
+//! text, and the Interfaces table.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::Style,
+    widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState},
+};
+
+use crate::ui::theme;
+
+/// Render a vertical scrollbar on the right edge of `area` when the
+/// content overflows the viewport. `position` is the scroll offset of
+/// the topmost visible row; `viewport` is the number of rows currently
+/// visible. No-op when everything fits. Styled to match the section
+/// rules (and NO_COLOR-aware via `theme::fg`).
+pub(in crate::ui) fn draw_scrollbar(
+    f: &mut Frame,
+    area: Rect,
+    total_rows: usize,
+    position: usize,
+    viewport: usize,
+) {
+    if total_rows <= viewport {
+        return;
+    }
+    // ratatui sizes the thumb against `(content_length - 1) + viewport`, so the
+    // thumb only reaches the track bottom when `position == content_length - 1`
+    // (last row scrolled to the *top* of the viewport). Our `position` is a
+    // scroll offset clamped to `total_rows - viewport` (last row at the *bottom*
+    // of the viewport), so reporting `total_rows` as the content length leaves
+    // the thumb short by `viewport - 1` rows. Reporting the number of distinct
+    // scroll positions instead makes the thumb track the visible window
+    // `[position, position + viewport)` over `[0, total_rows)` and sit flush at
+    // the bottom when fully scrolled.
+    let scroll_positions = total_rows - viewport + 1;
+    let mut scrollbar_state = ScrollbarState::new(scroll_positions)
+        .position(position)
+        .viewport_content_length(viewport);
+    // Thumb in the default foreground so it matches the table content;
+    // only the track recedes into the chrome gray.
+    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+        .begin_symbol(None)
+        .end_symbol(None)
+        .track_style(theme::fg(theme::border()))
+        .thumb_style(Style::default());
+    f.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
+}
+
+#[cfg(test)]
+mod tests {
+    /// Render `draw_scrollbar` into a test buffer and report whether
+    /// any non-space glyph landed in the rightmost column (the scrollbar
+    /// track/thumb sits on the right border).
+    fn scrollbar_renders(total_rows: usize, position: usize, viewport: usize) -> bool {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::layout::Rect;
+
+        let backend = TestBackend::new(20, 12);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|f| {
+                super::draw_scrollbar(f, Rect::new(0, 0, 20, 12), total_rows, position, viewport)
+            })
+            .expect("draw scrollbar");
+        let buffer = terminal.backend().buffer();
+        let right_x = 19;
+        (0..12).any(|y| buffer[(right_x, y)].symbol() != " ")
+    }
+
+    #[test]
+    fn scrollbar_hidden_when_content_fits() {
+        // 5 rows, 10-row viewport: nothing to scroll, no bar drawn.
+        assert!(!scrollbar_renders(5, 0, 10));
+        // Exactly fits is also a no-op.
+        assert!(!scrollbar_renders(10, 0, 10));
+    }
+
+    #[test]
+    fn scrollbar_shown_when_content_overflows() {
+        // 100 rows, 10-row viewport: bar must render on the right edge.
+        assert!(scrollbar_renders(100, 0, 10));
+        // Still drawn when scrolled into the middle of the list.
+        assert!(scrollbar_renders(100, 45, 10));
+    }
+}

--- a/src/ui/widgets/status_bar.rs
+++ b/src/ui/widgets/status_bar.rs
@@ -16,9 +16,11 @@ fn default_status_line(selected_tab: usize) -> &'static str {
         }
         // Details
         1 => {
-            " 'h' help | 1-5 jump | Tab/[/] cycle | j/k prev/next | 'c' copy remote addr | Esc back"
+            " 'h' help | 1-5 jump | Tab/[/] cycle | j/k prev/next | Ctrl-d/u scroll | 'c' copy remote addr | Esc back"
         }
-        // Interfaces / Graph / Help
+        // Interfaces / Help (both scroll with j/k)
+        2 | 4 => " 'h' help | 1-5 jump | Tab/[/] cycle | j/k scroll | Esc back to Overview",
+        // Graph
         _ => " 'h' help | 1-5 jump | Tab/[/] cycle | Esc back to Overview",
     }
 }


### PR DESCRIPTION
## What

- Details, Help, and Interfaces tabs now scroll (mouse wheel, vim keys, Ctrl-d/u on Details) with scrollbars. Overflowing content was silently clipped before.
- Traffic chart renders RX/TX as filled areas (ratatui 0.30 `GraphType::Area`), larger series drawn first so both stay visible.
- Connections sparkline bottom now aligns with the traffic chart plot.

## Notes

- New `PaneScroll` handles panes whose content height is only known at render time. Details scroll resets when the selection changes, and click-to-copy regions track the scroll offset.
- Snapshots updated. 87 tests and clippy clean.