### PR TITLE
chore: fix rustfmt drift in overview test imports

### DIFF
--- a/src/ui/tabs/overview.rs
+++ b/src/ui/tabs/overview.rs
@@ -1496,9 +1496,8 @@ mod tests {
 
     use super::{
         MINI_WAVE_INTENSITY, OverviewTab, SYSTEM_PANEL_WIDTH, connections_title,
-        detection_method_label,
-        handle_filter_mode_key, is_filter_backspace_char, mini_wave, mini_wave_ceiling,
-        mini_wave_window, smooth_mini_wave,
+        detection_method_label, handle_filter_mode_key, is_filter_backspace_char, mini_wave,
+        mini_wave_ceiling, mini_wave_window, smooth_mini_wave,
     };
     use crate::{
         app::{App, Config},


### PR DESCRIPTION
## Summary

`cargo fmt --all -- --check` currently fails on an unmodified `main` at `src/ui/tabs/overview.rs:1496`. That is the first command the PR template asks every contributor to run, so anyone opening a PR sees a failure that has nothing to do with their change and has to work out whether they caused it. I hit exactly that in #501.

This is pure `cargo fmt --all` output on the test-module import block — no behavior change, no logic touched.

## Linked issue

No prior issue; noticed while running the PR template's verification commands for #501.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build --release`

All four now pass on this branch. `cargo fmt --all -- --check` fails on `main` before it.

## Scope

- [x] One feature or fix per PR (no unrelated cleanups bundled in)
- [x] No new dependencies, or rationale provided in the summary above
- [x] No `#[allow(clippy::...)]` suppressions, or rationale provided

No `CHANGELOG.md` entry: rustfmt drift is not a user-visible change.

## AI-assisted contributions

Written with Claude Code. Verification commands were run locally and their real output is reported above.

- [ ] I have read every line I am submitting
- [x] I ran the verification commands above myself
- [x] The PR description reflects what the code actually does

## Notes for the reviewer

Worth a look at why this reached `main` — if CI runs `cargo fmt --all -- --check`, it should have caught this, so either the check is not wired into the workflow or it is not gating merges.