### PR TITLE
Show capture failures in the status bar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -153,11 +153,10 @@ impl ProcessDetectionStatus {
 }
 
 /// Current packet-capture health exposed to the UI.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 enum CaptureStatus {
     #[default]
-    Initializing,
-    Running,
+    Healthy,
     Failed(String),
 }
 
@@ -167,10 +166,24 @@ impl CaptureStatus {
     }
 }
 
+/// Single-line description of a capture failure. Multi-line errors (the
+/// privilege hint is several lines) are collapsed so the status bar can render
+/// them; the recovery advice is appended by the UI, which knows how much of the
+/// line is left for it.
 fn capture_failure_message(context: &str, error: &impl std::fmt::Display) -> String {
-    let detail = error.to_string().replace(['\r', '\n'], " ");
-    let detail = detail.trim().trim_end_matches('.');
-    format!("{context}: {detail}. Restart rustnet to resume. Press 'q' to quit.")
+    let mut detail = error
+        .to_string()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if detail.is_empty() {
+        detail.push_str("unknown error");
+    }
+    // Leave an existing "..." alone: shortening it would change what was reported.
+    if !detail.ends_with(['.', '!', '?']) {
+        detail.push('.');
+    }
+    format!("{context}: {detail}")
 }
 
 // Connection-table limits (max connections, historic retention, QUIC mappings)
@@ -1121,7 +1134,7 @@ impl App {
         let capture_status = Arc::clone(&self.capture_status);
         let _pktap_active = Arc::clone(&self.pktap_active);
         let pcap_export_file = self.config.pcap_export_file.clone();
-        *capture_status.write().unwrap() = CaptureStatus::Initializing;
+        *capture_status.write().unwrap() = CaptureStatus::Healthy;
 
         // Fires once the privileged part of capture setup is done (device
         // opened or open failed), so the main thread can drop privileges.
@@ -1135,7 +1148,6 @@ impl App {
                     // Store the actual interface name and linktype being used
                     *current_interface.write().unwrap() = Some(device_name.clone());
                     *linktype_storage.write().unwrap() = Some(linktype);
-                    *capture_status.write().unwrap() = CaptureStatus::Running;
 
                     // Drop CAP_NET_RAW now that the socket is open (Linux only)
                     #[cfg(all(target_os = "linux", feature = "landlock"))]
@@ -1217,6 +1229,15 @@ impl App {
                     let mut batch: Vec<CapturedPacket> = Vec::with_capacity(100);
                     let mut batch_deadline = Instant::now() + Duration::from_millis(100);
 
+                    // Every path that ends capture for a reason other than
+                    // shutdown has to record it, or the TUI keeps looking
+                    // healthy while the connection table silently freezes.
+                    let record_failure = |message: String| {
+                        if !should_stop.load(Ordering::Relaxed) {
+                            *capture_status.write().unwrap() = CaptureStatus::Failed(message);
+                        }
+                    };
+
                     loop {
                         if should_stop.load(Ordering::Relaxed) {
                             info!("Capture thread stopping");
@@ -1272,6 +1293,10 @@ impl App {
                                         }
                                         Err(crossbeam::channel::TrySendError::Disconnected(_)) => {
                                             warn!("Packet channel closed");
+                                            record_failure(capture_failure_message(
+                                                "Capture stopped",
+                                                &"the packet processing threads exited",
+                                            ));
                                             break;
                                         }
                                     }
@@ -1291,6 +1316,10 @@ impl App {
                                         }
                                         Err(crossbeam::channel::TrySendError::Disconnected(_)) => {
                                             warn!("Packet channel closed");
+                                            record_failure(capture_failure_message(
+                                                "Capture stopped",
+                                                &"the packet processing threads exited",
+                                            ));
                                             break;
                                         }
                                     }
@@ -1315,9 +1344,7 @@ impl App {
                             }
                             Err(e) => {
                                 error!("Capture error: {}", e);
-                                *capture_status.write().unwrap() = CaptureStatus::Failed(
-                                    capture_failure_message("Capture stopped", &e),
-                                );
+                                record_failure(capture_failure_message("Capture stopped", &e));
                                 break;
                             }
                         }
@@ -2717,7 +2744,7 @@ impl App {
             .ok()
             .and_then(|status| match &*status {
                 CaptureStatus::Failed(message) => Some(message.clone()),
-                CaptureStatus::Initializing | CaptureStatus::Running => None,
+                CaptureStatus::Healthy => None,
             })
     }
 
@@ -2833,7 +2860,7 @@ impl App {
     pub(crate) fn set_capture_error_for_test(&self, error: Option<&str>) {
         *self.capture_status.write().unwrap() = match error {
             Some(message) => CaptureStatus::Failed(message.to_string()),
-            None => CaptureStatus::Running,
+            None => CaptureStatus::Healthy,
         };
     }
 
@@ -3310,6 +3337,40 @@ impl Drop for App {
         self.stop();
         // Give threads time to stop gracefully
         thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+mod capture_failure_message_tests {
+    use super::capture_failure_message;
+
+    #[test]
+    fn collapses_multi_line_errors_and_terminates_the_sentence() {
+        let error = "Insufficient privileges\n  How to fix:\n  1. Run with sudo";
+        assert_eq!(
+            capture_failure_message("Capture failed to start", &error),
+            "Capture failed to start: Insufficient privileges How to fix: 1. Run with sudo."
+        );
+    }
+
+    #[test]
+    fn keeps_existing_terminal_punctuation() {
+        assert_eq!(
+            capture_failure_message("Capture stopped", &"Device busy, retrying..."),
+            "Capture stopped: Device busy, retrying..."
+        );
+        assert_eq!(
+            capture_failure_message("Capture stopped", &"Interface went down."),
+            "Capture stopped: Interface went down."
+        );
+    }
+
+    #[test]
+    fn reports_a_cause_even_when_the_error_renders_empty() {
+        assert_eq!(
+            capture_failure_message("Capture stopped", &"  \n "),
+            "Capture stopped: unknown error."
+        );
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,6 +152,27 @@ impl ProcessDetectionStatus {
     }
 }
 
+/// Current packet-capture health exposed to the UI.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+enum CaptureStatus {
+    #[default]
+    Initializing,
+    Running,
+    Failed(String),
+}
+
+impl CaptureStatus {
+    fn has_failed(&self) -> bool {
+        matches!(self, Self::Failed(_))
+    }
+}
+
+fn capture_failure_message(context: &str, error: &impl std::fmt::Display) -> String {
+    let detail = error.to_string().replace(['\r', '\n'], " ");
+    let detail = detail.trim().trim_end_matches('.');
+    format!("{context}: {detail}. Restart rustnet to resume. Press 'q' to quit.")
+}
+
 // Connection-table limits (max connections, historic retention, QUIC mappings)
 // now live in `rustnet_core::network::tracker::TrackerConfig`, which the
 // `ConnectionTracker` enforces. The defaults match the previous constants.
@@ -725,8 +746,9 @@ pub struct App {
     /// Data link type for packet parsing (needed for PKTAP detection)
     linktype: Arc<RwLock<Option<i32>>>,
 
-    /// Set when capture setup fails before a linktype can be discovered.
-    capture_failed: Arc<AtomicBool>,
+    /// Packet-capture lifecycle state. Runtime failures are retained so the
+    /// TUI does not look healthy after its capture thread has exited.
+    capture_status: Arc<RwLock<CaptureStatus>>,
 
     /// Whether PKTAP is active (macOS only) - used to disable process enrichment
     pktap_active: Arc<AtomicBool>,
@@ -917,7 +939,7 @@ impl App {
             is_loading: Arc::new(AtomicBool::new(true)),
             current_interface: Arc::new(RwLock::new(None)),
             linktype: Arc::new(RwLock::new(None)),
-            capture_failed: Arc::new(AtomicBool::new(false)),
+            capture_status: Arc::new(RwLock::new(CaptureStatus::default())),
             pktap_active: Arc::new(AtomicBool::new(false)),
             process_detection_status: Arc::new(RwLock::new(ProcessDetectionStatus::with_method(
                 "initializing...",
@@ -1096,10 +1118,10 @@ impl App {
         let stats = Arc::clone(&self.stats);
         let current_interface = Arc::clone(&self.current_interface);
         let linktype_storage = Arc::clone(&self.linktype);
-        let capture_failed = Arc::clone(&self.capture_failed);
+        let capture_status = Arc::clone(&self.capture_status);
         let _pktap_active = Arc::clone(&self.pktap_active);
         let pcap_export_file = self.config.pcap_export_file.clone();
-        capture_failed.store(false, Ordering::Relaxed);
+        *capture_status.write().unwrap() = CaptureStatus::Initializing;
 
         // Fires once the privileged part of capture setup is done (device
         // opened or open failed), so the main thread can drop privileges.
@@ -1113,6 +1135,7 @@ impl App {
                     // Store the actual interface name and linktype being used
                     *current_interface.write().unwrap() = Some(device_name.clone());
                     *linktype_storage.write().unwrap() = Some(linktype);
+                    *capture_status.write().unwrap() = CaptureStatus::Running;
 
                     // Drop CAP_NET_RAW now that the socket is open (Linux only)
                     #[cfg(all(target_os = "linux", feature = "landlock"))]
@@ -1292,6 +1315,9 @@ impl App {
                             }
                             Err(e) => {
                                 error!("Capture error: {}", e);
+                                *capture_status.write().unwrap() = CaptureStatus::Failed(
+                                    capture_failure_message("Capture stopped", &e),
+                                );
                                 break;
                             }
                         }
@@ -1312,7 +1338,9 @@ impl App {
                     );
                 }
                 Err(e) => {
-                    capture_failed.store(true, Ordering::Relaxed);
+                    *capture_status.write().unwrap() = CaptureStatus::Failed(
+                        capture_failure_message("Capture failed to start", &e),
+                    );
                     let _ = capture_ready_tx.send(());
                     let error_msg = format!("{}", e);
 
@@ -1350,7 +1378,7 @@ impl App {
         let should_stop = Arc::clone(&self.should_stop);
         let stats = Arc::clone(&self.stats);
         let linktype_storage = Arc::clone(&self.linktype);
-        let capture_failed = Arc::clone(&self.capture_failed);
+        let capture_status = Arc::clone(&self.capture_status);
         let json_log_file = self.json_log_file.clone();
         let pcap_sidecar_file = self.pcap_sidecar_file.clone();
         let dns_resolver = self.dns_resolver.clone();
@@ -1390,8 +1418,11 @@ impl App {
                         }
                         break parser;
                     }
-                    if capture_failed.load(Ordering::Relaxed) || should_stop.load(Ordering::Relaxed)
-                    {
+                    let capture_failed = capture_status
+                        .read()
+                        .map(|status| status.has_failed())
+                        .unwrap_or(true);
+                    if capture_failed || should_stop.load(Ordering::Relaxed) {
                         info!("pcap_rx_{} exiting before linktype was available", id);
                         return;
                     }
@@ -1537,7 +1568,7 @@ impl App {
         let (tx, rx) = channel::bounded::<PcapngRecord>(MAX_PCAPNG_QUEUE);
         let should_stop = Arc::clone(&self.should_stop);
         let linktype_storage = Arc::clone(&self.linktype);
-        let capture_failed = Arc::clone(&self.capture_failed);
+        let capture_status = Arc::clone(&self.capture_status);
         let current_interface = Arc::clone(&self.current_interface);
 
         thread::Builder::new()
@@ -1548,7 +1579,11 @@ impl App {
                     if let Some(linktype) = *linktype_storage.read().unwrap() {
                         break Some(linktype);
                     }
-                    if capture_failed.load(Ordering::Relaxed) {
+                    let capture_failed = capture_status
+                        .read()
+                        .map(|status| status.has_failed())
+                        .unwrap_or(true);
+                    if capture_failed {
                         warn!(
                             "PCAPNG export could not observe capture linktype because capture setup failed; writing empty fallback section"
                         );
@@ -2675,6 +2710,17 @@ impl App {
         self.current_interface.read().unwrap().clone()
     }
 
+    /// Get the persistent packet-capture failure shown by the TUI.
+    pub fn get_capture_error(&self) -> Option<String> {
+        self.capture_status
+            .read()
+            .ok()
+            .and_then(|status| match &*status {
+                CaptureStatus::Failed(message) => Some(message.clone()),
+                CaptureStatus::Initializing | CaptureStatus::Running => None,
+            })
+    }
+
     /// Get the current process detection status (method and degradation info)
     pub fn get_process_detection_status(&self) -> ProcessDetectionStatus {
         self.process_detection_status
@@ -2780,6 +2826,15 @@ impl App {
     #[cfg(test)]
     pub(crate) fn set_current_interface_for_test(&self, iface: Option<String>) {
         *self.current_interface.write().unwrap() = iface;
+    }
+
+    /// Override packet-capture failure state. Tests only.
+    #[cfg(test)]
+    pub(crate) fn set_capture_error_for_test(&self, error: Option<&str>) {
+        *self.capture_status.write().unwrap() = match error {
+            Some(message) => CaptureStatus::Failed(message.to_string()),
+            None => CaptureStatus::Running,
+        };
     }
 
     /// Seed an interface's cumulative stats. Tests only.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -227,7 +227,14 @@ pub fn draw(
     }
 
     use widgets::filter_input::FILTER_INPUT_HEIGHT;
+    use widgets::status_bar::status_bar_height;
     use widgets::tabs_bar::TABS_BAR_HEIGHT;
+
+    // A capture failure can need a second row, so the status bar is measured
+    // before the layout is split.
+    let capture_error = app.get_capture_error();
+    let status_height = status_bar_height(capture_error.as_deref(), f.area().width);
+
     let chunks = if ui_state.filter_mode || ui_state.has_active_filter() {
         Layout::default()
             .direction(Direction::Vertical)
@@ -235,7 +242,7 @@ pub fn draw(
                 Constraint::Length(TABS_BAR_HEIGHT),     // Tabs
                 Constraint::Min(0),                      // Content
                 Constraint::Length(FILTER_INPUT_HEIGHT), // Filter input area
-                Constraint::Length(1),                   // Status bar
+                Constraint::Length(status_height),       // Status bar
             ])
             .split(f.area())
     } else {
@@ -244,7 +251,7 @@ pub fn draw(
             .constraints([
                 Constraint::Length(TABS_BAR_HEIGHT), // Tabs
                 Constraint::Min(0),                  // Content
-                Constraint::Length(1),               // Status bar
+                Constraint::Length(status_height),   // Status bar
             ])
             .split(f.area())
     };
@@ -278,7 +285,6 @@ pub fn draw(
         draw_filter_input(f, ui_state, filter_area);
     }
 
-    let capture_error = app.get_capture_error();
     draw_status_bar(
         f,
         ui_state,
@@ -783,13 +789,39 @@ mod snapshot_tests {
                 f,
                 &ui_state,
                 0,
-                Some(
-                    "Capture stopped: The interface disappeared. Restart rustnet to resume. Press 'q' to quit.",
-                ),
+                Some("Capture stopped: The interface disappeared."),
                 f.area(),
             )
         });
         insta::assert_snapshot!(output);
+    }
+
+    /// A realistic libpcap error is longer than the status row, which does not
+    /// wrap: the cause is elided so the recovery hint stays on screen.
+    #[test]
+    fn status_bar_capture_error_keeps_hint_on_narrow_terminal() {
+        let ui_state = UIState::default();
+        let output = render(80, 1, |f| {
+            draw_status_bar(
+                f,
+                &ui_state,
+                0,
+                Some(
+                    "Capture failed to start: eth0: You don't have permission to capture on that device (socket: Operation not permitted).",
+                ),
+                f.area(),
+            )
+        });
+
+        assert!(
+            output.contains("Restart rustnet to resume. Press 'q' to quit."),
+            "recovery hint must survive truncation, got: {output}"
+        );
+        assert!(
+            output.contains("Capture failed to start:"),
+            "the cause must still be introduced, got: {output}"
+        );
+        assert!(output.contains('…'), "elision marker expected: {output}");
     }
 
     // --- Full-page renders backed by a seeded App ---
@@ -839,9 +871,7 @@ mod snapshot_tests {
     #[test]
     fn full_page_shows_capture_error() {
         let app = test_app();
-        app.set_capture_error_for_test(Some(
-            "Capture stopped: The interface disappeared. Restart rustnet to resume. Press 'q' to quit.",
-        ));
+        app.set_capture_error_for_test(Some("Capture stopped: The interface disappeared."));
         let ui_state = UIState {
             show_system_panel: false,
             ..Default::default()
@@ -858,6 +888,42 @@ mod snapshot_tests {
             output
                 .contains("Capture stopped: The interface disappeared. Restart rustnet to resume. Press 'q' to quit."),
             "capture failure should remain visible in the global status bar"
+        );
+    }
+
+    /// A real libpcap error does not fit one row; the status bar claims a
+    /// second one so both the cause and the recovery hint stay readable.
+    #[test]
+    fn full_page_capture_error_grows_the_status_bar_to_two_rows() {
+        let app = test_app();
+        app.set_capture_error_for_test(Some(
+            "Capture failed to start: eth0: You don't have permission to capture on that device (socket: Operation not permitted).",
+        ));
+        let ui_state = UIState {
+            show_system_panel: false,
+            ..Default::default()
+        };
+        let stats = app.get_stats();
+        let mut click_regions = ClickableRegions::default();
+
+        let output = render(80, 16, |f| {
+            draw(f, &app, &ui_state, &[], None, &stats, &mut click_regions)
+                .expect("draw Overview with a long capture error");
+        });
+
+        let rows: Vec<&str> = output.lines().collect();
+        let hint_row = rows
+            .iter()
+            .rposition(|row| row.contains("Restart rustnet to resume. Press 'q' to quit."))
+            .expect("recovery hint must stay on screen");
+        assert_eq!(
+            hint_row,
+            rows.len() - 1,
+            "the hint belongs on the last row, got:\n{output}"
+        );
+        assert!(
+            rows[hint_row - 1].contains("Capture failed to start: eth0: You don't have permission"),
+            "the row above the hint should carry the cause, got:\n{output}"
         );
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -278,7 +278,14 @@ pub fn draw(
         draw_filter_input(f, ui_state, filter_area);
     }
 
-    draw_status_bar(f, ui_state, connections.len(), status_area);
+    let capture_error = app.get_capture_error();
+    draw_status_bar(
+        f,
+        ui_state,
+        connections.len(),
+        capture_error.as_deref(),
+        status_area,
+    );
 
     Ok(())
 }
@@ -694,7 +701,9 @@ mod snapshot_tests {
     #[test]
     fn status_bar_overview_default() {
         let ui_state = UIState::default();
-        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 42, f.area()));
+        let output = render(120, 1, |f| {
+            draw_status_bar(f, &ui_state, 42, None, f.area())
+        });
         insta::assert_snapshot!(output);
     }
 
@@ -704,7 +713,9 @@ mod snapshot_tests {
             selected_tab: 1,
             ..Default::default()
         };
-        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 42, f.area()));
+        let output = render(120, 1, |f| {
+            draw_status_bar(f, &ui_state, 42, None, f.area())
+        });
         insta::assert_snapshot!(output);
     }
 
@@ -714,7 +725,9 @@ mod snapshot_tests {
             selected_tab: 2,
             ..Default::default()
         };
-        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 42, f.area()));
+        let output = render(120, 1, |f| {
+            draw_status_bar(f, &ui_state, 42, None, f.area())
+        });
         insta::assert_snapshot!(output);
     }
 
@@ -724,7 +737,7 @@ mod snapshot_tests {
             selected_tab: 4,
             ..Default::default()
         };
-        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 0, f.area()));
+        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 0, None, f.area()));
         insta::assert_snapshot!(output);
     }
 
@@ -734,7 +747,7 @@ mod snapshot_tests {
             filter_query: "port:443".to_string(),
             ..Default::default()
         };
-        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 7, f.area()));
+        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 7, None, f.area()));
         insta::assert_snapshot!(output);
     }
 
@@ -744,7 +757,9 @@ mod snapshot_tests {
             quit_confirmation: true,
             ..Default::default()
         };
-        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 42, f.area()));
+        let output = render(120, 1, |f| {
+            draw_status_bar(f, &ui_state, 42, None, f.area())
+        });
         insta::assert_snapshot!(output);
     }
 
@@ -754,7 +769,26 @@ mod snapshot_tests {
             clear_confirmation: true,
             ..Default::default()
         };
-        let output = render(120, 1, |f| draw_status_bar(f, &ui_state, 42, f.area()));
+        let output = render(120, 1, |f| {
+            draw_status_bar(f, &ui_state, 42, None, f.area())
+        });
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn status_bar_capture_error() {
+        let ui_state = UIState::default();
+        let output = render(120, 1, |f| {
+            draw_status_bar(
+                f,
+                &ui_state,
+                0,
+                Some(
+                    "Capture stopped: The interface disappeared. Restart rustnet to resume. Press 'q' to quit.",
+                ),
+                f.area(),
+            )
+        });
         insta::assert_snapshot!(output);
     }
 
@@ -800,6 +834,31 @@ mod snapshot_tests {
         app.set_loading_for_test(false);
         app.set_current_interface_for_test(Some("eth0".to_string()));
         app
+    }
+
+    #[test]
+    fn full_page_shows_capture_error() {
+        let app = test_app();
+        app.set_capture_error_for_test(Some(
+            "Capture stopped: The interface disappeared. Restart rustnet to resume. Press 'q' to quit.",
+        ));
+        let ui_state = UIState {
+            show_system_panel: false,
+            ..Default::default()
+        };
+        let stats = app.get_stats();
+        let mut click_regions = ClickableRegions::default();
+
+        let output = render(100, 16, |f| {
+            draw(f, &app, &ui_state, &[], None, &stats, &mut click_regions)
+                .expect("draw Overview with capture error");
+        });
+
+        assert!(
+            output
+                .contains("Capture stopped: The interface disappeared. Restart rustnet to resume. Press 'q' to quit."),
+            "capture failure should remain visible in the global status bar"
+        );
     }
 
     /// Test-fixture spec for one connection. Folded into a struct so

--- a/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__status_bar_capture_error.snap
+++ b/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__status_bar_capture_error.snap
@@ -1,0 +1,5 @@
+---
+source: src/ui/mod.rs
+expression: output
+---
+ Capture stopped: The interface disappeared. Restart rustnet to resume. Press 'q' to quit.

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -341,6 +341,14 @@ pub fn status_bar_success() -> Style {
         .fg(ok())
         .add_modifier(Modifier::BOLD | Modifier::REVERSED)
 }
+pub fn status_bar_error() -> Style {
+    if super::NO_COLOR.load(super::Ordering::Relaxed) {
+        return Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED);
+    }
+    Style::default()
+        .fg(err())
+        .add_modifier(Modifier::BOLD | Modifier::REVERSED)
+}
 pub fn status_bar_default() -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) || !is_classic() {
         return Style::default().add_modifier(Modifier::REVERSED);

--- a/src/ui/widgets/status_bar.rs
+++ b/src/ui/widgets/status_bar.rs
@@ -1,6 +1,7 @@
 //! Bottom status line: shows tab-specific keybinds by default, or
 //! transient confirmation prompts ("press q again to quit"),
-//! filtered-count messages, and clipboard feedback when relevant.
+//! filtered-count messages, clipboard feedback, and capture failures
+//! (which claim a second row when they do not fit on one).
 
 use ratatui::{Frame, layout::Rect, widgets::Paragraph};
 
@@ -32,6 +33,57 @@ fn default_status_line(ui_state: &UIState) -> &'static str {
     }
 }
 
+/// Actionable half of a capture-failure line.
+const CAPTURE_RECOVERY_HINT: &str = "Restart rustnet to resume. Press 'q' to quit.";
+
+fn capture_error_one_line(cause: &str) -> String {
+    format!(" {cause} {CAPTURE_RECOVERY_HINT} ")
+}
+
+/// Rows the status bar needs. Real libpcap errors are far longer than one
+/// terminal row and the bar does not wrap, so a failure that does not fit gets
+/// a second row instead of losing its recovery hint off the right edge.
+pub(in crate::ui) fn status_bar_height(capture_error: Option<&str>, width: u16) -> u16 {
+    match capture_error {
+        Some(cause) if capture_error_one_line(cause).chars().count() > width as usize => 2,
+        _ => 1,
+    }
+}
+
+fn elide(text: &str, width: usize) -> String {
+    if text.chars().count() <= width {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(width.saturating_sub(1)).collect();
+    format!("{}…", kept.trim_end())
+}
+
+/// Lay a capture failure out over the rows `status_bar_height` reserved: cause
+/// first, recovery hint below it. When only one row is available the cause is
+/// elided instead of the hint, which is the half the user can act on.
+fn capture_error_text(cause: &str, width: u16, height: u16) -> String {
+    let single = capture_error_one_line(cause);
+    if single.chars().count() <= width as usize {
+        return single;
+    }
+    if height >= 2 {
+        return format!(
+            "{}\n{}",
+            elide(&format!(" {cause} "), width as usize),
+            elide(&format!(" {CAPTURE_RECOVERY_HINT} "), width as usize),
+        );
+    }
+
+    // " " + cause + "… " + hint + " "
+    let room = (width as usize).saturating_sub(CAPTURE_RECOVERY_HINT.chars().count() + 4);
+    if room < 16 {
+        // Too narrow for both; show as much of the cause as fits.
+        return single;
+    }
+    let cause: String = cause.chars().take(room).collect();
+    format!(" {}… {CAPTURE_RECOVERY_HINT} ", cause.trim_end())
+}
+
 pub(in crate::ui) fn draw_status_bar(
     f: &mut Frame,
     ui_state: &UIState,
@@ -52,7 +104,7 @@ pub(in crate::ui) fn draw_status_bar(
     } else if let Some(message) = clipboard_message {
         format!(" {message} ")
     } else if let Some(error) = capture_error {
-        format!(" {error} ")
+        capture_error_text(error, area.width, area.height)
     } else if ui_state.has_active_filter() {
         format!(
             " 'h' help | 1-5 jump | Tab/[/] cycle | Showing {} filtered connections (Esc to clear) ",

--- a/src/ui/widgets/status_bar.rs
+++ b/src/ui/widgets/status_bar.rs
@@ -36,19 +36,23 @@ pub(in crate::ui) fn draw_status_bar(
     f: &mut Frame,
     ui_state: &UIState,
     connection_count: usize,
+    capture_error: Option<&str>,
     area: Rect,
 ) {
+    let clipboard_message = ui_state
+        .clipboard_message
+        .as_ref()
+        .filter(|(_, time)| time.elapsed().as_secs() < 3)
+        .map(|(message, _)| message);
+
     let status = if ui_state.quit_confirmation {
         " Press 'q' again to quit or any other key to cancel ".to_string()
     } else if ui_state.clear_confirmation {
         " Press 'x' again to clear all connections or any other key to cancel ".to_string()
-    } else if let Some((ref msg, ref time)) = ui_state.clipboard_message {
-        // Show clipboard message for 3 seconds
-        if time.elapsed().as_secs() < 3 {
-            format!(" {} ", msg)
-        } else {
-            default_status_line(ui_state).to_string()
-        }
+    } else if let Some(message) = clipboard_message {
+        format!(" {message} ")
+    } else if let Some(error) = capture_error {
+        format!(" {error} ")
     } else if ui_state.has_active_filter() {
         format!(
             " 'h' help | 1-5 jump | Tab/[/] cycle | Showing {} filtered connections (Esc to clear) ",
@@ -60,17 +64,10 @@ pub(in crate::ui) fn draw_status_bar(
 
     let style = if ui_state.quit_confirmation || ui_state.clear_confirmation {
         theme::status_bar_confirm()
-    } else if ui_state.clipboard_message.is_some()
-        && ui_state
-            .clipboard_message
-            .as_ref()
-            .unwrap()
-            .1
-            .elapsed()
-            .as_secs()
-            < 3
-    {
+    } else if clipboard_message.is_some() {
         theme::status_bar_success()
+    } else if capture_error.is_some() {
+        theme::status_bar_error()
     } else {
         theme::status_bar_default()
     };


### PR DESCRIPTION
## Summary

- Retain capture startup and runtime failures in application state.
- Show a persistent status-bar error with restart and quit guidance.
- Add focused UI and snapshot coverage.

## Why

When packet capture exits after an interface failure, the TUI keeps running without indicating that capture has stopped. Fixes #496.

## Testing

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
