### PR TITLE
ci: trigger platform builds on crates/ changes, fix stale RELEASE.md dispatch step

### DIFF
--- a/.github/workflows/test-platform-builds.yml
+++ b/.github/workflows/test-platform-builds.yml
@@ -13,6 +13,7 @@ on:
       - 'build.rs'
       - 'Cross.toml'
       - 'src/**'
+      - 'crates/**'
       - '.github/workflows/test-platform-builds.yml'
       - '.github/workflows/build-platforms.yml'
       - '.github/actions/**'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,9 +34,9 @@ git pull origin main
 ```
 
 1. Go to [Actions > Test Platform Builds](../../actions/workflows/test-platform-builds.yml)
-2. Click "Run workflow"
-3. Select `all` to test all platforms (including static Linux builds)
-4. Wait for the workflow to complete successfully
+2. Click "Run workflow" (it builds all platforms, including static Linux builds,
+   and also triggers a FreeBSD test build in the rustnet-bsd repo)
+3. Wait for the workflow to complete successfully
 
 This catches cross-platform and static linking issues before you invest time in release prep.
 


### PR DESCRIPTION
Three small drifts found during v1.5.0 release-readiness review:

- `test-platform-builds.yml` PR path filter did not include `crates/**`, so PRs touching only the library crates skipped cross-platform build checks.
- RELEASE.md step 2 still said to select `all` in the workflow dispatch, but that input no longer exists; the dispatch now always builds all platforms and triggers the FreeBSD test build.
- `pre-release-check.sh` ran bare `cargo clippy` / `cargo test`, which only cover the root package (the workspace root is itself a package). Verified locally: bare `cargo test` runs 120 tests vs 492 with `--workspace`. Now uses `--workspace --all-targets` to match `rust.yml` CI.