### PR TITLE
Fix tuple reuse metadata leaks and tombstone capacity

### DIFF
--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -54,6 +54,12 @@ use std::time::{Duration, SystemTime};
 /// packets do not create phantom established connections.
 const RECENTLY_CLOSED_TTL: Duration = Duration::from_secs(30);
 
+/// Tombstone capacity floor. `max_historic` sizes the user-facing archive,
+/// but tombstones guard correctness, so a tiny or zero `max_historic` must
+/// not strip them and reopen the phantom-connection window. Entries are a
+/// key and a timestamp; the TTL above bounds how long any of them live.
+const RECENTLY_CLOSED_MIN_ENTRIES: usize = 1024;
+
 /// The active connection table: flow key -> connection.
 ///
 /// Keys are compact `Copy` structs, and the map uses FxHash — with a small
@@ -521,7 +527,7 @@ impl ConnectionTracker {
         recently_closed.retain(|_, closed_at| {
             now.duration_since(*closed_at).unwrap_or_default() <= RECENTLY_CLOSED_TTL
         });
-        let max_entries = self.config.max_historic.max(1);
+        let max_entries = self.config.max_historic.max(RECENTLY_CLOSED_MIN_ENTRIES);
         if recently_closed.len() > max_entries {
             let mut entries: Vec<(ConnectionKey, SystemTime)> = recently_closed
                 .iter()
@@ -1140,6 +1146,44 @@ mod tests {
         let removed = tracker.cleanup(far_future);
         assert_eq!(removed.len(), 1);
         assert_eq!(tracker.historic_len(), 0, "historic disabled");
+    }
+
+    /// `max_historic` sizes the user-facing archive; it must not shrink the
+    /// tombstone table below the floor, or closing more flows than the cap
+    /// lets delayed teardown packets resurrect phantom connections.
+    #[test]
+    fn zero_max_historic_keeps_tombstones_for_all_closed_flows() {
+        let tracker = ConnectionTracker::with_config(TrackerConfig {
+            keep_historic: false,
+            max_historic: 0,
+            ..TrackerConfig::default()
+        });
+
+        let start = SystemTime::now();
+        for port in [40_000u16, 40_001] {
+            let mut syn = tcp_packet(true, false, false, false, true);
+            syn.local_addr.set_port(port);
+            tracker.ingest_at(&syn, start);
+            let mut rst = tcp_packet(false, false, false, true, true);
+            rst.local_addr.set_port(port);
+            tracker.ingest_at(&rst, start + Duration::from_secs(1));
+        }
+        assert_eq!(tracker.len(), 2);
+
+        let closed_at = start + Duration::from_secs(86_400);
+        let removed = tracker.cleanup(closed_at);
+        assert_eq!(removed.len(), 2);
+
+        for port in [40_000u16, 40_001] {
+            let mut late_fin = tcp_packet(false, true, true, false, true);
+            late_fin.local_addr.set_port(port);
+            let outcome = tracker.ingest_at(&late_fin, closed_at + Duration::from_secs(1));
+            assert!(
+                outcome.ignored_late,
+                "delayed teardown for port {port} must hit a tombstone"
+            );
+        }
+        assert!(tracker.is_empty(), "no phantom connections may be created");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -181,6 +181,12 @@ struct PcapngRecord {
     timestamp: SystemTime,
     original_len: u32,
     key: Option<ConnectionKey>,
+    /// `created_at` of the connection that owned `key` when the packet was
+    /// queued. Live keys are tuple-only, so a comment lookup at flush time
+    /// must verify the tuple still belongs to the same generation; otherwise
+    /// a rapidly reused tuple annotates this packet with the metadata of a
+    /// connection it never belonged to.
+    conn_created_at: Option<SystemTime>,
     deadline: Instant,
 }
 
@@ -663,9 +669,25 @@ pub struct ConnRateHistory {
     pub tx: VecDeque<u64>,
     rx_scale: GraphScale,
     tx_scale: GraphScale,
+    generation: Option<SystemTime>,
 }
 
 impl ConnRateHistory {
+    /// Push one sample for the connection generation stamped `created_at`.
+    /// Live connection keys are tuple-only, so a replacement generation reuses
+    /// its predecessor's map entry; a new generation resets the rings — and
+    /// the sticky graph scales — instead of inheriting the old connection's
+    /// graph and ceiling.
+    fn push_for_generation(&mut self, created_at: SystemTime, rx: u64, tx: u64, cap: usize) {
+        if self.generation != Some(created_at) {
+            *self = Self {
+                generation: Some(created_at),
+                ..Self::default()
+            };
+        }
+        self.push(rx, tx, cap);
+    }
+
     fn push(&mut self, rx: u64, tx: u64, cap: usize) {
         if self.rx.len() >= cap {
             self.rx.pop_front();
@@ -1445,6 +1467,9 @@ impl App {
                             }
                         };
                         if pcapng_enabled {
+                            let conn_created_at = key.and_then(|key| {
+                                tracker.connections().get(&key).map(|conn| conn.created_at)
+                            });
                             send_pcapng_record(
                                 pcapng_tx.as_ref(),
                                 &stats,
@@ -1453,6 +1478,7 @@ impl App {
                                     timestamp: packet_timestamp,
                                     original_len: packet_original_len,
                                     key,
+                                    conn_created_at,
                                     deadline: if key.is_some() {
                                         Instant::now() + PCAPNG_ATTRIBUTION_WAIT
                                     } else {
@@ -2256,7 +2282,8 @@ impl App {
                                     .collect();
                                 rates.retain(|key, _| alive.contains(key));
                                 for conn in snap.iter().filter(|c| !c.is_historic) {
-                                    rates.entry(conn.key()).or_default().push(
+                                    rates.entry(conn.key()).or_default().push_for_generation(
+                                        conn.created_at,
                                         conn.current_incoming_rate_bps as u64,
                                         conn.current_outgoing_rate_bps as u64,
                                         TRAFFIC_HISTORY_CAPACITY,
@@ -3102,18 +3129,29 @@ fn write_pcapng_record<W: Write>(
 fn pcapng_comment(record: &PcapngRecord, tracker: &ConnectionTracker) -> Option<String> {
     let key = record.key?;
     let conn = tracker.connections().get(&key)?;
+    if record.conn_created_at != Some(conn.created_at) {
+        return None;
+    }
     if conn.pid.is_none() && conn.process_name.is_none() {
         return None;
     }
     build_pcapng_comment(&conn)
 }
 
+/// Like [`pcapng_comment`], but without requiring process attribution. Both
+/// lookups reject a connection whose `created_at` differs from the one the
+/// packet was queued under: live keys are tuple-only, so a rapidly reused
+/// tuple would otherwise annotate this packet with a later generation's
+/// metadata.
 fn pcapng_comment_if_any_metadata(
     record: &PcapngRecord,
     tracker: &ConnectionTracker,
 ) -> Option<String> {
     let key = record.key?;
     let conn = tracker.connections().get(&key)?;
+    if record.conn_created_at != Some(conn.created_at) {
+        return None;
+    }
     build_pcapng_comment(&conn)
 }
 
@@ -3459,6 +3497,28 @@ mod open_log_file_tests {
 }
 
 #[cfg(test)]
+mod conn_rate_history_tests {
+    use super::*;
+
+    /// Live connection keys are tuple-only, so a replacement generation lands
+    /// on its predecessor's map entry; it must start with a fresh graph
+    /// instead of inheriting the old connection's history.
+    #[test]
+    fn replacement_generation_starts_with_fresh_rate_history() {
+        let mut history = ConnRateHistory::default();
+        let first_generation = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        history.push_for_generation(first_generation, 1_000_000, 2_000_000, 10);
+        history.push_for_generation(first_generation, 1_000_000, 2_000_000, 10);
+        assert_eq!(history.rx.len(), 2);
+
+        let second_generation = first_generation + Duration::from_secs(5);
+        history.push_for_generation(second_generation, 10, 20, 10);
+        assert_eq!(history.rx, [10]);
+        assert_eq!(history.tx, [20]);
+    }
+}
+
+#[cfg(test)]
 mod pcapng_export_tests {
     use super::*;
     use std::net::SocketAddr;
@@ -3469,8 +3529,59 @@ mod pcapng_export_tests {
             timestamp: std::time::UNIX_EPOCH,
             original_len: 1,
             key,
+            conn_created_at: None,
             deadline,
         }
+    }
+
+    /// A queued record must only be annotated with metadata from the exact
+    /// connection generation it was captured under; a reused tuple's newer
+    /// generation must not claim it.
+    #[test]
+    fn annotation_requires_matching_connection_generation() {
+        use crate::network::{
+            protocol::tcp::{TcpFlags, TcpHeaderInfo},
+            types::{ProtocolState, TcpState},
+        };
+
+        let tracker = ConnectionTracker::new();
+        let outcome = tracker.ingest(&ParsedPacket {
+            protocol: Protocol::Tcp,
+            local_addr: SocketAddr::from(([192, 0, 2, 9], 41_000)),
+            remote_addr: SocketAddr::from(([198, 51, 100, 9], 443)),
+            tcp_header: Some(TcpHeaderInfo {
+                seq: 1,
+                ack: 0,
+                window: 65_535,
+                flags: TcpFlags {
+                    syn: true,
+                    ack: false,
+                    fin: false,
+                    rst: false,
+                    psh: false,
+                    urg: false,
+                },
+                payload_len: 0,
+            }),
+            protocol_state: ProtocolState::Tcp(TcpState::Unknown),
+            is_outgoing: true,
+            packet_len: 60,
+            dpi_result: None,
+            process_name: None,
+            process_id: None,
+        });
+        let key = outcome.key;
+        tracker.connections().get_mut(&key).unwrap().process_name = Some("nginx".to_string());
+        let created_at = tracker.connections().get(&key).unwrap().created_at;
+
+        let mut matching = record(0xAA, Some(key), Instant::now());
+        matching.conn_created_at = Some(created_at);
+        assert!(pcapng_comment(&matching, &tracker).is_some());
+
+        let mut stale = record(0xBB, Some(key), Instant::now());
+        stale.conn_created_at = Some(created_at - Duration::from_secs(1));
+        assert!(pcapng_comment(&stale, &tracker).is_none());
+        assert!(pcapng_comment_if_any_metadata(&stale, &tracker).is_none());
     }
 
     /// Kubernetes attribution must be carried into the per-packet comment so


### PR DESCRIPTION
## Summary

- Annotate exported PCAPNG packets only with the connection generation they were captured under. A rapidly reused tuple no longer borrows process/DPI metadata from a later connection.
- Reset per-connection rate history when a tuple is reused, so a new connection does not inherit its predecessor's Details graph.
- Give the recently-closed tombstone table a capacity floor independent of `max_historic`, keeping phantom-connection protection intact for tiny or zero archive configs.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`