### PR TITLE
fix: exclude assets/ from the published crate to fit the 10 MB limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,11 @@ readme = "README.md"
 license.workspace = true
 keywords = ["network", "monitoring", "tui", "ebpf", "packet-capture"]
 categories = ["command-line-utilities", "network-programming", "visualization"]
-exclude = [".github/", "scripts/", "tests/", "*.log", "target/", ".gitignore"]
+# assets/ (README gif and screenshots, ~9 MB) pushed the crate past the
+# crates.io 10 MB upload limit at v1.5.0; crates.io rewrites the README's
+# relative image links to the GitHub repo, so excluding them changes nothing
+# on the crate page.
+exclude = [".github/", "assets/", "scripts/", "tests/", "*.log", "target/", ".gitignore"]
 
 [lib]
 name = "rustnet_monitor"


### PR DESCRIPTION
The v1.5.0 rustnet-monitor crate weighs 10.9 MiB compressed (11,418,702 bytes), just over the crates.io 10 MB upload limit (10,485,760). The upload bounces at the CDN edge as a 503, which is what failed the publish job twice; v1.4.0 was 8.4 MB and squeaked under. The growth is assets/: the README gif and screenshots total 8.9 MB.

Add assets/ to the package exclude list. crates.io rewrites the README's relative image links against the repository URL, so the crate page renders identically. Verified from a clean worktree: the package drops from 146 files / 10.9 MiB compressed to 138 files / 2.1 MiB (2,207,684 bytes) with zero assets/ entries.