### PR TITLE
docs: make the changelog-in-same-PR convention consistent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,6 +40,9 @@ them, but local verification catches issues faster. -->
 - [ ] No new dependencies, or rationale provided in the summary above
 - [ ] No `#[allow(clippy::...)]` suppressions, or rationale provided
   (see [CONTRIBUTING.md](https://github.com/domcyrus/rustnet/blob/main/CONTRIBUTING.md#code-quality-requirements))
+- [ ] User-visible changes are added to the `## [Unreleased]` section of
+  `CHANGELOG.md` in this PR, or this change is not user-visible
+  (see [CONTRIBUTING.md](https://github.com/domcyrus/rustnet/blob/main/CONTRIBUTING.md#pr-guidelines))
 
 ## AI-assisted contributions
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -93,6 +93,7 @@ RustNet 追求小而快。并不是每个协议或功能都适合放在核心工
 - 保持 PR 聚焦——每个 PR 只做一件事
 - 及时响应 review 反馈
 - 在提交 PR 之前在本地验证。PR 模板中列出了需要执行的精确命令。
+- 在同一个 PR 中把用户可见的改动写入 `CHANGELOG.md` 的 `## [Unreleased]` 小节
 
 ## 重复 Pull Request<a id="duplicate-pull-requests"></a>
 


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md:96` and `RELEASE.md:5-11` both already state the same rule: user-visible changes go into the `## [Unreleased]` section of `CHANGELOG.md` in the same PR that makes them, rather than being reconstructed from git history at release time. RELEASE.md is explicit that this is "ongoing, not at release time".

Two places did not carry that, which is how the convention ends up being applied inconsistently:

- **The PR template had no changelog item at all.** It has Verification and Scope checklists, so the list a contributor actually fills in never mentioned the changelog — the rule lived only in prose in a separate file.
- **`CONTRIBUTING.zh-CN.md` was missing the bullet** its English counterpart has in the PR Guidelines section, so the localized guidelines contradicted the English ones.

The new template item allows for changes that are not user-visible, which is the exception `CONTRIBUTING.md` already implies by scoping the rule to user-visible changes — a rustfmt fix or a CI tweak should not need an entry.

## Linked issue

No prior issue; came out of #501, where the convention was ambiguous enough in practice to be worth pinning down.

## Verification

Documentation and PR-template only — no code changes, so the Rust verification commands do not apply here (`.github/**` and `*.md` are outside the `rust.yml` path filters).

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build --release`

Checked anyway on this branch; all pass, unchanged from `main`.

## Scope

- [x] One feature or fix per PR (no unrelated cleanups bundled in)
- [x] No new dependencies, or rationale provided in the summary above
- [x] No `#[allow(clippy::...)]` suppressions, or rationale provided
- [x] User-visible changes are added to the `## [Unreleased]` section of `CHANGELOG.md` in this PR, or this change is not user-visible

No `CHANGELOG.md` entry here: contributor-facing documentation is not user-visible. That is also the first exercise of the new checkbox.

## AI-assisted contributions

Written with Claude Code.

- [ ] I have read every line I am submitting
- [x] I ran the verification commands above myself
- [x] The PR description reflects what the code actually does

## Notes for the reviewer

The zh-CN bullet is a translation of the English one; worth a native-speaker check that the wording matches the register of the surrounding bullets.

If the intent is actually the opposite — changelog assembled at release time rather than per-PR — then this PR is backwards and the fix belongs in `CONTRIBUTING.md` and `RELEASE.md` instead. Flagging because that is the one thing I cannot settle from the docs themselves.