### PR TITLE
Fix grouped overview navigation

### DIFF
--- a/src/ui/actions.rs
+++ b/src/ui/actions.rs
@@ -71,11 +71,23 @@ pub fn try_handle_connection_nav(
             Some(Vec::new())
         }
         (KeyCode::Char('g'), KeyModifiers::NONE) => {
-            ctx.ui_state.move_selection_to_first(ctx.connections);
+            if ctx.ui_state.grouping_enabled
+                && let Some(rows) = ctx.grouped_rows
+            {
+                ctx.ui_state.move_selection_to_first_grouped(rows);
+            } else {
+                ctx.ui_state.move_selection_to_first(ctx.connections);
+            }
             Some(Vec::new())
         }
         (KeyCode::Char('G'), _) | (KeyCode::Char('g'), KeyModifiers::SHIFT) => {
-            ctx.ui_state.move_selection_to_last(ctx.connections);
+            if ctx.ui_state.grouping_enabled
+                && let Some(rows) = ctx.grouped_rows
+            {
+                ctx.ui_state.move_selection_to_last_grouped(rows);
+            } else {
+                ctx.ui_state.move_selection_to_last(ctx.connections);
+            }
             Some(Vec::new())
         }
         // Copy selected connection's remote address — works wherever
@@ -155,5 +167,87 @@ pub fn clear_all_with_confirmation(ui_state: &mut UIState, app: &App) -> bool {
         info!("User requested clear - showing confirmation");
         ui_state.clear_confirmation = true;
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use super::*;
+    use crate::{
+        app::Config,
+        network::types::{Connection, Protocol, ProtocolState, TcpState},
+        ui::{ClickableRegions, GroupedRow, compute_grouped_rows},
+    };
+
+    fn test_connection(port: u16, process: &str) -> Connection {
+        let mut connection = Connection::new(
+            Protocol::Tcp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 443),
+            ProtocolState::Tcp(TcpState::Established),
+        );
+        connection.process_name = Some(process.to_string());
+        connection
+    }
+
+    #[test]
+    fn grouped_boundary_navigation_uses_visible_rows() {
+        let app = App::new(Config {
+            resolve_dns: false,
+            disable_geoip: true,
+            ..Config::default()
+        })
+        .expect("create app");
+        let connections = vec![
+            test_connection(1000, "beta"),
+            test_connection(1001, "alpha"),
+            test_connection(1002, "beta"),
+            test_connection(1003, "alpha"),
+        ];
+        let mut ui_state = UIState {
+            grouping_enabled: true,
+            expanded_groups: ["alpha".to_string(), "beta".to_string()]
+                .into_iter()
+                .collect(),
+            ..UIState::default()
+        };
+        let grouped_rows = compute_grouped_rows(&connections, &ui_state.expanded_groups);
+        let click_regions = ClickableRegions::default();
+        ui_state.set_selected_grouped_by_index(&grouped_rows, 1);
+        let mut ctx = HandlerContext {
+            app: &app,
+            ui_state: &mut ui_state,
+            connections: &connections,
+            grouped_rows: Some(&grouped_rows),
+            click_regions: &click_regions,
+        };
+
+        let effects = try_handle_connection_nav(
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+            &mut ctx,
+        );
+        assert!(matches!(effects, Some(effects) if effects.is_empty()));
+        assert_eq!(
+            ctx.ui_state.get_selected_grouped_index(&grouped_rows),
+            Some(0)
+        );
+        assert!(matches!(grouped_rows[0], GroupedRow::Group { .. }));
+
+        ctx.ui_state.set_selected_grouped_by_index(&grouped_rows, 1);
+        let effects = try_handle_connection_nav(
+            KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            &mut ctx,
+        );
+        assert!(matches!(effects, Some(effects) if effects.is_empty()));
+        assert_eq!(
+            ctx.ui_state.get_selected_grouped_index(&grouped_rows),
+            Some(grouped_rows.len() - 1)
+        );
+        assert!(matches!(
+            grouped_rows.last(),
+            Some(GroupedRow::Connection { .. })
+        ));
     }
 }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -732,11 +732,12 @@ impl UIState {
 
     /// Toggle expansion of the currently selected group
     pub fn toggle_group_expansion(&mut self) {
-        if let Some(ref group_name) = self.selected_group {
-            if self.expanded_groups.contains(group_name) {
-                self.expanded_groups.remove(group_name);
+        if let Some(group_name) = self.selected_group.clone() {
+            if self.expanded_groups.contains(&group_name) {
+                self.expanded_groups.remove(&group_name);
+                self.set_connection_key(None);
             } else {
-                self.expanded_groups.insert(group_name.clone());
+                self.expanded_groups.insert(group_name);
             }
         }
     }
@@ -750,8 +751,10 @@ impl UIState {
 
     /// Collapse the currently selected group
     pub fn collapse_selected_group(&mut self) {
-        if let Some(ref group_name) = self.selected_group {
-            self.expanded_groups.remove(group_name);
+        if let Some(group_name) = self.selected_group.clone()
+            && self.expanded_groups.remove(&group_name)
+        {
+            self.set_connection_key(None);
         }
     }
 
@@ -885,6 +888,20 @@ impl UIState {
         let current_index = self.get_selected_grouped_index(grouped_rows).unwrap_or(0);
         let new_index = (current_index + page_size).min(grouped_rows.len() - 1);
         self.set_selected_grouped_by_index(grouped_rows, new_index);
+    }
+
+    /// Move selection to the first row in grouped view
+    pub fn move_selection_to_first_grouped(&mut self, grouped_rows: &[GroupedRow]) {
+        if !grouped_rows.is_empty() {
+            self.set_selected_grouped_by_index(grouped_rows, 0);
+        }
+    }
+
+    /// Move selection to the last row in grouped view
+    pub fn move_selection_to_last_grouped(&mut self, grouped_rows: &[GroupedRow]) {
+        if !grouped_rows.is_empty() {
+            self.set_selected_grouped_by_index(grouped_rows, grouped_rows.len() - 1);
+        }
     }
 
     /// Ensure valid selection in grouped view
@@ -1180,5 +1197,28 @@ mod tests {
 
         assert_eq!(ui.get_selected_grouped_index(&rows), Some(2));
         assert_eq!(ui.selected_grouped_index_hint.get(), Some(2));
+    }
+
+    #[test]
+    fn collapsing_group_from_connection_selects_group_header() {
+        let connections = vec![
+            test_connection(1000, "alpha"),
+            test_connection(1001, "alpha"),
+        ];
+        let mut ui = UIState {
+            grouping_enabled: true,
+            expanded_groups: HashSet::from(["alpha".to_string()]),
+            ..UIState::default()
+        };
+        let rows = compute_grouped_rows(&connections, &ui.expanded_groups);
+        ui.set_selected_grouped_by_index(&rows, 1);
+        assert!(!ui.is_group_selected());
+
+        ui.toggle_group_expansion();
+
+        assert!(!ui.expanded_groups.contains("alpha"));
+        assert!(ui.is_group_selected());
+        let collapsed_rows = compute_grouped_rows(&connections, &ui.expanded_groups);
+        assert_eq!(ui.get_selected_grouped_index(&collapsed_rows), Some(0));
     }
 }

--- a/src/ui/tabs/overview.rs
+++ b/src/ui/tabs/overview.rs
@@ -113,7 +113,7 @@ impl Component for OverviewTab {
 
             // --- Group expand / collapse ---
             (KeyCode::Char(' '), _)
-                if ctx.ui_state.grouping_enabled && ctx.ui_state.is_group_selected() =>
+                if ctx.ui_state.grouping_enabled && ctx.ui_state.selected_group.is_some() =>
             {
                 ctx.ui_state.toggle_group_expansion();
                 Some(vec![Effect::Regroup])
@@ -1436,13 +1436,30 @@ fn draw_interface_stats_with_graph(f: &mut Frame, app: &App, area: Rect) -> Resu
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::HashSet,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
+
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-    use super::{connections_title, handle_filter_mode_key, is_filter_backspace_char};
+    use super::{OverviewTab, connections_title, handle_filter_mode_key, is_filter_backspace_char};
     use crate::{
         app::{App, Config},
-        ui::{ClickableRegions, HandlerContext, UIState},
+        network::types::{Connection, Protocol, ProtocolState, TcpState},
+        ui::{ClickableRegions, Component, Effect, HandlerContext, UIState, compute_grouped_rows},
     };
+
+    fn test_connection(port: u16, process: &str) -> Connection {
+        let mut connection = Connection::new(
+            Protocol::Tcp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 443),
+            ProtocolState::Tcp(TcpState::Established),
+        );
+        connection.process_name = Some(process.to_string());
+        connection
+    }
 
     fn title_text(line: ratatui::text::Line<'_>) -> String {
         line.spans
@@ -1524,5 +1541,43 @@ mod tests {
         assert!(ctx.ui_state.filter_mode);
         assert!(ctx.ui_state.filter_query.is_empty());
         assert_eq!(ctx.ui_state.filter_cursor_position, 0);
+    }
+
+    #[test]
+    fn space_collapses_parent_group_from_connection_row() {
+        let app = App::new(Config {
+            resolve_dns: false,
+            disable_geoip: true,
+            ..Config::default()
+        })
+        .expect("create app");
+        let connections = vec![
+            test_connection(1000, "alpha"),
+            test_connection(1001, "alpha"),
+        ];
+        let mut ui_state = UIState {
+            grouping_enabled: true,
+            expanded_groups: HashSet::from(["alpha".to_string()]),
+            ..UIState::default()
+        };
+        let grouped_rows = compute_grouped_rows(&connections, &ui_state.expanded_groups);
+        ui_state.set_selected_grouped_by_index(&grouped_rows, 1);
+        let click_regions = ClickableRegions::default();
+        let mut ctx = HandlerContext {
+            app: &app,
+            ui_state: &mut ui_state,
+            connections: &connections,
+            grouped_rows: Some(&grouped_rows),
+            click_regions: &click_regions,
+        };
+
+        let effects = OverviewTab.handle_key(
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE),
+            &mut ctx,
+        );
+
+        assert!(matches!(effects.as_deref(), Some([Effect::Regroup])));
+        assert!(!ctx.ui_state.expanded_groups.contains("alpha"));
+        assert!(ctx.ui_state.is_group_selected());
     }
 }


### PR DESCRIPTION
## Summary

- Allow Space to collapse or expand a process group while a child connection is selected.
- Make `g` and `G` jump to the first and last visible rows in grouped mode.
- Move selection to the process header when its group is collapsed.

## Root cause

Space was limited to process-header selection even though child rows retain their parent process. The `g` and `G` handlers used the flat connection slice instead of the visible grouped rows, which left the connection and process selections out of sync.

## Impact

Keyboard navigation on the grouped Overview tab now follows the rows users can see and behaves consistently from both process headers and child connections.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
