### PR TITLE
Fix TCP retransmit detection and duplicate-ACK counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **TCP Transport Health Counters**: `TCP Retransmits` in the Details pane stayed
+  at 0 for the life of a connection while `Fast Retransmits` climbed into the
+  dozens. Outbound sequence tracking desynchronized permanently the first time a
+  segment was missed, so no later retransmission was counted; it now tracks a
+  high-water mark that resyncs across gaps. Duplicate-ACK detection also counted
+  inbound data segments, which repeat the same ack number throughout any download
+  and inflated `Fast Retransmits` on healthy connections. `Duplicate ACKs` now
+  reports a lifetime total rather than the length of the run in progress, and
+  sequence comparisons use RFC 1982 serial arithmetic so they survive the 32-bit
+  wraparound (#501)
+
 ## [1.5.0] - 2026-07-21
 
 This release makes RustNet Kubernetes-aware: connections can be attributed to their

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -55,6 +55,13 @@ fn update_tcp_state(current_state: TcpState, flags: &TcpFlags, is_outgoing: bool
     }
 }
 
+/// RFC 1982 serial-number comparison: true when `a` precedes `b` in TCP
+/// sequence space. A plain `a < b` inverts once the 32-bit counter wraps,
+/// which long-lived or high-volume connections do reach.
+fn seq_lt(a: u32, b: u32) -> bool {
+    (a.wrapping_sub(b) as i32) < 0
+}
+
 /// Analyze TCP segment and update analytics for retransmissions and packet quality
 /// Returns (new_retransmits, new_out_of_order, new_fast_retransmits)
 fn analyze_tcp_segment(
@@ -77,81 +84,79 @@ fn analyze_tcp_segment(
         // Outbound packet - check for retransmissions
         if payload_len > 0 {
             // Only consider packets with payload for retransmit detection
-            if analytics.last_seq_outbound != 0 {
-                // Check if this sequence number is less than expected (retransmission)
-                let expected_seq = analytics.last_seq_outbound;
+            let seq_end = seq.wrapping_add(payload_len);
 
-                if seq < expected_seq {
-                    // This is a retransmission
-                    analytics.retransmit_count += 1;
-                    new_retransmits += 1;
-                    debug!(
-                        "TCP retransmission detected: seq={}, expected={}",
-                        seq, expected_seq
-                    );
-                } else if seq > expected_seq {
-                    // Gap in sequence numbers - might be out of order or packet loss
-                    debug!(
-                        "TCP sequence gap detected: seq={}, expected={}",
-                        seq, expected_seq
-                    );
-                } else {
-                    // seq == expected_seq, normal in-order packet
-                    analytics.last_seq_outbound = seq.wrapping_add(payload_len);
-                }
-            } else {
+            if !analytics.seen_outbound {
                 // First packet with data
-                analytics.last_seq_outbound = seq.wrapping_add(payload_len);
+                analytics.seen_outbound = true;
+                analytics.highest_seq_outbound = seq_end;
+            } else if !seq_lt(analytics.highest_seq_outbound, seq_end) {
+                // Segment ends at or before the highest byte already sent, so
+                // it carries data the peer was sent before: a retransmission.
+                // Counted every time, as repeated resends of one segment are
+                // each a distinct retransmission.
+                analytics.retransmit_count += 1;
+                new_retransmits += 1;
+                debug!(
+                    "TCP retransmission detected: seq={}, len={}, highest={}",
+                    seq, payload_len, analytics.highest_seq_outbound
+                );
+            } else {
+                // Advances the stream. Covers both in-order segments and gaps
+                // left by dropped captures; either way the high-water mark
+                // resyncs so later retransmissions are still detected.
+                analytics.highest_seq_outbound = seq_end;
             }
         }
     } else {
         // Inbound packet - check for out-of-order and duplicate ACKs
         if payload_len > 0 {
-            if analytics.last_seq_inbound != 0 {
-                let expected_seq = analytics.last_seq_inbound;
+            let seq_end = seq.wrapping_add(payload_len);
 
-                if seq < expected_seq {
-                    // Out-of-order packet (arrived late)
-                    analytics.out_of_order_count += 1;
-                    new_out_of_order += 1;
-                    debug!(
-                        "TCP out-of-order packet: seq={}, expected={}",
-                        seq, expected_seq
-                    );
-                } else if seq > expected_seq {
-                    // Gap - possible packet loss
-                    analytics.last_seq_inbound = seq.wrapping_add(payload_len);
-                } else {
-                    // Normal in-order packet
-                    analytics.last_seq_inbound = seq.wrapping_add(payload_len);
-                }
-            } else {
+            if !analytics.seen_inbound {
                 // First inbound packet with data
-                analytics.last_seq_inbound = seq.wrapping_add(payload_len);
+                analytics.seen_inbound = true;
+                analytics.highest_seq_inbound = seq_end;
+            } else if !seq_lt(analytics.highest_seq_inbound, seq_end) {
+                // Re-covers data already received: arrived late or duplicated.
+                analytics.out_of_order_count += 1;
+                new_out_of_order += 1;
+                debug!(
+                    "TCP out-of-order packet: seq={}, len={}, highest={}",
+                    seq, payload_len, analytics.highest_seq_inbound
+                );
+            } else {
+                analytics.highest_seq_inbound = seq_end;
             }
         }
 
-        // Check for duplicate ACKs (fast retransmit indicator)
-        if has_ack_flag {
-            if analytics.last_ack_received != 0 {
-                if ack == analytics.last_ack_received {
-                    // Duplicate ACK
-                    analytics.duplicate_ack_count += 1;
-
-                    // RFC 2581: 3 duplicate ACKs trigger fast retransmit
-                    if analytics.duplicate_ack_count == 3 {
-                        analytics.fast_retransmit_count += 1;
-                        new_fast_retransmits += 1;
-                        debug!("TCP fast retransmit triggered (3 duplicate ACKs)");
-                    }
-                } else {
-                    // New ACK - reset duplicate counter
-                    analytics.last_ack_received = ack;
-                    analytics.duplicate_ack_count = 0;
-                }
-            } else {
+        // Check for duplicate ACKs (fast retransmit indicator).
+        //
+        // RFC 5681 §2 requires a duplicate ACK to carry no data — otherwise
+        // every inbound data segment of a download counts as one, since they
+        // all repeat the same ack number while we have nothing to send, and
+        // the fast-retransmit total balloons on healthy connections.
+        if has_ack_flag && payload_len == 0 {
+            if !analytics.seen_ack {
                 // First ACK seen
+                analytics.seen_ack = true;
                 analytics.last_ack_received = ack;
+            } else if ack == analytics.last_ack_received {
+                // Duplicate ACK
+                analytics.dup_ack_run += 1;
+                analytics.duplicate_ack_count += 1;
+
+                // RFC 5681: 3 duplicate ACKs trigger fast retransmit
+                if analytics.dup_ack_run == 3 {
+                    analytics.fast_retransmit_count += 1;
+                    new_fast_retransmits += 1;
+                    debug!("TCP fast retransmit triggered (3 duplicate ACKs)");
+                }
+            } else if seq_lt(analytics.last_ack_received, ack) {
+                // Only a forward-moving ACK ends the run. A reordered stale
+                // ACK must not clear it, or the run never reaches 3.
+                analytics.last_ack_received = ack;
+                analytics.dup_ack_run = 0;
             }
         }
     }
@@ -1111,5 +1116,99 @@ mod tests {
         };
         let new_state = update_tcp_state(TcpState::Established, &flags, true);
         assert_eq!(new_state, TcpState::Closed);
+    }
+
+    use crate::network::types::TcpAnalytics;
+
+    /// Send one outbound data segment. Window and ack are irrelevant here.
+    fn send(analytics: &mut TcpAnalytics, seq: u32, len: u32) {
+        analyze_tcp_segment(analytics, seq, 0, 65535, len, true, false);
+    }
+
+    /// Receive one inbound segment.
+    fn recv(analytics: &mut TcpAnalytics, seq: u32, ack: u32, len: u32) {
+        analyze_tcp_segment(analytics, seq, ack, 65535, len, false, true);
+    }
+
+    #[test]
+    fn detects_retransmit_after_a_sequence_gap() {
+        // Regression: a gap used to freeze the outbound tracker permanently,
+        // so every later retransmission went uncounted.
+        let mut a = TcpAnalytics::new();
+
+        // Starting at 0 also covers the old `!= 0` "initialised" sentinel,
+        // which silently dropped the first segment of such a stream.
+        send(&mut a, 0, 100); // in order, high-water = 100
+        assert!(a.seen_outbound);
+
+        send(&mut a, 5000, 100); // gap (capture drop) — must resync to 5100
+        assert_eq!(a.retransmit_count, 0, "a gap is not a retransmission");
+        assert_eq!(a.highest_seq_outbound, 5100, "tracker must resync on a gap");
+
+        send(&mut a, 5000, 100); // genuine resend of data already sent
+        assert_eq!(a.retransmit_count, 1);
+
+        send(&mut a, 5100, 100); // stream continues normally afterwards
+        assert_eq!(a.retransmit_count, 1);
+        assert_eq!(a.highest_seq_outbound, 5200);
+    }
+
+    #[test]
+    fn sequence_comparison_survives_wraparound() {
+        // Straddle the u32 boundary, where a raw `<` inverts.
+        let mut a = TcpAnalytics::new();
+
+        send(&mut a, u32::MAX - 50, 100); // wraps to 49
+        assert_eq!(a.highest_seq_outbound, 49);
+
+        send(&mut a, 49, 100); // advances past the wrap, not a retransmit
+        assert_eq!(a.retransmit_count, 0);
+
+        send(&mut a, u32::MAX - 50, 100); // pre-wrap data resent
+        assert_eq!(a.retransmit_count, 1);
+    }
+
+    #[test]
+    fn inbound_data_segments_are_not_duplicate_acks() {
+        // Regression: a download repeats the same ack number on every data
+        // segment while we have nothing to send. Those are not dup ACKs, and
+        // counting them inflated fast retransmits on healthy connections.
+        let mut a = TcpAnalytics::new();
+
+        let mut seq = 1000;
+        for _ in 0..20 {
+            recv(&mut a, seq, 500, 1400);
+            seq += 1400;
+        }
+
+        assert_eq!(a.duplicate_ack_count, 0);
+        assert_eq!(a.fast_retransmit_count, 0);
+        assert_eq!(a.out_of_order_count, 0);
+    }
+
+    #[test]
+    fn fast_retransmit_fires_once_per_dup_ack_run() {
+        let mut a = TcpAnalytics::new();
+
+        recv(&mut a, 0, 500, 0); // first ACK establishes the baseline
+        recv(&mut a, 0, 500, 0); // dup 1
+        recv(&mut a, 0, 500, 0); // dup 2
+        assert_eq!(a.fast_retransmit_count, 0);
+
+        recv(&mut a, 0, 500, 0); // dup 3 -> fast retransmit
+        assert_eq!(a.fast_retransmit_count, 1);
+
+        recv(&mut a, 0, 500, 0); // dup 4 must not re-trigger
+        assert_eq!(a.fast_retransmit_count, 1);
+        assert_eq!(a.duplicate_ack_count, 4, "cumulative, not the run length");
+
+        // A new ACK ends the run; the next run triggers again.
+        recv(&mut a, 0, 900, 0);
+        assert_eq!(a.dup_ack_run, 0);
+        for _ in 0..3 {
+            recv(&mut a, 0, 900, 0);
+        }
+        assert_eq!(a.fast_retransmit_count, 2);
+        assert_eq!(a.duplicate_ack_count, 7);
     }
 }

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -2176,15 +2176,25 @@ impl Default for RateTracker {
 /// TCP analytics for tracking retransmissions and connection quality
 #[derive(Debug, Clone)]
 pub struct TcpAnalytics {
-    // Sequence number tracking
-    pub last_seq_outbound: u32,
-    pub last_seq_inbound: u32,
+    // Highest sequence number seen in each direction, i.e. the next byte the
+    // stream is expected to reach. Tracking the high-water mark rather than a
+    // strict "next expected seq" keeps detection alive across gaps: a segment
+    // missed by the capture advances the mark instead of desynchronising it.
+    pub highest_seq_outbound: u32,
+    pub highest_seq_inbound: u32,
+    // 0 is a legal sequence/ack number, so it cannot double as "not yet seen".
+    pub seen_outbound: bool,
+    pub seen_inbound: bool,
 
     // ACK tracking for duplicate detection
     pub last_ack_received: u32,
-    pub duplicate_ack_count: u32,
+    pub seen_ack: bool,
+    /// Length of the duplicate-ACK run currently in progress. Live state,
+    /// cleared by every ACK that advances; not a lifetime statistic.
+    pub dup_ack_run: u32,
 
     // Statistics counters
+    pub duplicate_ack_count: u64,
     pub retransmit_count: u64,
     pub out_of_order_count: u64,
     pub fast_retransmit_count: u64,
@@ -2196,9 +2206,13 @@ pub struct TcpAnalytics {
 impl TcpAnalytics {
     pub fn new() -> Self {
         Self {
-            last_seq_outbound: 0,
-            last_seq_inbound: 0,
+            highest_seq_outbound: 0,
+            highest_seq_inbound: 0,
+            seen_outbound: false,
+            seen_inbound: false,
             last_ack_received: 0,
+            seen_ack: false,
+            dup_ack_run: 0,
             duplicate_ack_count: 0,
             retransmit_count: 0,
             out_of_order_count: 0,


### PR DESCRIPTION
## Summary

The Details pane reported `TCP Retransmits 0` for the entire life of a connection while `Fast Retransmits` climbed into the dozens — a superset counter reading below its own subset. Two independent bugs produced that.

**Outbound retransmits were undercounted (stuck at 0).** `analyze_tcp_segment` compared each outbound segment against a strict "next expected seq" and only advanced that marker on an exact match. The first time a segment was missed — a dropped capture, a coalesced or reordered segment — the marker froze permanently: every subsequent packet then looked like a forward gap, so no retransmission was ever counted again. The inbound path already resynced on gaps, which is why out-of-order counting kept working and retransmit counting did not. Both directions now track a high-water mark that advances across gaps, so detection survives an imperfect capture.

**Fast retransmits were overcounted.** Duplicate-ACK detection ignored the payload length, so every inbound *data* segment counted as a duplicate ACK — during any download they all repeat the same ack number while the local side has nothing to send. RFC 5681 §2 requires a duplicate ACK to carry no data. This alone drove a large fast-retransmit total on entirely healthy connections.

Three smaller correctness fixes in the same function:

- `Duplicate ACKs` was live state — the length of the run in progress, cleared by every new ACK — but was rendered in Transport Health beside three lifetime counters. Split into `dup_ack_run` (live) and a cumulative `duplicate_ack_count`; the Details pane now shows a real total. This changes the meaning of a displayed field.
- Sequence comparisons used raw `<` on wrapping `u32` counters, which inverts at the 32-bit boundary. Now RFC 1982 serial arithmetic via a `seq_lt` helper.
- `!= 0` served as the "initialised" sentinel, but 0 is a valid sequence and ack number. Replaced with explicit `seen_*` flags.

Only a duplicate-ACK run reaching exactly 3 triggers a fast retransmit, and only a forward-moving ACK ends a run — a reordered stale ACK no longer resets it before it reaches the threshold.

## Linked issue

No prior issue; found while inspecting a live connection's Transport Health panel. Per CONTRIBUTING.md bug fixes do not need one.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build --release`

All four pass, rebased onto current `main` (c548000).

## Scope

- [x] One feature or fix per PR (no unrelated cleanups bundled in)
- [x] No new dependencies, or rationale provided in the summary above
- [x] No `#[allow(clippy::...)]` suppressions, or rationale provided
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## AI-assisted contributions

Written with Claude Code. Verification commands were run locally and their real output is reported above.

- [ ] I have read every line I am submitting
- [x] I ran the verification commands above myself
- [x] The PR description reflects what the code actually does

## Notes for the reviewer

Four tests cover the two regressions and the two latent bugs: `detects_retransmit_after_a_sequence_gap` (also covers the zero-sequence sentinel), `sequence_comparison_survives_wraparound`, `inbound_data_segments_are_not_duplicate_acks`, and `fast_retransmit_fires_once_per_dup_ack_run`.

Two deliberate trade-offs worth a look:

1. A retransmission that re-sends old data *and* extends past the high-water mark in one segment is treated as advancing the stream, not as a retransmit. Detecting those needs real range tracking; the simpler high-water mark handles the common case without per-connection allocation.
2. Counting is now per-segment, so a segment resent three times counts three times. That seemed right for a health indicator, but it is a judgment call.

`Fast Retransmits` and `TCP Retransmits` can still legitimately differ after this: the former is *inferred* from inbound dup ACKs (the peer signalling loss), the latter requires *observing* our own resend on the wire. They should now be in the same ballpark rather than 40 versus 0.