### PR TITLE
ci: run clippy and tests workspace-wide in pre-release-check.sh

### DIFF
--- a/scripts/pre-release-check.sh
+++ b/scripts/pre-release-check.sh
@@ -90,13 +90,16 @@ else
   fail "cargo fmt --check has formatting issues"
 fi
 
-if cargo clippy -- -D warnings > /dev/null 2>&1; then
+# --workspace --all-targets to match CI (rust.yml): the workspace root is
+# itself a package, so bare `cargo {clippy,test}` only covers rustnet-monitor
+# and skips the library crates.
+if cargo clippy --workspace --all-targets -- -D warnings > /dev/null 2>&1; then
   pass "cargo clippy"
 else
   fail "cargo clippy has warnings"
 fi
 
-if cargo test > /dev/null 2>&1; then
+if cargo test --workspace > /dev/null 2>&1; then
   pass "cargo test"
 else
   fail "cargo test failed"


### PR DESCRIPTION
Follow-up to #467 (this commit was pushed to that branch after it was merged, so it never landed).

`pre-release-check.sh` ran bare `cargo clippy` / `cargo test`, which only cover the root package since the workspace root is itself a package. Verified locally: bare `cargo test` runs 120 tests vs 492 with `--workspace`. Now uses `--workspace --all-targets` to match `rust.yml` CI.