### PR TITLE
perf(ui/interfaces): reduce per-row rate lookups

### DIFF
--- a/src/ui/tabs/interfaces.rs
+++ b/src/ui/tabs/interfaces.rs
@@ -99,13 +99,14 @@ pub(in crate::ui) fn draw_interface_stats(
         };
 
         // Get rate for this interface
-        let rx_rate_str = if let Some(rate) = rates.get(&stat.interface_name) {
+        let rate = rates.get(&stat.interface_name);
+        let rx_rate_str = if let Some(rate) = rate {
             format!("{}/s", format_bytes(rate.rx_bytes_per_sec))
         } else {
             "---".to_string()
         };
 
-        let tx_rate_str = if let Some(rate) = rates.get(&stat.interface_name) {
+        let tx_rate_str = if let Some(rate) = rate {
             format!("{}/s", format_bytes(rate.tx_bytes_per_sec))
         } else {
             "---".to_string()
@@ -116,7 +117,7 @@ pub(in crate::ui) fn draw_interface_stats(
             Cell::from(Line::from(Span::styled(s, style)).right_aligned())
         };
         rows.push(Row::new(vec![
-            Cell::from(stat.interface_name.clone()),
+            Cell::from(stat.interface_name.as_str()),
             right(rx_rate_str),
             right(tx_rate_str),
             right(format!("{}", stat.rx_packets)),


### PR DESCRIPTION
## Summary

The Interfaces tab rebuilds one table row per network interface on each render. That row construction previously queried the rate map twice with the same `interface_name`: once for RX and once for TX.

This reuses one `rates.get(&stat.interface_name)` result for both rate columns, and borrows the interface name when building the first cell instead of cloning the `String`. The table contents, sorting, scroll windowing, and scrollbar behavior are unchanged.

## Linked issue

References #398.

## Verification

Per [CONTRIBUTING.md > Code Quality Requirements](https://github.com/domcyrus/rustnet/blob/main/CONTRIBUTING.md#code-quality-requirements),
I ran the following locally and they all pass:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build --release`

Additional checks:

- [x] `cargo test -p rustnet-monitor ui::snapshot_tests::interfaces_tab`
- [x] `cargo deny check` (`advisories`, `bans`, `licenses`, and `sources` ok; existing duplicate-crate warnings only)

## Scope

- [x] One feature or fix per PR (no unrelated cleanups bundled in)
- [x] No new dependencies, or rationale provided in the summary above
- [x] No `#[allow(clippy::...)]` suppressions, or rationale provided
  (see [CONTRIBUTING.md](https://github.com/domcyrus/rustnet/blob/main/CONTRIBUTING.md#code-quality-requirements))

## AI-assisted contributions

If you used an AI assistant (Copilot, Claude, ChatGPT, Cursor, etc.) to
write any of this code, that is fine, but please confirm:

- [x] I have read every line I am submitting
- [x] I ran the verification commands above myself
- [x] The PR description reflects what the code actually does

## Notes for the reviewer

No user-visible output change is intended; the existing Interfaces tab snapshot covers the rendered table after this change.
