### PR TITLE
Fix connection lifecycle and graph regressions

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -753,6 +753,22 @@ The main process table switches between Egress (TX) and Ingress (RX) and shows:
 - Process attribution coverage, with unresolved traffic grouped as `Unknown`
 - Rolling 60-second process traffic as a percentage of interface traffic in the selected direction
 
+The table adapts to the available terminal width, so narrower terminals hide some columns. Its columns mean:
+
+| Column | Meaning |
+|---|---|
+| **Process** | Process name and PID. Traffic without process attribution is grouped as `Unknown`. |
+| **Pulse** | Relative share of the selected direction's rolling 60-second captured traffic. |
+| **TX now / RX now** | Current traffic rate for the process in the selected direction. |
+| **Peak TX / Peak RX** | Highest observed current rate while the process remains in the retained Activity view. |
+| **60s %** | Process share of all captured process traffic in the selected direction over the rolling 60-second window. |
+| **Iface 60s** | Process traffic over 60 seconds as a percentage of the matching interface traffic. A `~` prefix indicates an approximate host-wide comparison for multi-interface capture. |
+| **TX 60s / RX 60s** | Captured bytes attributed to the process in the selected direction over the rolling 60-second window. |
+| **Retained** | Total bytes across the process's active and retained historic connections in the selected direction. This is bounded retained data, not a lifetime counter. |
+| **Conns** | `active/total`, for example `41/66` means 41 active connections and 66 retained connections in total. The total includes active plus recently completed historic connections. |
+| **Remote** | Number of unique remote socket endpoints across the retained connections. An endpoint is an IP address plus port, so one host contacted on two ports counts as two remotes. Repeated connections to the same endpoint count once. A `+` suffix means the count exceeded the 256-destination display cap. |
+| **Top remote peer** | Remote endpoint with the most retained traffic in the selected direction. |
+
 Traffic Pulse shows the current captured rate, but calculates coverage from captured bytes and interface-counter bytes over the same rolling 60-second window. This avoids the large fluctuations caused by comparing independently sampled instantaneous rates. Coverage divides the captured total by the interface total and caps the displayed percentage at 100%, because slightly different window endpoints or counter visibility can otherwise produce small overages. Both raw totals remain visible for diagnosis. When RustNet captures one named interface, it compares directly with that interface. With multi-interface capture, RustNet compares against a host-wide interface aggregate and prefixes the value with `~` because VPN and virtual interface counters can overlap.
 
 Press `d` to switch between Egress (TX, blue) and Ingress (RX, green), `s` to cycle the Activity sort metric, `S` to reverse its order, and `i` to toggle the detailed interface table.

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -316,6 +316,12 @@ impl ConnectionTracker {
                     let mut historic = conn.snapshot_clone();
                     historic.is_historic = true;
                     historic.closed_at = Some(now);
+                    // Cached rates describe live traffic. Carrying them into a
+                    // closed record makes Overview and Details report traffic
+                    // that can no longer occur, and leaves a moving fallback
+                    // point after the live rate history is retired.
+                    historic.current_incoming_rate_bps = 0.0;
+                    historic.current_outgoing_rate_bps = 0.0;
                     let historic_key = HistoricKey {
                         key: *key,
                         created_nanos: conn
@@ -598,6 +604,11 @@ mod tests {
         tracker.ingest(&parse(&udp_frame(40000, 53)));
         assert_eq!(tracker.len(), 1);
 
+        for mut entry in tracker.connections().iter_mut() {
+            entry.current_incoming_rate_bps = 2048.0;
+            entry.current_outgoing_rate_bps = 1024.0;
+        }
+
         // A far-future `now` forces every connection past its timeout.
         let far_future = SystemTime::now() + Duration::from_secs(86_400);
         let removed = tracker.cleanup(far_future);
@@ -610,6 +621,9 @@ mod tests {
             1,
             "removed conn archived as historic"
         );
+        let historic = tracker.historic().iter().next().unwrap();
+        assert_eq!(historic.current_incoming_rate_bps, 0.0);
+        assert_eq!(historic.current_outgoing_rate_bps, 0.0);
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -1327,9 +1327,21 @@ impl TrafficHistory {
         if data.len() < window || window == 0 {
             return data.to_vec();
         }
-        data.windows(window)
-            .map(|w| w.iter().sum::<u64>() / window as u64)
-            .collect()
+
+        // Keep one output for every retained sample. Dropping the first
+        // `window - 1` points leaves a permanent gap at the left edge when a
+        // full history is rendered against its fixed-capacity time window.
+        let mut smoothed = Vec::with_capacity(data.len());
+        let mut sum = 0u128;
+        for (index, &value) in data.iter().enumerate() {
+            sum += u128::from(value);
+            if index >= window {
+                sum -= u128::from(data[index - window]);
+            }
+            let sample_count = (index + 1).min(window) as u128;
+            smoothed.push((sum / sample_count) as u64);
+        }
+        smoothed
     }
 
     /// Get data for Chart widget: (time_offset, rate) pairs, smoothed with moving average
@@ -2528,6 +2540,21 @@ mod tests {
         // Empty history: empty out, no panic.
         let empty = TrafficHistory::new(10);
         assert!(empty.get_connection_sparkline_data(5).is_empty());
+    }
+
+    #[test]
+    fn sparkline_smoothing_preserves_the_full_history_window() {
+        let mut history = TrafficHistory::new(5);
+        for i in 1u64..=5 {
+            history.add_sample(i * 10, i * 100, 1, 0, 0, None);
+        }
+
+        let rx = history.get_rx_sparkline_data(usize::MAX);
+        let tx = history.get_tx_sparkline_data(usize::MAX);
+        assert_eq!(rx, vec![10, 15, 20, 30, 40]);
+        assert_eq!(tx, vec![100, 150, 200, 300, 400]);
+        assert_eq!(rx.len(), history.capacity());
+        assert_eq!(tx.len(), history.capacity());
     }
 
     #[test]

--- a/src/ui/connection_table.rs
+++ b/src/ui/connection_table.rs
@@ -333,24 +333,14 @@ pub(in crate::ui) fn build_header<'a>(columns: &[Column], ui_state: &UIState) ->
     Row::new(cells).height(1).bottom_margin(1)
 }
 
-const EXPIRY_WARNING_START: f32 = 0.75;
-
-fn expiry_glow_intensity(staleness: f32) -> Option<f64> {
-    (staleness >= EXPIRY_WARNING_START).then(|| {
-        f64::from(
-            ((staleness - EXPIRY_WARNING_START) / (1.0 - EXPIRY_WARNING_START)).clamp(0.0, 1.0),
-        )
-    })
-}
-
 /// Row-level staleness styling shared by every connection row. Fresh rows
-/// keep per-cell colors. Historic rows turn gray, while expiring rows move
-/// continuously from bright yellow through orange to vivid red.
+/// keep per-cell colors. Historic rows turn gray, while expiring rows stay
+/// yellow through the warning window and intensify toward red near removal.
 fn staleness_style(conn: &Connection) -> (Option<Style>, bool) {
     let staleness = conn.staleness_ratio();
     if conn.is_historic {
         (Some(theme::historic_row()), false)
-    } else if let Some(intensity) = expiry_glow_intensity(staleness) {
+    } else if let Some(intensity) = theme::expiry_glow_intensity(staleness) {
         let color = theme::expiry_glow(intensity);
         let style = if intensity >= 0.6 {
             theme::bold_fg(color)
@@ -529,11 +519,14 @@ mod tests {
 
     #[test]
     fn expiry_glow_tracks_the_removal_window() {
-        assert_eq!(expiry_glow_intensity(0.74), None);
-        assert_eq!(expiry_glow_intensity(0.75), Some(0.0));
-        assert_eq!(expiry_glow_intensity(0.875), Some(0.5));
-        assert_eq!(expiry_glow_intensity(1.0), Some(1.0));
-        assert_eq!(expiry_glow_intensity(1.5), Some(1.0));
+        assert_eq!(theme::expiry_glow_intensity(0.74), None);
+        assert_eq!(theme::expiry_glow_intensity(0.75), Some(0.0));
+        assert_eq!(theme::expiry_glow_intensity(0.89), Some(0.0));
+        assert_eq!(theme::expiry_glow_intensity(0.90), Some(0.0));
+        let midpoint = theme::expiry_glow_intensity(0.95).unwrap();
+        assert!((midpoint - 0.5).abs() < 0.000_001);
+        assert_eq!(theme::expiry_glow_intensity(1.0), Some(1.0));
+        assert_eq!(theme::expiry_glow_intensity(1.5), Some(1.0));
         assert_eq!(theme::expiry_glow(0.0), Color::Rgb(0xFA, 0xCC, 0x15));
         assert_eq!(theme::expiry_glow(0.5), Color::Rgb(0xFB, 0x92, 0x3C));
         assert_eq!(theme::expiry_glow(1.0), Color::Rgb(0xFF, 0x2D, 0x55));

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -480,7 +480,7 @@ pub(in crate::ui) fn draw_connection_details(
     } else {
         // Mirror the historic Status line for active connections so the
         // user can see how recently traffic moved on this connection.
-        // Color follows the same staleness buckets as the Overview row
+        // Color follows the same staleness progression as the Overview row
         // styling so the cue is consistent across views.
         let ago = conn.last_activity.elapsed().unwrap_or_default();
         let active_display = if ago.as_secs() < 60 {
@@ -489,13 +489,9 @@ pub(in crate::ui) fn draw_connection_details(
             format!("Active (last seen {}m ago)", ago.as_secs() / 60)
         };
         let staleness = conn.staleness_ratio();
-        let active_color = if staleness >= 0.90 {
-            theme::err()
-        } else if staleness >= 0.75 {
-            theme::warn()
-        } else {
-            theme::ok()
-        };
+        let active_color = theme::expiry_glow_intensity(staleness)
+            .map(theme::expiry_glow)
+            .unwrap_or_else(theme::ok);
         push_detail_field_styled(
             &mut details_text,
             &mut detail_fields,
@@ -1509,10 +1505,8 @@ pub(in crate::ui) fn draw_connection_details(
         Style::default()
             .fg(Color::DarkGray)
             .add_modifier(Modifier::DIM | Modifier::BOLD)
-    } else if staleness >= 0.90 {
-        theme::bold_fg(theme::err())
-    } else if staleness >= 0.75 {
-        theme::bold_fg(theme::warn())
+    } else if let Some(intensity) = theme::expiry_glow_intensity(staleness) {
+        theme::bold_fg(theme::expiry_glow(intensity))
     } else {
         Style::default().add_modifier(Modifier::BOLD)
     };
@@ -1752,7 +1746,15 @@ pub(in crate::ui) fn draw_connection_details(
         ]);
 
         let traffic_history = ctx.app.get_traffic_history();
-        let frac = traffic_history.scroll_fraction();
+        // A fallback contains no time series to advance. Driving its single
+        // point with the aggregate sampling clock makes it move left, then
+        // snap right on every tick, which is especially visible immediately
+        // after a connection becomes historic.
+        let frac = if history.is_some() {
+            traffic_history.scroll_fraction()
+        } else {
+            0.0
+        };
         let window = traffic_history.capacity();
         braille_graph::wave_panel(
             f,

--- a/src/ui/tabs/help.rs
+++ b/src/ui/tabs/help.rs
@@ -261,7 +261,9 @@ pub(in crate::ui) fn draw_help(f: &mut Frame, ui_state: &UIState, area: Rect) ->
             Span::styled("Orange", theme::fg(theme::expiry_glow(0.5))),
             Span::styled(" → ", theme::fg(theme::muted())),
             Span::styled("Red ", theme::fg(theme::expiry_glow(1.0))),
-            Span::raw("Connection nearing timeout (75-100%; intensifies toward removal)"),
+            Span::raw(
+                "Connection nearing timeout (75-100%; holds yellow to 90%, then intensifies)",
+            ),
         ]),
         Line::from(vec![
             Span::styled("  Gray ", theme::historic_row()),

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -166,6 +166,9 @@ const EXPIRY_GLOW_STOPS: [(u8, u8, u8); 5] = [
     (0xFF, 0x2D, 0x55), // vivid red at removal
 ];
 
+const EXPIRY_WARNING_START: f32 = 0.75;
+const EXPIRY_CRITICAL_START: f32 = 0.90;
+
 fn lerp_channel(a: u8, b: u8, t: f64) -> u8 {
     (a as f64 + (b as f64 - a as f64) * t).round() as u8
 }
@@ -219,6 +222,17 @@ pub fn muted_wave(t: f64) -> Color {
 /// Yellow-to-red glow for connections nearing their removal timeout.
 pub fn expiry_glow(t: f64) -> Color {
     five_stop(&EXPIRY_GLOW_STOPS, t)
+}
+
+/// Map connection staleness to the expiry glow. The row turns yellow at 75%
+/// of its timeout, stays yellow through the warning window, then intensifies
+/// toward red during the final 10% before removal.
+pub fn expiry_glow_intensity(staleness: f32) -> Option<f64> {
+    (staleness >= EXPIRY_WARNING_START).then(|| {
+        f64::from(
+            ((staleness - EXPIRY_CRITICAL_START) / (1.0 - EXPIRY_CRITICAL_START)).clamp(0.0, 1.0),
+        )
+    })
 }
 
 // --- Protocol aliases ---

--- a/src/ui/widgets/braille_graph.rs
+++ b/src/ui/widgets/braille_graph.rs
@@ -113,7 +113,8 @@ fn smooth_columns(cols: &[f64]) -> Vec<f64> {
 ///
 /// `frac` ∈ [0, 1] is how far we are into the current sampling
 /// interval; it shifts the wave left by a sub-cell amount each frame
-/// so the graph scrolls smoothly instead of stepping once per sample.
+/// so the graph scrolls smoothly instead of stepping once per sample. A
+/// single sample stays fixed because there is no advancing series to scroll.
 ///
 /// Each row is one solid-colored `Line`; `row_color` maps `intensity`
 /// (1.0 at the crest row, →0 at the base) to a gradient color.
@@ -141,7 +142,12 @@ pub(in crate::ui) fn render(
     } else {
         0.0
     };
-    let right = (samples.len() - 1) as f64 + frac.clamp(0.0, 1.0);
+    let scroll = if samples.len() > 1 {
+        frac.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let right = (samples.len() - 1) as f64 + scroll;
     let cols: Vec<f64> = (0..dots_x)
         .map(|x| {
             let pos = right - (dots_x - 1 - x) as f64 * per_dot;
@@ -354,6 +360,18 @@ mod tests {
         let cells: Vec<char> = bottom.chars().collect();
         assert_eq!(cells[0], '\u{2800}', "left edge should be blank");
         assert_eq!(*cells.last().unwrap(), '⣿', "right edge should be full");
+    }
+
+    #[test]
+    fn single_sample_does_not_oscillate_with_scroll_fraction() {
+        let render_at = |frac| {
+            render(&[100], 30, 2, 100.0, frac, 60, |_| {
+                ratatui::style::Color::Reset
+            })
+        };
+
+        assert_eq!(render_at(0.0), render_at(0.5));
+        assert_eq!(render_at(0.0), render_at(1.0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep connection rows yellow through the warning window
- clear archived rates and stabilize Details graph fallbacks
- preserve full traffic history through smoothing
- document Activity table metrics

## Root cause

Recent UI changes blended the expiry color too early, retained cached live rates after archival, and shortened smoothed graph history by two samples.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
