### PR TITLE
feat(sandbox): drop root privileges after initialization on Linux

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,7 @@ On Linux 5.13+, RustNet uses [Landlock](https://landlock.io/) to restrict its ow
 | Network | 6.4+ | TCP bind/connect blocked (RustNet is passive) |
 | Capabilities | Any | `CAP_NET_RAW` dropped after pcap socket opened |
 | Capabilities | Any | `CAP_BPF`, `CAP_PERFMON` dropped after eBPF programs loaded |
+| Root uid | Any | When started as root (e.g. `sudo rustnet`), the process drops to the invoking user (`SUDO_UID`/`SUDO_GID`) or `nobody` after initialization |
 | Privileges | 3.5+ | `PR_SET_NO_NEW_PRIVS` set by RustNet itself — always, even with `--no-sandbox` — prevents privilege escalation via setuid binaries |
 
 ### How It Works
@@ -39,7 +40,8 @@ On Linux 5.13+, RustNet uses [Landlock](https://landlock.io/) to restrict its ow
 1. **Initialization phase**: RustNet loads eBPF programs, opens packet capture handles, and creates log files
 2. **Privilege lock**: `PR_SET_NO_NEW_PRIVS` is set (applied even when the sandbox is disabled)
 3. **Capability drop**: `CAP_NET_RAW`, `CAP_BPF`, and `CAP_PERFMON` are removed from the process
-4. **Landlock**: Restricts filesystem and network access
+4. **Root uid drop**: when running as root, the process switches to the invoking sudo user (or `nobody`) via `setresuid`/`setresgid`. Already-open capture sockets, eBPF programs, and log/export files keep working. This matters most on kernels without Landlock, where the uid drop is the main containment
+5. **Landlock**: Restricts filesystem and network access
 
 ### Security Benefits
 
@@ -50,14 +52,24 @@ If an attacker exploits a vulnerability in DPI/packet parsing:
 - Cannot bind TCP ports (reverse shell blocked)
 - Cannot create new raw sockets (capability dropped)
 - Cannot escalate privileges via setuid binaries (`PR_SET_NO_NEW_PRIVS`, set even with `--no-sandbox`)
+- Does not run as root: under `sudo rustnet` the process continues as the invoking user, so even on kernels without Landlock a compromise does not yield root
 
 ### CLI Options
 
 ```
---no-sandbox        Disable Landlock sandboxing and capability dropping
-                    (PR_SET_NO_NEW_PRIVS is still set)
+--no-sandbox        Disable Landlock sandboxing, capability dropping, and the
+                    root uid drop (PR_SET_NO_NEW_PRIVS is still set)
 --sandbox-strict    Require full sandbox enforcement or exit
+--no-uid-drop       Keep running as root instead of dropping to
+                    SUDO_UID/SUDO_GID (or nobody) after initialization
 ```
+
+Trade-off of the root uid drop: the procfs fallback for process attribution can
+then only inspect processes owned by the target user, and Kubernetes log
+directories under `/var/log/pods` may become unreadable. The eBPF fast path
+(the default) is unaffected. If you rely on procfs-only attribution (e.g. a
+build without eBPF) and need to attribute other users' processes, use
+`--no-uid-drop`.
 
 ### Graceful Degradation
 

--- a/SECURITY.zh-CN.md
+++ b/SECURITY.zh-CN.md
@@ -32,6 +32,7 @@ RustNet 处理不受信任的网络数据，因此纵深防御至关重要。本
 | 网络 | 6.4+ | 禁止 TCP bind/connect（RustNet 为被动模式） |
 | Linux capabilities | 任意 | pcap socket 打开后丢弃 `CAP_NET_RAW` |
 | Linux capabilities | 任意 | eBPF 程序加载后丢弃 `CAP_BPF`、`CAP_PERFMON`、`CAP_SYS_ADMIN` |
+| root uid | 任意 | 以 root 启动时（如 `sudo rustnet`），初始化完成后降权到调用用户（`SUDO_UID`/`SUDO_GID`）或 `nobody` |
 | 特权 | 3.5+ | `PR_SET_NO_NEW_PRIVS` 由 RustNet 自身设置——始终生效，即使使用 `--no-sandbox`——防止通过 setuid 二进制文件提升特权 |
 
 ### 工作原理
@@ -39,7 +40,8 @@ RustNet 处理不受信任的网络数据，因此纵深防御至关重要。本
 1. **初始化阶段**：RustNet 加载 eBPF 程序、打开包捕获句柄、创建日志文件
 2. **特权锁定**：设置 `PR_SET_NO_NEW_PRIVS`（即使禁用沙箱也会应用）
 3. **Linux capabilities 剥离**：移除 `CAP_NET_RAW`、`CAP_BPF`、`CAP_PERFMON` 和 `CAP_SYS_ADMIN`
-4. **Landlock**：限制文件系统和网络访问
+4. **root uid 降权**：以 root 运行时，通过 `setresuid`/`setresgid` 切换到调用 sudo 的用户（或 `nobody`）。已打开的捕获 socket、eBPF 程序和日志/导出文件继续有效。在没有 Landlock 的内核上，这是主要的隔离手段
+5. **Landlock**：限制文件系统和网络访问
 
 ### 安全收益
 
@@ -50,14 +52,22 @@ RustNet 处理不受信任的网络数据，因此纵深防御至关重要。本
 - 无法绑定 TCP 端口（阻止反向 shell）
 - 无法创建新的 raw socket（Linux capabilities 已剥离）
 - 无法通过 setuid 二进制文件提升特权（`PR_SET_NO_NEW_PRIVS`，即使使用 `--no-sandbox` 也会设置）
+- 不以 root 运行：使用 `sudo rustnet` 时进程会切换为调用用户，即使在没有 Landlock 的内核上，攻击者也无法获得 root
 
 ### CLI 选项
 
 ```
---no-sandbox        禁用 Landlock 沙箱和 Linux capabilities 剥离
+--no-sandbox        禁用 Landlock 沙箱、Linux capabilities 剥离和 root uid 降权
                     （仍会设置 PR_SET_NO_NEW_PRIVS）
 --sandbox-strict    要求完整沙箱强制生效，否则退出
+--no-uid-drop       初始化后保持 root 运行，
+                    不降权到 SUDO_UID/SUDO_GID（或 nobody）
 ```
+
+root uid 降权的权衡：降权后，procfs 回退路径的进程归属只能检查目标用户拥有的进程，
+`/var/log/pods` 下的 Kubernetes 日志目录也可能不可读。eBPF 快速路径（默认）不受影响。
+如果依赖纯 procfs 归属（如未启用 eBPF 的构建）且需要归属其他用户的进程，请使用
+`--no-uid-drop`。
 
 ### 优雅降级
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -103,6 +103,8 @@ Options:
   -f, --bpf-filter <FILTER>              BPF filter expression for packet capture
       --no-sandbox                       Disable Landlock sandboxing (Linux only)
       --sandbox-strict                   Require full sandbox enforcement or exit (Linux only)
+      --no-uid-drop                      Keep running as root instead of dropping to
+                                         SUDO_UID/SUDO_GID (or nobody) after initialization (Linux only)
   -h, --help                             Print help
   -V, --version                          Print version
 ```

--- a/USAGE.zh-CN.md
+++ b/USAGE.zh-CN.md
@@ -103,6 +103,8 @@ Options:
   -f, --bpf-filter <FILTER>              用于数据包捕获的 BPF 过滤器表达式
       --no-sandbox                       禁用 Landlock 沙箱（仅限 Linux）
       --sandbox-strict                   要求完整沙箱强制执行，否则退出（仅限 Linux）
+      --no-uid-drop                      初始化后保持 root 运行，不降权到
+                                         SUDO_UID/SUDO_GID（或 nobody）（仅限 Linux）
   -h, --help                             打印帮助
   -V, --version                          打印版本
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -69,6 +69,9 @@ pub struct SandboxInfo {
     /// Whether CAP_BPF/CAP_PERFMON were dropped
     #[cfg(target_os = "linux")]
     pub ebpf_caps_dropped: bool,
+    /// Whether the root uid/gid were dropped (setresuid to the sudo user or nobody)
+    #[cfg(target_os = "linux")]
+    pub uid_dropped: bool,
     /// Whether Landlock is available on this kernel
     #[cfg(target_os = "linux")]
     pub landlock_available: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -187,5 +187,17 @@ pub fn build_cli() -> Command {
                 .conflicts_with("no-sandbox"),
         );
 
+    #[cfg(target_os = "linux")]
+    let cmd = cmd.arg(
+        Arg::new("no-uid-drop")
+            .long("no-uid-drop")
+            .help(
+                "Keep running as root instead of dropping to SUDO_UID/SUDO_GID (or nobody) \
+                 after initialization. Keeping root lets the procfs fallback attribute \
+                 other users' processes when eBPF is unavailable",
+            )
+            .action(clap::ArgAction::SetTrue),
+    );
+
     cmd
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,20 @@ fn main() -> Result<()> {
         info!("Kubernetes attribution mode: {}", mode);
     }
 
+    // Resolve the identity to drop root to after privileged init (Linux only):
+    // the invoking sudo user, or nobody when started as plain root. Resolved
+    // before the export files are pre-created so they can be chowned to the
+    // target user: they are created root-owned 0600 and are reopened by path
+    // at runtime (libpcap savefile, sidecar JSONL appends), which would fail
+    // after the drop if they stayed owned by root.
+    #[cfg(target_os = "linux")]
+    let uid_drop_target = if matches.get_flag("no-uid-drop") {
+        info!("Root uid drop disabled by --no-uid-drop");
+        None
+    } else {
+        network::platform::sandbox::privdrop::resolve_drop_target()
+    };
+
     // Pre-create the PCAP export file and its sidecar JSONL (needed for Landlock
     // permissions). This must be done BEFORE the sandbox is applied so the files
     // exist when adding rules: Landlock requires an open FD to scope a rule to a
@@ -153,17 +167,24 @@ fn main() -> Result<()> {
             // later written by libpcap's pcap_dump_open, which does NOT honor
             // O_NOFOLLOW, so a warn-and-continue here would let libpcap follow an
             // attacker-controlled symlink and write the capture there anyway.
-            precreate_private_file(path).map_err(|e| {
+            let file = precreate_private_file(path).map_err(|e| {
                 anyhow::anyhow!("Failed to pre-create {} file '{}': {}", label, path, e)
             })?;
+            #[cfg(target_os = "linux")]
+            chown_to_uid_drop_target(&file, uid_drop_target, label, path);
+            #[cfg(not(target_os = "linux"))]
+            let _ = file;
         }
     }
 
     let mut output_handles = app::AppOutputHandles::default();
     if let Some(ref pcapng_path) = config.pcapng_export_file {
-        output_handles.pcapng_export = Some(precreate_private_file(pcapng_path).map_err(|e| {
+        let file = precreate_private_file(pcapng_path).map_err(|e| {
             anyhow::anyhow!("Failed to pre-create PCAPNG file '{}': {}", pcapng_path, e)
-        })?);
+        })?;
+        #[cfg(target_os = "linux")]
+        chown_to_uid_drop_target(&file, uid_drop_target, "PCAPNG", pcapng_path);
+        output_handles.pcapng_export = Some(file);
     }
 
     // Set up terminal
@@ -271,6 +292,7 @@ fn main() -> Result<()> {
             block_network: true, // RustNet is passive, doesn't need TCP
             read_paths,
             write_paths,
+            drop_uid: uid_drop_target,
         };
 
         match apply_sandbox(&sandbox_config) {
@@ -286,6 +308,7 @@ fn main() -> Result<()> {
                     status: status_str.to_string(),
                     cap_dropped: result.cap_net_raw_dropped,
                     ebpf_caps_dropped: result.ebpf_caps_dropped,
+                    uid_dropped: result.uid_dropped,
                     landlock_available: result.landlock_available,
                     fs_restricted: result.landlock_fs_applied,
                     net_restricted: result.landlock_net_applied,
@@ -303,6 +326,7 @@ fn main() -> Result<()> {
                     status: "Error".to_string(),
                     cap_dropped: false,
                     ebpf_caps_dropped: false,
+                    uid_dropped: false,
                     landlock_available: false,
                     fs_restricted: false,
                     net_restricted: false,
@@ -567,6 +591,27 @@ fn setup_logging(level: LevelFilter) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Hand a pre-created export file over to the uid-drop target so it can still
+/// be reopened by path after root privileges are dropped. Best-effort: on
+/// failure the drop still happens and the affected export degrades with a
+/// runtime warning when the reopen fails.
+#[cfg(target_os = "linux")]
+fn chown_to_uid_drop_target(
+    file: &fs::File,
+    target: Option<network::platform::sandbox::privdrop::DropTarget>,
+    label: &str,
+    path: &str,
+) {
+    if let Some(target) = target
+        && let Err(e) = network::platform::sandbox::privdrop::chown_to_target(file, target)
+    {
+        warn!(
+            "Failed to chown {} file '{}' to uid {}: {} (the file may not be writable after the root uid drop)",
+            label, path, target.uid, e
+        );
+    }
 }
 
 fn precreate_private_file(path: &str) -> io::Result<fs::File> {

--- a/src/network/platform/linux/sandbox/landlock.rs
+++ b/src/network/platform/linux/sandbox/landlock.rs
@@ -336,6 +336,7 @@ mod tests {
             block_network: true,
             read_paths: vec![],
             write_paths: vec![],
+            drop_uid: None,
         };
         let result = apply_landlock(&config).unwrap();
         assert!(!result.fs_applied);
@@ -355,6 +356,7 @@ mod tests {
             block_network: true,
             read_paths: vec![],
             write_paths: vec![],
+            drop_uid: None,
         };
         let result = apply_landlock(&config).expect("best-effort must not error");
         // scope can only be reported applied when fs was applied too

--- a/src/network/platform/linux/sandbox/mod.rs
+++ b/src/network/platform/linux/sandbox/mod.rs
@@ -14,6 +14,9 @@
 //! - Scope: abstract UNIX socket connects + signals to outside processes blocked
 //!   (kernel 6.12+, ABI v6)
 //! - Capabilities: CAP_NET_RAW, CAP_BPF, CAP_PERFMON dropped
+//! - Identity: when started as root (e.g. `sudo rustnet`), euid/egid drop to
+//!   the invoking user (SUDO_UID/SUDO_GID) or `nobody`, see [`privdrop`].
+//!   Disable with `--no-uid-drop`.
 //! - Privileges: PR_SET_NO_NEW_PRIVS set by rustnet itself (no privilege
 //!   escalation via execve). This is applied unconditionally — even with
 //!   `--no-sandbox` or when Landlock is unavailable — since it is privilege
@@ -23,7 +26,9 @@
 //!
 //! 1. Set PR_SET_NO_NEW_PRIVS
 //! 2. Drop capabilities (CAP_NET_RAW, CAP_BPF, CAP_PERFMON)
-//! 3. Apply Landlock (filesystem + network restrictions)
+//! 3. Drop root uid/gid (setresuid to SUDO_UID/SUDO_GID or nobody)
+//! 4. Apply Landlock (filesystem + network restrictions; needs no privileges
+//!    since PR_SET_NO_NEW_PRIVS is already set)
 //!
 //! # Compatibility
 //!
@@ -36,6 +41,9 @@
 pub mod capabilities;
 #[cfg(feature = "landlock")]
 mod landlock;
+// Not gated on `landlock`: the uid drop only needs libc, and matters most on
+// exactly the kernels/builds where Landlock is unavailable.
+pub mod privdrop;
 use std::path::PathBuf;
 
 /// Sandbox enforcement mode
@@ -52,7 +60,8 @@ pub enum SandboxMode {
 
 /// Configuration for the sandbox
 // Without the landlock feature only the stub apply_sandbox() exists, which
-// reads just `mode`; the remaining fields are part of the shared API.
+// reads just `mode` and `drop_uid`; the remaining fields are part of the
+// shared API.
 #[cfg_attr(not(feature = "landlock"), allow(dead_code))]
 #[derive(Debug, Clone, Default)]
 pub struct SandboxConfig {
@@ -64,6 +73,9 @@ pub struct SandboxConfig {
     pub read_paths: Vec<PathBuf>,
     /// Paths that need write access (e.g., log files)
     pub write_paths: Vec<PathBuf>,
+    /// When running as root: the identity to drop to after initialization
+    /// (`None` = not root, or drop disabled via `--no-uid-drop`)
+    pub drop_uid: Option<privdrop::DropTarget>,
 }
 
 /// Result of sandbox application
@@ -78,6 +90,8 @@ pub struct SandboxResult {
     pub cap_net_raw_dropped: bool,
     /// Whether CAP_BPF/CAP_PERFMON were dropped
     pub ebpf_caps_dropped: bool,
+    /// Whether the root uid/gid were dropped (setresuid to the sudo user or nobody)
+    pub uid_dropped: bool,
     /// Whether Landlock is available on this kernel
     pub landlock_available: bool,
     /// Whether Landlock filesystem restrictions were applied
@@ -171,6 +185,7 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
             message: message.to_string(),
             cap_net_raw_dropped: false,
             ebpf_caps_dropped: false,
+            uid_dropped: false,
             landlock_available,
             landlock_fs_applied: false,
             landlock_net_applied: false,
@@ -185,6 +200,7 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
         message: String::new(),
         cap_net_raw_dropped: false,
         ebpf_caps_dropped: false,
+        uid_dropped: false,
         landlock_available,
         landlock_fs_applied: false,
         landlock_net_applied: false,
@@ -260,7 +276,42 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
         }
     }
 
-    // Step 3: Apply Landlock restrictions
+    // Step 3: Drop the root uid/gid (sudo case)
+    // Capabilities alone leave euid 0; on kernels without Landlock this drop
+    // is the main containment. Runs after the capability drops purely for
+    // reporting; transitioning all uids away from 0 clears the capability
+    // sets anyway. Runs before Landlock, which needs no privileges since
+    // PR_SET_NO_NEW_PRIVS is already set. The libc set*id wrappers apply the
+    // change to every thread, including those spawned before this point.
+    if let Some(target) = config.drop_uid {
+        match privdrop::drop_to(target) {
+            Ok(()) => {
+                result.uid_dropped = true;
+                messages.push(format!(
+                    "root dropped to uid {} gid {}",
+                    target.uid, target.gid
+                ));
+                log::info!(
+                    "Dropped root privileges to uid {} gid {} (verified); \
+                     procfs process attribution is now limited to that user's \
+                     processes (eBPF attribution unaffected)",
+                    target.uid,
+                    target.gid
+                );
+            }
+            Err(e) => {
+                let msg = format!("Failed to drop root uid/gid: {}", e);
+                log::warn!("{}", msg);
+                messages.push(msg);
+                if config.mode == SandboxMode::Strict {
+                    return Err(e).context("Strict mode requires the root uid drop to succeed");
+                }
+                result.status = SandboxStatus::PartiallyEnforced;
+            }
+        }
+    }
+
+    // Step 4: Apply Landlock restrictions
     match landlock::apply_landlock(config) {
         Ok(ll_result) => {
             result.landlock_fs_applied = ll_result.fs_applied;
@@ -307,7 +358,11 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
     }
 
     // Determine final status
-    if !result.cap_net_raw_dropped && !result.landlock_fs_applied && !result.landlock_net_applied {
+    if !result.cap_net_raw_dropped
+        && !result.uid_dropped
+        && !result.landlock_fs_applied
+        && !result.landlock_net_applied
+    {
         result.status = SandboxStatus::NotApplied;
     }
 
@@ -350,6 +405,35 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
         ));
     }
 
+    // The uid drop needs only libc, so non-landlock builds still shed root
+    // after initialization (unless the sandbox is disabled entirely).
+    let mut uid_dropped = false;
+    let mut drop_message = String::new();
+    if config.mode != SandboxMode::Disabled
+        && let Some(target) = config.drop_uid
+    {
+        match privdrop::drop_to(target) {
+            Ok(()) => {
+                uid_dropped = true;
+                drop_message = format!("; root dropped to uid {} gid {}", target.uid, target.gid);
+                log::info!(
+                    "Dropped root privileges to uid {} gid {} (verified); \
+                     procfs process attribution is now limited to that user's \
+                     processes",
+                    target.uid,
+                    target.gid
+                );
+            }
+            Err(e) => {
+                log::warn!("Failed to drop root uid/gid: {}", e);
+                if config.mode == SandboxMode::Strict {
+                    return Err(e.context("Strict mode requires the root uid drop to succeed"));
+                }
+                drop_message = format!("; root uid drop failed: {}", e);
+            }
+        }
+    }
+
     log::warn!("Landlock feature not compiled in");
     let message = if no_new_privs {
         "Landlock feature not compiled in (no-new-privs still set)"
@@ -357,10 +441,15 @@ pub fn apply_sandbox(config: &SandboxConfig) -> anyhow::Result<SandboxResult> {
         "Landlock feature not compiled in"
     };
     Ok(SandboxResult {
-        status: SandboxStatus::NotApplied,
-        message: message.to_string(),
+        status: if uid_dropped {
+            SandboxStatus::PartiallyEnforced
+        } else {
+            SandboxStatus::NotApplied
+        },
+        message: format!("{}{}", message, drop_message),
         cap_net_raw_dropped: false,
         ebpf_caps_dropped: false,
+        uid_dropped,
         landlock_available: false,
         landlock_fs_applied: false,
         landlock_net_applied: false,

--- a/src/network/platform/linux/sandbox/privdrop.rs
+++ b/src/network/platform/linux/sandbox/privdrop.rs
@@ -1,0 +1,192 @@
+//! Root privilege drop (setuid) for Linux
+//!
+//! When rustnet is started via `sudo` it keeps euid 0 for its whole lifetime,
+//! even though root is only needed during initialization: opening the raw
+//! capture socket (CAP_NET_RAW) and loading eBPF programs (CAP_BPF +
+//! CAP_PERFMON). Dropping capabilities alone still leaves euid 0, and on
+//! kernels without Landlock (< 5.13) that means a compromise of the DPI code
+//! runs as unconstrained root.
+//!
+//! This module drops the process to the invoking sudo user (`SUDO_UID` /
+//! `SUDO_GID`), or to `nobody` (65534) when started as plain root, after all
+//! privileged initialization is complete. Already-open file descriptors (the
+//! capture socket, eBPF map/program fds, log and export files) remain valid
+//! across the drop.
+//!
+//! # Trust model
+//!
+//! `SUDO_UID`/`SUDO_GID` are environment variables and thus caller-controlled,
+//! but they can only ever select which *unprivileged* identity we become:
+//! uid 0 and unparseable values are rejected and fall back to `nobody`, so a
+//! forged value cannot retain or regain privilege.
+//!
+//! # Trade-offs
+//!
+//! After the drop, the procfs fallback for process attribution can only scan
+//! `/proc/<pid>/fd` of processes owned by the target user; the eBPF fast path
+//! is unaffected (it reads already-open map fds). Kubernetes log-directory
+//! metadata under `/var/log/pods` may also become unreadable. `--no-uid-drop`
+//! keeps the old keep-root behavior.
+
+use anyhow::{Result, anyhow};
+
+/// The uid/gid pair to drop to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DropTarget {
+    pub uid: libc::uid_t,
+    pub gid: libc::gid_t,
+}
+
+/// Overflow uid/gid, `nobody`/`nogroup` on all mainstream distros. Used when
+/// rustnet runs as plain root (no sudo) or SUDO_UID/SUDO_GID are unusable.
+const NOBODY: DropTarget = DropTarget {
+    uid: 65534,
+    gid: 65534,
+};
+
+/// Resolve the identity to drop to, or `None` when not running as root
+/// (nothing to drop; the setcap path never has euid 0).
+pub fn resolve_drop_target() -> Option<DropTarget> {
+    // SAFETY: geteuid() has no failure mode and takes no pointers.
+    if unsafe { libc::geteuid() } != 0 {
+        return None;
+    }
+    Some(target_from_env(
+        std::env::var("SUDO_UID").ok().as_deref(),
+        std::env::var("SUDO_GID").ok().as_deref(),
+    ))
+}
+
+/// Pick the target from SUDO_UID/SUDO_GID; both must parse to a nonzero id,
+/// otherwise fall back to `nobody`. Split out from `resolve_drop_target` for
+/// testability (no process-global env manipulation in tests).
+fn target_from_env(sudo_uid: Option<&str>, sudo_gid: Option<&str>) -> DropTarget {
+    let parse = |v: Option<&str>| v.and_then(|s| s.parse::<u32>().ok()).filter(|&id| id != 0);
+    match (parse(sudo_uid), parse(sudo_gid)) {
+        (Some(uid), Some(gid)) => DropTarget { uid, gid },
+        _ => NOBODY,
+    }
+}
+
+/// Change the file's owner to the drop target.
+///
+/// Used on pre-created export files (0600, root-owned) so they can still be
+/// reopened by name after the uid drop, e.g. libpcap's `pcap_dump_open` and
+/// the per-event sidecar JSONL appends. Operates on the already-open fd
+/// (`fchown`), never on the path, so it cannot be redirected by a
+/// symlink/rename swap after the O_NOFOLLOW create.
+pub fn chown_to_target(file: &std::fs::File, target: DropTarget) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    // SAFETY: fchown on a valid owned fd; no pointers involved.
+    let rc = unsafe { libc::fchown(file.as_raw_fd(), target.uid, target.gid) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+/// Irreversibly drop root to `target`: supplementary groups first, then gid,
+/// then uid (all three of real/effective/saved so root cannot be regained).
+///
+/// Must be called while euid is 0. Uses the libc wrappers (not raw syscalls):
+/// glibc and musl broadcast set*id() to every thread of the process, so
+/// threads spawned before the drop (capture, enrichment) are covered too.
+///
+/// Side effect: transitioning all three uids away from 0 clears the effective
+/// and permitted capability sets, which subsumes the explicit capability
+/// drops that run before this.
+pub fn drop_to(target: DropTarget) -> Result<()> {
+    if target.uid == 0 || target.gid == 0 {
+        return Err(anyhow!("refusing to 'drop' to uid 0 / gid 0"));
+    }
+
+    // SAFETY: setgroups reads `ngroups` gid_t values from the pointer; we pass
+    // exactly one element and its valid address.
+    let gids = [target.gid];
+    if unsafe { libc::setgroups(1, gids.as_ptr()) } != 0 {
+        return Err(anyhow!(
+            "setgroups failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    // gid before uid: once uid 0 is gone, setresgid would fail.
+    // SAFETY: setresgid/setresuid take plain integers.
+    if unsafe { libc::setresgid(target.gid, target.gid, target.gid) } != 0 {
+        return Err(anyhow!(
+            "setresgid({}) failed: {}",
+            target.gid,
+            std::io::Error::last_os_error()
+        ));
+    }
+    if unsafe { libc::setresuid(target.uid, target.uid, target.uid) } != 0 {
+        return Err(anyhow!(
+            "setresuid({}) failed: {}",
+            target.uid,
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    // Verify the drop stuck and root cannot be regained.
+    let (mut ruid, mut euid, mut suid) = (0, 0, 0);
+    let (mut rgid, mut egid, mut sgid) = (0, 0, 0);
+    // SAFETY: getresuid/getresgid write to the three provided out-pointers.
+    unsafe {
+        libc::getresuid(&mut ruid, &mut euid, &mut suid);
+        libc::getresgid(&mut rgid, &mut egid, &mut sgid);
+    }
+    if [ruid, euid, suid] != [target.uid; 3] || [rgid, egid, sgid] != [target.gid; 3] {
+        return Err(anyhow!(
+            "uid/gid drop verification failed (uids {ruid}/{euid}/{suid}, gids {rgid}/{egid}/{sgid})"
+        ));
+    }
+    // SAFETY: setuid takes a plain integer. With ruid/euid/suid all nonzero
+    // and no CAP_SETUID this must fail; success means the drop is unsound.
+    if unsafe { libc::setuid(0) } == 0 {
+        return Err(anyhow!("uid drop verification failed: setuid(0) succeeded"));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_target_from_env_uses_sudo_ids() {
+        assert_eq!(
+            target_from_env(Some("1000"), Some("1000")),
+            DropTarget {
+                uid: 1000,
+                gid: 1000
+            }
+        );
+    }
+
+    #[test]
+    fn test_target_from_env_rejects_root_and_garbage() {
+        // uid 0 must never be a drop target
+        assert_eq!(target_from_env(Some("0"), Some("0")), NOBODY);
+        // unparseable values fall back to nobody
+        assert_eq!(target_from_env(Some("abc"), Some("1000")), NOBODY);
+        assert_eq!(target_from_env(Some("-1"), Some("1000")), NOBODY);
+        // both must be present
+        assert_eq!(target_from_env(Some("1000"), None), NOBODY);
+        assert_eq!(target_from_env(None, None), NOBODY);
+    }
+
+    #[test]
+    fn test_drop_to_rejects_root_target() {
+        assert!(drop_to(DropTarget { uid: 0, gid: 0 }).is_err());
+    }
+
+    #[test]
+    fn test_resolve_drop_target_none_when_not_root() {
+        // Tests don't run as root in CI; as non-root there is nothing to drop.
+        if unsafe { libc::geteuid() } != 0 {
+            assert!(resolve_drop_target().is_none());
+        }
+    }
+}

--- a/src/ui/tabs/overview.rs
+++ b/src/ui/tabs/overview.rs
@@ -755,6 +755,9 @@ fn draw_stats_panel(
         if sandbox_info.ebpf_caps_dropped {
             features.push("eBPF caps dropped");
         }
+        if sandbox_info.uid_dropped {
+            features.push("Root UID dropped");
+        }
         if sandbox_info.fs_restricted {
             features.push("FS restricted");
         }


### PR DESCRIPTION
Under sudo, rustnet kept euid 0 for its whole lifetime, so on kernels without Landlock a DPI compromise ran as unconstrained root.

After capture and eBPF init the process now drops to SUDO_UID/SUDO_GID (or nobody for plain root). Already-open fds keep working, and pre-created export files are chowned to the target user so PCAP/JSONL reopens still work. Opt out with the new --no-uid-drop flag or --no-sandbox; --sandbox-strict fails if the drop fails.

Trade-off (documented in SECURITY.md): procfs-fallback attribution then only sees the target user's processes; the eBPF path is unaffected.

Verified in a Debian VM: all threads at the invoking uid with empty capability sets, exports written post-drop, nobody fallback, and both opt-out flags. fmt/clippy/tests clean, including the non-landlock build.
