### PR TITLE
fix(ppa): build a deterministic orig tarball so all series pass Launchpad

### DIFF
--- a/.github/workflows/ppa-release.yml
+++ b/.github/workflows/ppa-release.yml
@@ -159,11 +159,12 @@ jobs:
           RELEASE_TAG="v${BASE_VERSION}"
           if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
             echo "✓ Found release tag: $RELEASE_TAG"
-            git archive --format=tar --prefix="${PACKAGE_NAME}-${VERSION}/" "$RELEASE_TAG" | tar -x -C build-ppa
+            SRC_REF="$RELEASE_TAG"
           else
             echo "⚠ Release tag $RELEASE_TAG not found, using HEAD"
-            git archive --format=tar --prefix="${PACKAGE_NAME}-${VERSION}/" HEAD | tar -x -C build-ppa
+            SRC_REF="HEAD"
           fi
+          git archive --format=tar --prefix="${PACKAGE_NAME}-${VERSION}/" "$SRC_REF" | tar -x -C build-ppa
 
           # Vendor dependencies separately from orig tarball
           echo "Vendoring Rust dependencies..."
@@ -185,7 +186,12 @@ jobs:
           echo "Creating orig tarball..."
           cd ..
           ORIG_TARBALL="${PACKAGE_NAME}_${VERSION}.orig.tar.gz"
-          tar -czf "${ORIG_TARBALL}" "${PACKAGE_NAME}-${VERSION}"
+          # Repacking the extracted tree with `tar -czf` embeds a gzip
+          # timestamp, so each matrix job produced a byte-different tarball
+          # and Launchpad rejected every series after the first (one
+          # upstream version must have one identical orig tarball).
+          # `git archive` piped through `gzip -n` is deterministic.
+          git -C "$GITHUB_WORKSPACE" archive --format=tar --prefix="${PACKAGE_NAME}-${VERSION}/" "$SRC_REF" | gzip -n > "${ORIG_TARBALL}"
 
           # Add debian directory and vendor tarball
           cp -r "$GITHUB_WORKSPACE/debian" "${PACKAGE_NAME}-${VERSION}/"


### PR DESCRIPTION
Each ppa-release matrix job repacked the extracted source tree with `tar -czf`, which embeds a gzip timestamp. The questing and resolute jobs therefore uploaded byte-different `orig.tar.gz` files for the same upstream version, and Launchpad rejected whichever series arrived second ("already exists but uploaded version has different contents"). This bit both v1.4.0 and v1.5.0: resolute silently stayed on 1.3.0+ds2 until a manual re-dispatch with a `tarball_suffix`.

Generate the orig tarball directly from `git archive` piped through `gzip -n` instead. git archive output is deterministic for a given tree (sorted entries, commit-time mtimes, uid/gid 0) and `gzip -n` omits the timestamp header, so every matrix job produces identical bytes and Launchpad's reuse-if-hash-matches path accepts all series.

Tested by checking that two consecutive local `git archive | gzip -n` invocations of the v1.5.0 tag produce identical sha256 sums, while two `tar -czf` repacks differ.