### PR TITLE
fix(dpi): correct protocol detection switches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "rustnet-capture"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "log",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "rustnet-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "rustnet-host"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "libbpf-cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 # `<field>.workspace = true`. The binary keeps its own `version` (it tracks the
 # user-facing 1.x release line, independent of the 0.x library crates).
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 authors = ["domcyrus"]
 edition = "2024"
 rust-version = "1.88.0" # Let-chains require Rust 1.88.0+
@@ -19,9 +19,9 @@ license = "Apache-2.0"
 # instead of one edit per member manifest. Members reference these with
 # `<dep>.workspace = true`.
 [workspace.dependencies]
-rustnet-core = { version = "0.2.0", path = "crates/rustnet-core" }
-rustnet-capture = { version = "0.2.0", path = "crates/rustnet-capture" }
-rustnet-host = { version = "0.2.0", path = "crates/rustnet-host" }
+rustnet-core = { version = "0.3.0", path = "crates/rustnet-core" }
+rustnet-capture = { version = "0.3.0", path = "crates/rustnet-capture" }
+rustnet-host = { version = "0.3.0", path = "crates/rustnet-host" }
 anyhow = "1.0"
 log = "0.4"
 

--- a/crates/rustnet-core/src/network/dpi/bittorrent.rs
+++ b/crates/rustnet-core/src/network/dpi/bittorrent.rs
@@ -190,6 +190,17 @@ fn analyze_utp(payload: &[u8]) -> Option<BitTorrentInfo> {
         return None;
     }
 
+    // Real uTP connection IDs are randomly generated, so 0 is effectively
+    // never seen — but bytes 2-3 == 0 is exactly what a WireGuard handshake
+    // initiation looks like here (type byte 0x01 followed by three reserved
+    // zero bytes). Since this check runs on every unmatched UDP packet,
+    // require a non-zero connection ID so WireGuard rekeys are not
+    // classified as BitTorrent.
+    let connection_id = u16::from_be_bytes([payload[2], payload[3]]);
+    if connection_id == 0 {
+        return None;
+    }
+
     // Window size sanity check — 0 is valid for ST_RESET but otherwise should be non-zero
     let wnd_size = u32::from_be_bytes([payload[12], payload[13], payload[14], payload[15]]);
     if pkt_type != 3 && wnd_size == 0 {
@@ -517,9 +528,27 @@ mod tests {
         let mut payload = vec![0u8; UTP_HEADER_LEN];
         payload[0] = (pkt_type << 4) | (version & 0x0F);
         payload[1] = extension;
+        // connection_id at bytes 2-3: always random (non-zero) in real uTP
+        payload[2..4].copy_from_slice(&0x1234u16.to_be_bytes());
         // wnd_size at bytes 12-15
         payload[12..16].copy_from_slice(&wnd_size.to_be_bytes());
         payload
+    }
+
+    #[test]
+    fn test_utp_rejects_wireguard_handshake_initiation() {
+        // WireGuard handshake initiation: message type 0x01, three reserved
+        // zero bytes, then a random sender index and ephemeral key. It
+        // passes every other uTP field check (version 1, type ST_DATA,
+        // extension 0, non-zero bytes at the wnd_size position), so the
+        // zero connection-id bytes are what must reject it.
+        let mut payload = vec![0u8; 148];
+        payload[0] = 0x01; // type=1 (handshake initiation), reserved bytes 1-3 zero
+        for (i, byte) in payload.iter_mut().enumerate().skip(4) {
+            *byte = (i * 31 % 251 + 1) as u8; // arbitrary non-zero key material
+        }
+        assert!(analyze_utp(&payload).is_none());
+        assert!(analyze_udp_bittorrent(&payload).is_none());
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/dpi/dns.rs
+++ b/crates/rustnet-core/src/network/dpi/dns.rs
@@ -68,6 +68,7 @@ fn skip_dns_name(payload: &[u8], start: usize) -> Option<usize> {
 fn parse_question(payload: &[u8], start: usize) -> (Option<String>, Option<DnsQueryType>, usize) {
     let mut offset = start;
     let mut name = String::new();
+    let mut name_over_limit = false;
 
     // Parse domain name (label-by-label, with light pointer handling — we
     // only need to terminate the walk, not fully resolve compressed labels).
@@ -95,17 +96,22 @@ fn parse_question(payload: &[u8], start: usize) -> (Option<String>, Option<DnsQu
             break;
         }
 
-        if !name.is_empty() {
-            name.push('.');
-        }
+        if !name_over_limit {
+            if !name.is_empty() {
+                name.push('.');
+            }
 
-        if let Ok(label) = std::str::from_utf8(&payload[offset + 1..offset + 1 + label_len]) {
-            name.push_str(label);
-        }
+            if let Ok(label) = std::str::from_utf8(&payload[offset + 1..offset + 1 + label_len]) {
+                name.push_str(label);
+            }
 
-        // Enforce RFC 1035 maximum name length.
-        if name.len() > MAX_DNS_NAME_LEN {
-            break;
+            // Enforce RFC 1035 maximum name length: stop accumulating, but
+            // keep walking the remaining labels so `offset` ends up past the
+            // whole QNAME — otherwise QTYPE/QCLASS would be read from name
+            // bytes and report a fabricated query type.
+            if name.len() > MAX_DNS_NAME_LEN {
+                name_over_limit = true;
+            }
         }
 
         offset += 1 + label_len;
@@ -414,6 +420,9 @@ mod tests {
             // Name should be truncated near the RFC limit, not the full 630+ chars
             assert!(name.len() <= MAX_DNS_NAME_LEN + 63 + 1);
         }
+        // The walk must still consume the whole QNAME so QTYPE is read from
+        // the right offset — not fabricated from mid-name bytes.
+        assert_eq!(info.query_type, Some(DnsQueryType::A));
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/dpi/ftp.rs
+++ b/crates/rustnet-core/src/network/dpi/ftp.rs
@@ -27,30 +27,38 @@ const FTP_COMMANDS: &[&str] = &[
     "SIZE", "MDTM", "MLSD", "MLST",
 ];
 
+/// Commands accepted by the port-independent signature check. This is the
+/// subset of [`FTP_COMMANDS`] that no other common line-based protocol
+/// shares: SMTP claims `AUTH`/`QUIT`/`NOOP`/`HELP`, POP3 claims
+/// `USER`/`PASS`/`STAT`/`LIST`/`RETR`/`DELE`, and NNTP claims `MODE`, so
+/// matching those off port 21 would label mail and news flows as FTP.
+const FTP_DISTINCTIVE_COMMANDS: &[&str] = &[
+    "ACCT", "CWD", "CDUP", "SMNT", "REIN", "PORT", "PASV", "TYPE", "STRU", "STOR", "STOU", "APPE",
+    "ALLO", "REST", "RNFR", "RNTO", "ABOR", "RMD", "MKD", "PWD", "NLST", "SITE", "SYST", "FEAT",
+    "OPTS", "EPSV", "EPRT", "PBSZ", "PROT", "CCC", "SIZE", "MDTM", "MLSD", "MLST",
+];
+
 /// Cheap heuristic that returns `true` when a payload's first line plausibly
 /// belongs to the FTP control channel. Used so non-standard-port flows can
 /// still be classified.
+///
+/// Only distinctively-FTP commands count as a signature. Server replies
+/// (`220 <banner>`) are deliberately NOT matched here: the 3-digit reply
+/// grammar is shared verbatim by SMTP, POP3-era protocols, and NNTP, so
+/// off port 21 a reply line carries no FTP signal. Replies are still parsed
+/// by [`analyze_ftp`] on the port-21 path.
 pub fn is_ftp(payload: &[u8]) -> bool {
     let line = first_line(payload);
     if line.is_empty() {
         return false;
     }
-    // Server response: 3-digit code, then space or '-' (continuation marker).
-    if line.len() >= 4
-        && line[0].is_ascii_digit()
-        && line[1].is_ascii_digit()
-        && line[2].is_ascii_digit()
-        && (line[3] == b' ' || line[3] == b'-')
-    {
-        return true;
-    }
-    // Client request: known command (case-insensitive) followed by space, CRLF,
-    // or end-of-line.
     let upper = first_token_upper(line);
     if upper.is_empty() {
         return false;
     }
-    FTP_COMMANDS.iter().any(|cmd| cmd.as_bytes() == upper)
+    FTP_DISTINCTIVE_COMMANDS
+        .iter()
+        .any(|cmd| cmd.as_bytes() == upper)
 }
 
 /// Parse an FTP control-channel payload. Returns `None` when the payload does
@@ -71,6 +79,11 @@ pub fn analyze_ftp(payload: &[u8]) -> Option<FtpInfo> {
         && (line[3] == b' ' || line[3] == b'-')
     {
         let code = std::str::from_utf8(&line[0..3]).ok()?.parse::<u16>().ok()?;
+        // RFC 959 §4.2: the first digit is 1-5 and the second 0-5. Anything
+        // else ("999 hi") is not an FTP reply.
+        if !(1..=5).contains(&(code / 100)) || (code / 10) % 10 > 5 {
+            return None;
+        }
         let is_continuation = line[3] == b'-';
         let message = std::str::from_utf8(&line[4..])
             .ok()
@@ -208,8 +221,10 @@ mod tests {
 
     #[test]
     fn detects_server_greeting() {
+        // Replies are parsed on the port-21 path but are NOT a signature:
+        // the 3-digit grammar is shared with SMTP/POP3/NNTP.
         let payload = b"220 ProFTPD 1.3.7 Server (Example) [::ffff:10.0.0.1]\r\n";
-        assert!(is_ftp(payload));
+        assert!(!is_ftp(payload));
         let info = analyze_ftp(payload).expect("should parse");
         assert!(matches!(info.message_type, FtpMessageType::Response));
         assert_eq!(info.response_code, Some(220));
@@ -219,9 +234,32 @@ mod tests {
     #[test]
     fn detects_continuation_response() {
         let payload = b"220-Welcome to the FTP service.\r\n220 Ready.\r\n";
-        assert!(is_ftp(payload));
+        assert!(!is_ftp(payload));
         let info = analyze_ftp(payload).expect("should parse");
         assert_eq!(info.response_code, Some(220));
+    }
+
+    #[test]
+    fn signature_ignores_verbs_shared_with_mail_protocols() {
+        // SMTP traffic must not be classified as FTP off port 21.
+        assert!(!is_ftp(b"220 smtp.gmail.com ESMTP x1234\r\n"));
+        assert!(!is_ftp(b"EHLO mail.example.com\r\n"));
+        assert!(!is_ftp(b"AUTH LOGIN\r\n"));
+        // POP3 shares USER/PASS/RETR/LIST/DELE with FTP.
+        assert!(!is_ftp(b"USER alice\r\n"));
+        assert!(!is_ftp(b"RETR 1\r\n"));
+        // Distinctively-FTP commands still trigger the signature.
+        assert!(is_ftp(b"PASV\r\n"));
+        assert!(is_ftp(b"TYPE I\r\n"));
+        assert!(is_ftp(b"cwd /pub\r\n"));
+    }
+
+    #[test]
+    fn rejects_out_of_range_reply_codes() {
+        // RFC 959 reply codes are 1xx-5xx with second digit 0-5.
+        assert!(analyze_ftp(b"999 hello\r\n").is_none());
+        assert!(analyze_ftp(b"090 hello\r\n").is_none());
+        assert!(analyze_ftp(b"260-x\r\n").is_none());
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/dpi/http.rs
+++ b/crates/rustnet-core/src/network/dpi/http.rs
@@ -23,24 +23,31 @@ pub fn analyze_http(payload: &[u8]) -> Option<HttpInfo> {
     let mut lines = text.lines();
     let first_line = lines.next()?;
     // Consume the first-line tokens lazily via iterator to avoid the
-    // `split_whitespace().collect::<Vec<_>>()` heap allocation. HTTP start
-    // lines always have exactly 3 SP-delimited tokens (RFC 9112 §3), so
-    // three consecutive `next()` calls are sufficient — no Vec needed.
+    // `split_whitespace().collect::<Vec<_>>()` heap allocation. Requests
+    // have exactly 3 SP-delimited tokens; responses have 2 or 3 since the
+    // reason phrase is optional (RFC 9112 §4).
     let mut tokens = first_line.split_whitespace();
-    let (tok0, tok1, tok2) = match (tokens.next(), tokens.next(), tokens.next()) {
-        (Some(a), Some(b), Some(c)) => (a, b, c),
+    let (tok0, tok1) = match (tokens.next(), tokens.next()) {
+        (Some(a), Some(b)) => (a, b),
         _ => return None,
     };
 
     if first_line.starts_with("HTTP/") {
-        // Response line: HTTP/1.1 200 OK
-        info.version = parse_http_version(tok0);
-        info.status_code = tok1.parse::<u16>().ok();
+        // Response line: HTTP/1.1 200 OK — the reason phrase may be empty,
+        // but the status code must be a 3-digit number.
+        info.version = parse_http_version(tok0)?;
+        info.status_code = Some(
+            tok1.parse::<u16>()
+                .ok()
+                .filter(|c| (100..=599).contains(c))?,
+        );
     } else if is_http_method(tok0) {
-        // Request line: GET /path HTTP/1.1
+        // Request line: GET /path HTTP/1.1. The version token is required:
+        // SIP and RTSP share the same verbs ("OPTIONS sip:bob@example.com
+        // SIP/2.0"), so a method match alone is not HTTP.
+        info.version = parse_http_version(tokens.next()?)?;
         info.method = Some(tok0.to_string());
         info.path = Some(tok1.to_string());
-        info.version = parse_http_version(tok2);
     } else {
         return None; // Not valid HTTP
     }
@@ -97,12 +104,12 @@ fn is_http_method(s: &str) -> bool {
     )
 }
 
-fn parse_http_version(s: &str) -> HttpVersion {
+fn parse_http_version(s: &str) -> Option<HttpVersion> {
     match s {
-        "HTTP/1.0" => HttpVersion::Http10,
-        "HTTP/1.1" => HttpVersion::Http11,
-        "HTTP/2" => HttpVersion::Http2,
-        _ => HttpVersion::Http11,
+        "HTTP/1.0" => Some(HttpVersion::Http10),
+        "HTTP/1.1" => Some(HttpVersion::Http11),
+        "HTTP/2" => Some(HttpVersion::Http2),
+        _ => None,
     }
 }
 
@@ -139,14 +146,11 @@ mod tests {
         assert_eq!(info.path.as_deref(), Some("/api/v1/upload"));
         assert_eq!(info.host.as_deref(), Some("api.example.com"));
 
-        // A start line with fewer than 3 whitespace-delimited tokens must be
-        // rejected; this guards against the lazy `next()` chain silently
-        // accepting truncated lines that the old `parts.len() >= 3` guard
-        // would also have rejected.
-        let truncated: [&[u8]; 3] = [
+        // A truncated request line must be rejected: requests need all
+        // three tokens (method, target, version).
+        let truncated: [&[u8]; 2] = [
             b"GET /index.html\r\n\r\n", // only 2 tokens
             b"GET\r\n\r\n",             // only 1 token
-            b"HTTP/1.1 200\r\n\r\n",    // only 2 tokens (response, no reason phrase)
         ];
         for payload in &truncated {
             assert!(
@@ -155,6 +159,31 @@ mod tests {
                 std::str::from_utf8(payload).unwrap_or("<invalid utf8>")
             );
         }
+    }
+
+    #[test]
+    fn test_http_response_without_reason_phrase() {
+        // RFC 9112 §4: the reason phrase is optional. Real servers emit
+        // `HTTP/1.1 200 \r\n` (empty phrase) and some omit the trailing
+        // space entirely; both are valid responses.
+        for payload in [b"HTTP/1.1 200\r\n\r\n".as_slice(), b"HTTP/1.1 200 \r\n\r\n"] {
+            let info = analyze_http(payload).expect("reason phrase is optional");
+            assert_eq!(info.status_code, Some(200));
+        }
+    }
+
+    #[test]
+    fn test_non_http_text_protocols_rejected() {
+        // SIP and RTSP share request verbs with HTTP; the version token
+        // must be validated so they are not misclassified.
+        let sip = b"OPTIONS sip:bob@example.com SIP/2.0\r\nVia: SIP/2.0/TCP host\r\n\r\n";
+        assert!(analyze_http(sip).is_none());
+
+        let rtsp = b"OPTIONS rtsp://cam.local/stream RTSP/1.0\r\nCSeq: 1\r\n\r\n";
+        assert!(analyze_http(rtsp).is_none());
+
+        // A response-shaped line with a non-numeric status is not HTTP.
+        assert!(analyze_http(b"HTTP/1.1 OK 200\r\n\r\n").is_none());
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/dpi/mod.rs
+++ b/crates/rustnet-core/src/network/dpi/mod.rs
@@ -104,8 +104,9 @@ pub fn analyze_tcp_packet(
     }
 
     // 6. Check for FTP control channel (port 21 plaintext / AUTH TLS upgrade,
-    //    or signature). Runs before more generic protocols since the start
-    //    line is unambiguous (3-digit reply code OR a small known command set).
+    //    or signature). Off port 21 only distinctively-FTP commands count as
+    //    a signature; 3-digit reply lines are shared with SMTP/POP3/NNTP and
+    //    are only classified on port 21.
     //
     //    Implicit FTPS on port 990 is intentionally NOT routed here: that
     //    flow is TLS from the very first byte and falls through to the

--- a/crates/rustnet-core/src/network/dpi/mqtt.rs
+++ b/crates/rustnet-core/src/network/dpi/mqtt.rs
@@ -10,26 +10,23 @@ pub fn is_mqtt_packet(payload: &[u8]) -> bool {
     let packet_type = payload[0] >> 4;
     let flags = payload[0] & 0x0F;
 
-    // Valid MQTT packet types are 1-14
-    if !(1..=14).contains(&packet_type) {
+    // Valid MQTT packet types are 1-15 (AUTH=15 was added in MQTT 5)
+    if !(1..=15).contains(&packet_type) {
         return false;
     }
 
-    // Validate flags for packet types with fixed flag requirements (MQTT spec §2.1.2)
-    match packet_type {
-        1 | 2 | 4 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 => {
-            // CONNECT, CONNACK, PUBACK, PUBREL, PUBCOMP, SUBACK, UNSUBACK,
-            // PINGREQ/RESP, DISCONNECT must have flags = 0, except SUBSCRIBE(8)
-            // and UNSUBSCRIBE(10) which must have 0x02.
-            let expected = match packet_type {
-                8 | 10 => 0x02, // SUBSCRIBE, UNSUBSCRIBE require bit 1 set
-                _ => 0x00,
-            };
-            if flags != expected {
-                return false;
-            }
+    // Validate flags for packet types with fixed flag requirements (MQTT
+    // spec §2.1.2): every type except PUBLISH(3), whose flags carry
+    // DUP/QoS/RETAIN, has reserved flags — 0x02 for PUBREL(6),
+    // SUBSCRIBE(8), and UNSUBSCRIBE(10), 0x00 for the rest.
+    if packet_type != 3 {
+        let expected = match packet_type {
+            6 | 8 | 10 => 0x02,
+            _ => 0x00,
+        };
+        if flags != expected {
+            return false;
         }
-        _ => {} // PUBLISH(3), PUBREC(5) — flags carry DUP/QoS/RETAIN
     }
 
     // Validate remaining length encoding and check it's plausible
@@ -69,6 +66,9 @@ pub fn analyze_mqtt(payload: &[u8]) -> Option<MqttInfo> {
         2 => MqttPacketType::Connack,
         3 => MqttPacketType::Publish,
         4 => MqttPacketType::Puback,
+        5 => MqttPacketType::Pubrec,
+        6 => MqttPacketType::Pubrel,
+        7 => MqttPacketType::Pubcomp,
         8 => MqttPacketType::Subscribe,
         9 => MqttPacketType::Suback,
         10 => MqttPacketType::Unsubscribe,
@@ -76,6 +76,7 @@ pub fn analyze_mqtt(payload: &[u8]) -> Option<MqttInfo> {
         12 => MqttPacketType::Pingreq,
         13 => MqttPacketType::Pingresp,
         14 => MqttPacketType::Disconnect,
+        15 => MqttPacketType::Auth,
         _ => return None,
     };
 
@@ -436,11 +437,36 @@ mod tests {
     }
 
     #[test]
-    fn test_type_15_invalid() {
-        // Type 15 is reserved
+    fn test_type_15_auth() {
+        // Type 15 is AUTH in MQTT 5. Not signature-detected (only CONNECT
+        // is), but the port-based path must classify it.
         let pkt = vec![0xF0, 0x00];
         assert!(!is_mqtt_packet(&pkt));
-        assert!(analyze_mqtt(&pkt).is_none());
+        let info = analyze_mqtt(&pkt).unwrap();
+        assert_eq!(info.packet_type, MqttPacketType::Auth);
+    }
+
+    #[test]
+    fn test_qos2_flow_packets() {
+        // PUBREC / PUBREL / PUBCOMP make up the QoS 2 delivery flow;
+        // PUBREL carries the reserved flags 0x02 (MQTT spec §2.1.2).
+        let pubrec = vec![0x50, 0x02, 0x00, 0x01];
+        assert_eq!(
+            analyze_mqtt(&pubrec).unwrap().packet_type,
+            MqttPacketType::Pubrec
+        );
+
+        let pubrel = vec![0x62, 0x02, 0x00, 0x01];
+        assert_eq!(
+            analyze_mqtt(&pubrel).unwrap().packet_type,
+            MqttPacketType::Pubrel
+        );
+
+        let pubcomp = vec![0x70, 0x02, 0x00, 0x01];
+        assert_eq!(
+            analyze_mqtt(&pubcomp).unwrap().packet_type,
+            MqttPacketType::Pubcomp
+        );
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/dpi/netbios.rs
+++ b/crates/rustnet-core/src/network/dpi/netbios.rs
@@ -7,8 +7,14 @@ use crate::network::types::{NetBiosInfo, NetBiosOpcode, NetBiosService};
 /// Minimum NetBIOS Name Service packet size
 const MIN_NBNS_SIZE: usize = 12;
 
-/// Minimum NetBIOS Datagram Service packet size
-const MIN_NBDGM_SIZE: usize = 14;
+/// Datagram Service header sizes per RFC 1002 §4.4: DIRECT_UNIQUE /
+/// DIRECT_GROUP / BROADCAST messages have a 14-byte header (through
+/// PACKET_OFFSET), QUERY REQUEST/RESPONSE messages a 10-byte header
+/// (through SOURCE_PORT), and a DATAGRAM ERROR is 11 bytes (10-byte
+/// header plus the error code).
+const NBDGM_DIRECT_HEADER: usize = 14;
+const NBDGM_QUERY_HEADER: usize = 10;
+const NBDGM_ERROR_SIZE: usize = 11;
 
 /// Analyze a NetBIOS Name Service packet (UDP port 137).
 ///
@@ -49,31 +55,44 @@ pub fn analyze_netbios_ns(payload: &[u8]) -> Option<NetBiosInfo> {
 ///
 /// Returns `None` if the packet is too small or invalid.
 pub fn analyze_netbios_dgm(payload: &[u8]) -> Option<NetBiosInfo> {
-    if payload.len() < MIN_NBDGM_SIZE {
+    // Message type at byte 0
+    let msg_type = *payload.first()?;
+
+    // RFC 1002 §4.4: header size — and therefore where the encoded name
+    // starts — depends on the message type.
+    let (opcode, min_size, name_offset) = match msg_type {
+        // §4.4.1 DIRECT_UNIQUE / DIRECT_GROUP / BROADCAST: message
+        // delivery, SOURCE_NAME follows the 14-byte header
+        0x10..=0x12 => (
+            NetBiosOpcode::Datagram,
+            NBDGM_DIRECT_HEADER,
+            Some(NBDGM_DIRECT_HEADER),
+        ),
+        // §4.4.2 DATAGRAM ERROR: header + error code, no name
+        0x13 => (NetBiosOpcode::Error, NBDGM_ERROR_SIZE, None),
+        // §4.4.3 DATAGRAM QUERY REQUEST: DESTINATION_NAME follows the
+        // 10-byte header
+        0x14 => (
+            NetBiosOpcode::Query,
+            NBDGM_QUERY_HEADER,
+            Some(NBDGM_QUERY_HEADER),
+        ),
+        // §4.4.3 POSITIVE / NEGATIVE QUERY RESPONSE
+        0x15 | 0x16 => (
+            NetBiosOpcode::Response,
+            NBDGM_QUERY_HEADER,
+            Some(NBDGM_QUERY_HEADER),
+        ),
+        other => (NetBiosOpcode::Unknown(other), NBDGM_QUERY_HEADER, None),
+    };
+
+    if payload.len() < min_size {
         return None;
     }
 
-    // Message type at byte 0
-    let msg_type = payload[0];
-
-    // Map message type to opcode
-    let opcode = match msg_type {
-        0x10 => NetBiosOpcode::Query,        // Direct unique datagram
-        0x11 => NetBiosOpcode::Query,        // Direct group datagram
-        0x12 => NetBiosOpcode::Registration, // Broadcast datagram
-        0x13 => NetBiosOpcode::Query,        // Datagram error
-        0x14 => NetBiosOpcode::Query,        // Datagram query request
-        0x15 => NetBiosOpcode::Response,     // Datagram positive query response
-        0x16 => NetBiosOpcode::Response,     // Datagram negative query response
-        _ => NetBiosOpcode::Unknown(msg_type),
-    };
-
-    // Try to extract source name from offset 14 if available
-    let name = if payload.len() > 14 {
-        decode_netbios_name(&payload[14..])
-    } else {
-        None
-    };
+    let name = name_offset
+        .and_then(|off| payload.get(off..))
+        .and_then(decode_netbios_name);
 
     Some(NetBiosInfo {
         service: NetBiosService::DatagramService,
@@ -230,11 +249,47 @@ mod tests {
 
     #[test]
     fn test_nbdgm_direct() {
-        let mut packet = vec![0u8; 20];
+        let mut packet = vec![0u8; 14];
         packet[0] = 0x10; // Direct unique datagram
+        packet.extend_from_slice(&encode_netbios_name("SENDERPC")); // SOURCE_NAME
         let info = analyze_netbios_dgm(&packet).expect("should parse");
         assert_eq!(info.service, NetBiosService::DatagramService);
+        assert_eq!(info.opcode, NetBiosOpcode::Datagram);
+        assert_eq!(info.name, Some("SENDERPC".to_string()));
+    }
+
+    #[test]
+    fn test_nbdgm_broadcast_is_datagram_not_registration() {
+        // 0x12 is a broadcast datagram (RFC 1002 §4.4.1) — it has nothing
+        // to do with NBNS name registration.
+        let mut packet = vec![0u8; 14];
+        packet[0] = 0x12;
+        let info = analyze_netbios_dgm(&packet).expect("should parse");
+        assert_eq!(info.opcode, NetBiosOpcode::Datagram);
+    }
+
+    #[test]
+    fn test_nbdgm_query_request_name_at_offset_10() {
+        // §4.4.3 messages have a 10-byte header; DESTINATION_NAME starts at
+        // offset 10, not 14.
+        let mut packet = vec![0u8; 10];
+        packet[0] = 0x14; // DATAGRAM QUERY REQUEST
+        packet.extend_from_slice(&encode_netbios_name("FILESERVER"));
+        let info = analyze_netbios_dgm(&packet).expect("should parse");
         assert_eq!(info.opcode, NetBiosOpcode::Query);
+        assert_eq!(info.name, Some("FILESERVER".to_string()));
+    }
+
+    #[test]
+    fn test_nbdgm_error_datagram() {
+        // A spec-conformant DATAGRAM ERROR is exactly 11 bytes
+        // (§4.4.2: 10-byte header + 1-byte error code).
+        let mut packet = vec![0u8; 11];
+        packet[0] = 0x13;
+        packet[10] = 0x82; // ERR_SOURCE_NAME_BAD_FORMAT
+        let info = analyze_netbios_dgm(&packet).expect("should parse");
+        assert_eq!(info.opcode, NetBiosOpcode::Error);
+        assert_eq!(info.name, None);
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/dpi/quic.rs
+++ b/crates/rustnet-core/src/network/dpi/quic.rs
@@ -1038,12 +1038,12 @@ fn scan_packet_frames(
                 } else {
                     None
                 };
-                offset = reason_end;
-                if offset > payload.len() {
-                    break;
-                }
 
-                // Store CONNECTION_CLOSE information in quic_info
+                // Store CONNECTION_CLOSE information in quic_info. This must
+                // happen before the truncation check below: the error code
+                // and frame type were parsed validly even when the reason
+                // phrase is cut off, and dropping them would lose the
+                // Draining/Closed state transition.
                 quic_info.connection_close = Some(crate::network::types::QuicCloseInfo {
                     frame_type: frame_type_byte,
                     error_code,
@@ -1062,6 +1062,11 @@ fn scan_packet_frames(
                     "QUIC: Detected CONNECTION_CLOSE frame type 0x{:02x}, error_code: {}, reason: {:?}",
                     frame_type_byte, error_code, reason
                 );
+
+                offset = reason_end;
+                if offset > payload.len() {
+                    break;
+                }
             }
 
             0x1e => {

--- a/crates/rustnet-core/src/network/dpi/snmp.rs
+++ b/crates/rustnet-core/src/network/dpi/snmp.rs
@@ -62,32 +62,32 @@ pub fn analyze_snmp(payload: &[u8]) -> Option<SnmpInfo> {
     let version = parse_version(&payload[offset..offset + version_len])?;
     offset += version_len;
 
-    // Parse community string for v1/v2c (OCTET STRING)
-    let community = if matches!(version, SnmpVersion::V1 | SnmpVersion::V2c) {
-        if offset >= payload.len() || payload[offset] != BER_OCTET_STRING {
-            None
-        } else {
+    // Parse community string for v1/v2c (OCTET STRING). It is mandatory in
+    // both versions (RFC 1157 §4, RFC 3416), so its absence means the
+    // payload is not SNMP.
+    let (community, pdu_type) = match version {
+        SnmpVersion::V1 | SnmpVersion::V2c => {
+            if offset >= payload.len() || payload[offset] != BER_OCTET_STRING {
+                return None;
+            }
             offset += 1;
             let (comm_len, len_bytes) = parse_ber_length(&payload[offset..])?;
             offset += len_bytes;
 
             if offset + comm_len > payload.len() {
-                None
-            } else {
-                let community_bytes = &payload[offset..offset + comm_len];
-                offset += comm_len;
-                std::str::from_utf8(community_bytes)
-                    .ok()
-                    .map(|s| s.to_string())
+                return None;
             }
-        }
-    } else {
-        // v3 has different structure - skip community
-        None
-    };
+            let community_bytes = &payload[offset..offset + comm_len];
+            offset += comm_len;
+            let community = std::str::from_utf8(community_bytes)
+                .ok()
+                .map(|s| s.to_string());
 
-    // Find PDU type (context-specific tag 0xA0-0xA8)
-    let pdu_type = find_pdu_type(&payload[offset..])?;
+            // The PDU tag directly follows the community string.
+            (community, pdu_type_at(payload, offset)?)
+        }
+        SnmpVersion::V3 => (None, v3_pdu_type(payload, offset)?),
+    };
 
     Some(SnmpInfo {
         version,
@@ -142,28 +142,59 @@ fn parse_version(data: &[u8]) -> Option<SnmpVersion> {
     }
 }
 
-/// Find the PDU type in the remaining data
-fn find_pdu_type(data: &[u8]) -> Option<SnmpPduType> {
-    // Look for context-specific tags (0xA0-0xA8). Single pass: the match
-    // both gates non-PDU bytes (via `_ => continue`) and converts the tag
-    // into its variant, so we no longer carry a dead `Unknown(other)` arm
-    // shadowed by the outer range check.
-    for &byte in data.iter().take(50) {
-        let pdu_type = match byte {
-            PDU_GET_REQUEST => SnmpPduType::GetRequest,
-            PDU_GET_NEXT_REQUEST => SnmpPduType::GetNextRequest,
-            PDU_GET_RESPONSE => SnmpPduType::GetResponse,
-            PDU_SET_REQUEST => SnmpPduType::SetRequest,
-            PDU_TRAP_V1 => SnmpPduType::Trap,
-            PDU_GET_BULK_REQUEST => SnmpPduType::GetBulkRequest,
-            PDU_INFORM_REQUEST => SnmpPduType::InformRequest,
-            PDU_TRAP_V2 => SnmpPduType::TrapV2,
-            PDU_REPORT => SnmpPduType::Report,
-            _ => continue,
-        };
-        return Some(pdu_type);
+/// Read the PDU tag expected at exactly `offset`. Structural — never scans:
+/// a byte in the 0xA0-0xA8 range inside a length or INTEGER value (e.g. a
+/// request-id) must not be mistaken for a PDU tag.
+fn pdu_type_at(payload: &[u8], offset: usize) -> Option<SnmpPduType> {
+    let pdu_type = match *payload.get(offset)? {
+        PDU_GET_REQUEST => SnmpPduType::GetRequest,
+        PDU_GET_NEXT_REQUEST => SnmpPduType::GetNextRequest,
+        PDU_GET_RESPONSE => SnmpPduType::GetResponse,
+        PDU_SET_REQUEST => SnmpPduType::SetRequest,
+        PDU_TRAP_V1 => SnmpPduType::Trap,
+        PDU_GET_BULK_REQUEST => SnmpPduType::GetBulkRequest,
+        PDU_INFORM_REQUEST => SnmpPduType::InformRequest,
+        PDU_TRAP_V2 => SnmpPduType::TrapV2,
+        PDU_REPORT => SnmpPduType::Report,
+        _ => return None,
+    };
+    Some(pdu_type)
+}
+
+/// Walk the SNMPv3 message structure (RFC 3412 §6) to the PDU tag:
+/// msgGlobalData (SEQUENCE) and msgSecurityParameters (OCTET STRING) are
+/// skipped whole, then msgData is either a plaintext ScopedPDU — a SEQUENCE
+/// holding contextEngineID, contextName, and the PDU — or an encrypted
+/// OCTET STRING, in which case the PDU type is not visible.
+fn v3_pdu_type(payload: &[u8], offset: usize) -> Option<SnmpPduType> {
+    let offset = skip_tlv(payload, offset, BER_SEQUENCE)?; // msgGlobalData
+    let offset = skip_tlv(payload, offset, BER_OCTET_STRING)?; // msgSecurityParameters
+
+    match *payload.get(offset)? {
+        BER_SEQUENCE => {
+            // Plaintext ScopedPDU: enter the SEQUENCE, then skip
+            // contextEngineID and contextName.
+            let mut offset = offset + 1;
+            let (_, len_bytes) = parse_ber_length(&payload[offset..])?;
+            offset += len_bytes;
+            let offset = skip_tlv(payload, offset, BER_OCTET_STRING)?; // contextEngineID
+            let offset = skip_tlv(payload, offset, BER_OCTET_STRING)?; // contextName
+            pdu_type_at(payload, offset)
+        }
+        BER_OCTET_STRING => Some(SnmpPduType::Encrypted),
+        _ => None,
     }
-    None
+}
+
+/// Skip one TLV with the expected tag, returning the offset just past it.
+fn skip_tlv(payload: &[u8], offset: usize, expected_tag: u8) -> Option<usize> {
+    if *payload.get(offset)? != expected_tag {
+        return None;
+    }
+    let offset = offset + 1;
+    let (len, len_bytes) = parse_ber_length(&payload[offset..])?;
+    let end = offset.checked_add(len_bytes)?.checked_add(len)?;
+    (end <= payload.len()).then_some(end)
 }
 
 #[cfg(test)]
@@ -299,25 +330,95 @@ mod tests {
         assert_eq!(bytes, 3);
     }
 
-    #[test]
-    fn test_find_pdu_type_skips_non_pdu_bytes() {
-        // Leading bytes are non-PDU (request-ID INTEGER, length, etc.);
-        // the scan must skip past them and land on the GetBulkRequest tag.
-        let data = [0x02, 0x04, 0x00, 0x00, 0x00, 0x07, PDU_GET_BULK_REQUEST];
-        assert_eq!(find_pdu_type(&data), Some(SnmpPduType::GetBulkRequest));
+    /// Build an SNMPv3 message. `scoped_pdu_plaintext` selects between a
+    /// plaintext ScopedPDU (carrying a GetRequest) and an encrypted one.
+    fn build_snmp_v3(scoped_pdu_plaintext: bool) -> Vec<u8> {
+        let mut packet = Vec::new();
+
+        packet.push(BER_SEQUENCE);
+        let len_pos = packet.len();
+        packet.push(0x00);
+
+        // Version: INTEGER 3 (v3)
+        packet.push(BER_INTEGER);
+        packet.push(0x01);
+        packet.push(0x03);
+
+        // msgGlobalData SEQUENCE: msgID, msgMaxSize, msgFlags, msgSecurityModel.
+        // The msgID value 0x12A34456 deliberately contains a 0xA3 byte — the
+        // old scanning detector misread it as a SetRequest PDU tag.
+        packet.push(BER_SEQUENCE);
+        packet.push(0x10);
+        packet.push(BER_INTEGER);
+        packet.push(0x04);
+        packet.extend_from_slice(&[0x12, 0xA3, 0x44, 0x56]); // msgID
+        packet.push(BER_INTEGER);
+        packet.push(0x02);
+        packet.extend_from_slice(&[0x05, 0xDC]); // msgMaxSize 1500
+        packet.push(BER_OCTET_STRING);
+        packet.push(0x01);
+        packet.push(0x04); // msgFlags: reportable
+        packet.push(BER_INTEGER);
+        packet.push(0x01);
+        packet.push(0x03); // msgSecurityModel: USM
+
+        // msgSecurityParameters: opaque OCTET STRING
+        packet.push(BER_OCTET_STRING);
+        packet.push(0x02);
+        packet.extend_from_slice(&[0x30, 0x00]);
+
+        if scoped_pdu_plaintext {
+            // ScopedPDU SEQUENCE: contextEngineID, contextName, PDU
+            packet.push(BER_SEQUENCE);
+            packet.push(0x0D);
+            packet.push(BER_OCTET_STRING);
+            packet.push(0x02);
+            packet.extend_from_slice(&[0x80, 0x01]); // contextEngineID
+            packet.push(BER_OCTET_STRING);
+            packet.push(0x00); // contextName (empty)
+            packet.push(PDU_GET_REQUEST);
+            packet.push(0x05);
+            packet.push(BER_INTEGER);
+            packet.push(0x01);
+            packet.push(0x01); // request-id
+            packet.push(BER_SEQUENCE);
+            packet.push(0x00); // varbinds (empty)
+        } else {
+            // Encrypted ScopedPDU: opaque OCTET STRING
+            packet.push(BER_OCTET_STRING);
+            packet.push(0x04);
+            packet.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        }
+
+        packet[len_pos] = (packet.len() - len_pos - 1) as u8;
+        packet
     }
 
     #[test]
-    fn test_find_pdu_type_returns_none_when_no_pdu() {
-        let data = [0x00, 0x01, 0x02, 0x03];
-        assert!(find_pdu_type(&data).is_none());
+    fn test_snmp_v3_plaintext_scoped_pdu() {
+        let packet = build_snmp_v3(true);
+        let info = analyze_snmp(&packet).expect("should parse");
+        assert_eq!(info.version, SnmpVersion::V3);
+        assert_eq!(info.community, None);
+        assert_eq!(info.pdu_type, SnmpPduType::GetRequest);
     }
 
     #[test]
-    fn test_find_pdu_type_caps_search_at_50_bytes() {
-        // PDU tag sits at offset 60 — beyond the cap, so it must not be found.
-        let mut data = vec![0x00u8; 60];
-        data.push(PDU_GET_REQUEST);
-        assert!(find_pdu_type(&data).is_none());
+    fn test_snmp_v3_encrypted_scoped_pdu() {
+        let packet = build_snmp_v3(false);
+        let info = analyze_snmp(&packet).expect("should parse");
+        assert_eq!(info.version, SnmpVersion::V3);
+        assert_eq!(info.pdu_type, SnmpPduType::Encrypted);
+    }
+
+    #[test]
+    fn test_pdu_tag_not_scanned_from_value_bytes() {
+        // A v1 message whose community is followed by a non-PDU byte must be
+        // rejected — the detector must not scan ahead for a 0xA0-0xA8 byte.
+        let mut packet = build_snmp_v1_get("public");
+        // Overwrite the PDU tag with an INTEGER tag: still not SNMP.
+        let pdu_pos = packet.iter().position(|&b| b == PDU_GET_REQUEST).unwrap();
+        packet[pdu_pos] = BER_INTEGER;
+        assert!(analyze_snmp(&packet).is_none());
     }
 }

--- a/crates/rustnet-core/src/network/parser.rs
+++ b/crates/rustnet-core/src/network/parser.rs
@@ -301,6 +301,14 @@ impl PacketParser {
         // Actual packet size = link-layer header (offset bytes) + IP total length
         let actual_packet_len = offset + ip_total_length;
 
+        // Bytes 6-7: flags + fragment offset. A non-first fragment carries
+        // no transport header — parsing it would read mid-payload bytes as
+        // ports and fabricate connections.
+        let fragment_offset = u16::from_be_bytes([ip_data[6], ip_data[7]]) & 0x1FFF;
+        if fragment_offset != 0 {
+            return None;
+        }
+
         let protocol_num = ip_data[9];
         let src_ip = IpAddr::V4(Ipv4Addr::new(
             ip_data[12],
@@ -316,6 +324,11 @@ impl PacketParser {
         ));
 
         let ihl = ip_data[0] & 0x0F;
+        // IHL below 5 is invalid (the fixed header alone is 20 bytes);
+        // treating it as a header length would overlap header and payload.
+        if ihl < 5 {
+            return None;
+        }
         let ip_header_len = (ihl as usize) * 4;
 
         if ip_data.len() < ip_header_len {
@@ -387,9 +400,10 @@ impl PacketParser {
 
         let transport_data = &ip_data[40..];
 
-        // Handle extension headers if needed
+        // Handle extension headers if needed (`None` = non-first fragment,
+        // which carries no transport header)
         let (final_next_header, transport_offset) =
-            self.parse_ipv6_extension_headers(next_header, transport_data);
+            self.parse_ipv6_extension_headers(next_header, transport_data)?;
         // A crafted extension header can declare a length that runs past the
         // captured bytes, so `transport_offset` may exceed the slice length.
         // Clamp before slicing to avoid an out-of-bounds panic (one-packet DoS).
@@ -518,11 +532,24 @@ impl PacketParser {
         // For raw IP packets, there's no Ethernet header
         let actual_packet_len = u16::from_be_bytes([data[2], data[3]]) as usize;
 
+        // Bytes 6-7: flags + fragment offset. A non-first fragment carries
+        // no transport header — parsing it would read mid-payload bytes as
+        // ports and fabricate connections.
+        let fragment_offset = u16::from_be_bytes([data[6], data[7]]) & 0x1FFF;
+        if fragment_offset != 0 {
+            return None;
+        }
+
         let protocol_num = data[9];
         let src_ip = IpAddr::V4(Ipv4Addr::new(data[12], data[13], data[14], data[15]));
         let dst_ip = IpAddr::V4(Ipv4Addr::new(data[16], data[17], data[18], data[19]));
 
         let ihl = data[0] & 0x0F;
+        // IHL below 5 is invalid (the fixed header alone is 20 bytes);
+        // treating it as a header length would overlap header and payload.
+        if ihl < 5 {
+            return None;
+        }
         let ip_header_len = (ihl as usize) * 4;
 
         if data.len() < ip_header_len {
@@ -592,9 +619,10 @@ impl PacketParser {
 
         let transport_data = &data[40..];
 
-        // Handle extension headers if needed
+        // Handle extension headers if needed (`None` = non-first fragment,
+        // which carries no transport header)
         let (final_next_header, transport_offset) =
-            self.parse_ipv6_extension_headers(next_header, transport_data);
+            self.parse_ipv6_extension_headers(next_header, transport_data)?;
         // A crafted extension header can declare a length that runs past the
         // captured bytes, so `transport_offset` may exceed the slice length.
         // Clamp before slicing to avoid an out-of-bounds panic (one-packet DoS).
@@ -611,7 +639,15 @@ impl PacketParser {
         }
     }
 
-    fn parse_ipv6_extension_headers(&self, mut next_header: u8, data: &[u8]) -> (u8, usize) {
+    /// Walk the IPv6 extension-header chain. Returns the final next-header
+    /// value and the offset of the transport header, or `None` for a
+    /// non-first fragment: its "transport header" position holds mid-payload
+    /// bytes that must not be parsed as ports.
+    fn parse_ipv6_extension_headers(
+        &self,
+        mut next_header: u8,
+        data: &[u8],
+    ) -> Option<(u8, usize)> {
         let mut offset = 0;
 
         const HOP_BY_HOP: u8 = 0;
@@ -625,7 +661,7 @@ impl PacketParser {
             match next_header {
                 HOP_BY_HOP | ROUTING | DESTINATION_OPTIONS => {
                     if data.len() < offset + 2 {
-                        return (next_header, offset);
+                        return Some((next_header, offset));
                     }
                     next_header = data[offset];
                     let header_len = ((data[offset + 1] as usize) + 1) * 8;
@@ -633,29 +669,36 @@ impl PacketParser {
                 }
                 FRAGMENT => {
                     if data.len() < offset + 8 {
-                        return (next_header, offset);
+                        return Some((next_header, offset));
+                    }
+                    // Bytes 2-3: fragment offset (upper 13 bits). Only the
+                    // first fragment (offset 0) carries the transport header.
+                    let fragment_offset =
+                        u16::from_be_bytes([data[offset + 2], data[offset + 3]]) >> 3;
+                    if fragment_offset != 0 {
+                        return None;
                     }
                     next_header = data[offset];
                     offset += 8;
                 }
                 AUTHENTICATION => {
                     if data.len() < offset + 2 {
-                        return (next_header, offset);
+                        return Some((next_header, offset));
                     }
                     next_header = data[offset];
                     let header_len = ((data[offset + 1] as usize) + 2) * 4;
                     offset += header_len;
                 }
                 ENCAPSULATING_SECURITY => {
-                    return (next_header, offset);
+                    return Some((next_header, offset));
                 }
                 _ => {
-                    return (next_header, offset);
+                    return Some((next_header, offset));
                 }
             }
 
             if offset >= data.len() {
-                return (next_header, offset);
+                return Some((next_header, offset));
             }
         }
     }

--- a/crates/rustnet-core/src/network/protocol/tcp.rs
+++ b/crates/rustnet-core/src/network/protocol/tcp.rs
@@ -80,8 +80,13 @@ pub fn parse(
 
     let tcp_flags = parse_tcp_flags(flags);
 
-    // Calculate actual TCP payload length
+    // Calculate actual TCP payload length. A data offset below 5 is invalid
+    // (RFC 9293 §3.1) — treating it as a header length would make the
+    // payload overlap the header itself.
     let tcp_header_len = ((transport_data[12] >> 4) as usize) * 4;
+    if tcp_header_len < 20 {
+        return None;
+    }
     let tcp_payload_len = transport_data.len().saturating_sub(tcp_header_len) as u32;
 
     let tcp_header = TcpHeaderInfo {
@@ -120,7 +125,6 @@ pub fn parse(
 
     // Perform DPI if enabled and there's payload
     let dpi_result = if config.enable_dpi {
-        let tcp_header_len = ((transport_data[12] >> 4) as usize) * 4;
         if transport_data.len() > tcp_header_len {
             let payload = &transport_data[tcp_header_len..];
             dpi::analyze_tcp_packet(payload, local_addr.port(), remote_addr.port(), is_outgoing)

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -320,6 +320,9 @@ pub enum MqttPacketType {
     Connack,
     Publish,
     Puback,
+    Pubrec,
+    Pubrel,
+    Pubcomp,
     Subscribe,
     Suback,
     Unsubscribe,
@@ -327,6 +330,7 @@ pub enum MqttPacketType {
     Pingreq,
     Pingresp,
     Disconnect,
+    Auth,
 }
 
 impl fmt::Display for MqttPacketType {
@@ -336,6 +340,9 @@ impl fmt::Display for MqttPacketType {
             MqttPacketType::Connack => write!(f, "CONNACK"),
             MqttPacketType::Publish => write!(f, "PUBLISH"),
             MqttPacketType::Puback => write!(f, "PUBACK"),
+            MqttPacketType::Pubrec => write!(f, "PUBREC"),
+            MqttPacketType::Pubrel => write!(f, "PUBREL"),
+            MqttPacketType::Pubcomp => write!(f, "PUBCOMP"),
             MqttPacketType::Subscribe => write!(f, "SUBSCRIBE"),
             MqttPacketType::Suback => write!(f, "SUBACK"),
             MqttPacketType::Unsubscribe => write!(f, "UNSUBSCRIBE"),
@@ -343,6 +350,7 @@ impl fmt::Display for MqttPacketType {
             MqttPacketType::Pingreq => write!(f, "PINGREQ"),
             MqttPacketType::Pingresp => write!(f, "PINGRESP"),
             MqttPacketType::Disconnect => write!(f, "DISCONNECT"),
+            MqttPacketType::Auth => write!(f, "AUTH"),
         }
     }
 }
@@ -744,6 +752,8 @@ pub enum SnmpPduType {
     InformRequest,
     TrapV2,
     Report,
+    /// SNMPv3 with an encrypted ScopedPDU — the PDU type is not visible.
+    Encrypted,
 }
 
 impl std::fmt::Display for SnmpPduType {
@@ -758,6 +768,7 @@ impl std::fmt::Display for SnmpPduType {
             SnmpPduType::InformRequest => write!(f, "INFORM"),
             SnmpPduType::TrapV2 => write!(f, "TRAPv2"),
             SnmpPduType::Report => write!(f, "REPORT"),
+            SnmpPduType::Encrypted => write!(f, "ENCRYPTED"),
         }
     }
 }
@@ -817,6 +828,10 @@ pub enum NetBiosOpcode {
     Wack,
     Refresh,
     Response,
+    /// Datagram Service message delivery (direct unique/group or broadcast).
+    Datagram,
+    /// Datagram Service error report.
+    Error,
     Unknown(u8),
 }
 
@@ -829,6 +844,8 @@ impl std::fmt::Display for NetBiosOpcode {
             NetBiosOpcode::Wack => write!(f, "WACK"),
             NetBiosOpcode::Refresh => write!(f, "Refresh"),
             NetBiosOpcode::Response => write!(f, "Response"),
+            NetBiosOpcode::Datagram => write!(f, "Datagram"),
+            NetBiosOpcode::Error => write!(f, "Error"),
             NetBiosOpcode::Unknown(v) => write!(f, "Unknown({})", v),
         }
     }


### PR DESCRIPTION
Fixes DPI misclassifications (SIP/RTSP as HTTP, SMTP as FTP, WireGuard as BitTorrent uTP), adds MQTT QoS 2/AUTH types, structural SNMP PDU parsing with v3 support, correct NetBIOS datagram offsets, DNS QTYPE on over-long names, QUIC close on truncated reason, and drops non-first IP fragments at the parser. Library crates bumped to 0.3.0 (new public enum variants).