### PR TITLE
Add rich process attribution results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   application state and shown as a persistent status-bar error with restart and quit
   guidance, instead of the TUI running on silently after capture stopped. The status
   bar grows a second row when the message and hint do not fit on one (#497)
+- **Rich Process Attribution**: `ProcessLookup::get_process_attribution()` returns a
+  `ProcessAttribution` carrying TGID, thread ID, effective UID/GID, executable path,
+  the producing backend, and a monotonic observation timestamp instead of only
+  `(pid, name)`. The new `MatchQuality` records how a connection was matched, so a
+  relaxed wildcard or listener guess is no longer indistinguishable from a proven
+  4-tuple hit. On Linux the eBPF backends carry the kernel-recorded identity through
+  unchanged and resolve `/proc/<tgid>/exe` in user space; the enhanced cache stores
+  the full result, so metadata and match quality survive the first lookup. Platforms
+  that only implement the legacy tuple API are bridged automatically, so
+  `get_process_for_connection()` keeps working everywhere (#505)
 
 ### Changed
 - **Modern Linux eBPF Attribution Backend**: Process attribution now prefers BPF

--- a/crates/rustnet-host/README.md
+++ b/crates/rustnet-host/README.md
@@ -23,14 +23,42 @@ if let Some((pid, name)) = lookup.get_process_for_connection(&conn) {
 }
 ```
 
+Callers that want more than a pid and a name ask for a `ProcessAttribution`
+instead:
+
+```rust
+if let Some(attribution) = lookup.get_process_attribution(&conn) {
+    println!(
+        "{} ({}) uid={:?} exe={:?} via {} ({} match)",
+        attribution.name,
+        attribution.tgid,
+        attribution.uid,
+        attribution.executable,
+        attribution.backend,
+        attribution.quality,
+    );
+}
+```
+
+`MatchQuality` records how the connection was matched, so a relaxed
+wildcard/listener guess is never mistaken for a proven 4-tuple hit; use
+`quality.is_exact()` to tell them apart. On Linux the eBPF backends also fill in
+the thread id, effective UID/GID, and an observation timestamp taken from a
+**monotonic** clock (`bpf_ktime_get_ns`), which is not wall-clock time. The
+executable path is resolved once from `/proc/<tgid>/exe`; an unreadable link
+yields `executable: None` and never fails the attribution.
+
+Platforms that have not been ported get a compatibility bridge over
+`get_process_for_connection()` reporting `MatchQuality::Unspecified`, so every
+existing caller and platform keeps working unchanged.
+
 When a platform can't use its optimal method, `ProcessLookup::get_degradation_reason`
 reports why (e.g. missing `CAP_BPF`, no root for PKTAP) via `DegradationReason`,
 which front-ends can surface to the user.
 
 Linux callers can inspect `ProcessLookup::get_attribution_backend()` and
 `ProcessLookup::get_attribution_capabilities()` to distinguish fentry/fexit,
-legacy kprobes, procfs, and partial protocol coverage. Existing
-`get_process_for_connection()` callers remain unchanged.
+legacy kprobes, procfs, and partial protocol coverage.
 
 Both Linux BPF objects use CO-RE for safe socket field access and therefore
 require usable target BTF. A compatible target-BTF kernel tries fentry/fexit
@@ -41,7 +69,9 @@ directly to procfs rather than relying on fixed structure offsets.
 
 The ignored root test covers outbound TCP, accepted TCP, connected UDP, and
 unconnected UDP for IPv4 and IPv6. It also verifies TGID/TID, UID/GID, `comm`,
-and monotonic timestamps.
+monotonic timestamps, match quality, `/proc/<tgid>/exe` resolution, and that a
+socket opened by a worker thread is attributed to that thread rather than to the
+group leader.
 
 ```bash
 sudo -E cargo test -p rustnet-host --features ebpf -- \

--- a/crates/rustnet-host/src/lib.rs
+++ b/crates/rustnet-host/src/lib.rs
@@ -14,6 +14,13 @@
 //!   (`GetExtendedTcpTable`/`...UdpTable`) fallback.
 //! - **FreeBSD** — `sockstat`.
 //!
+//! [`ProcessLookup::get_process_attribution`] returns the richer
+//! [`ProcessAttribution`]: thread id, effective UID/GID, executable path, the
+//! producing [`AttributionBackend`], a [`MatchQuality`] saying how the
+//! connection was matched, and a monotonic observation time. Platforms that
+//! only implement the tuple API are bridged automatically, so
+//! `get_process_for_connection` keeps working everywhere.
+//!
 //! When a platform can't use its optimal method, [`ProcessLookup::get_degradation_reason`]
 //! reports why via [`DegradationReason`] (e.g. missing `CAP_BPF`, no root for
 //! PKTAP), which front-ends can surface to the user.
@@ -29,6 +36,7 @@ use rustnet_core::network::types::{Connection, Protocol};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::PathBuf;
 
 /// Active process-attribution backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -67,6 +75,154 @@ bitflags::bitflags! {
         const UDP_V6_SEND    = 1 << 4;
         const ICMP_V4_SEND   = 1 << 5;
         const ICMP_V6_SEND   = 1 << 6;
+    }
+}
+
+/// How closely an attribution result matched the connection it was asked about.
+///
+/// Backends record sockets under the tuple they saw at creation time, which is
+/// not always the tuple the capture side observes on the wire. A lookup may
+/// therefore have to relax the key, and the caller deserves to know that it
+/// did: a relaxed hit is a plausible owner, not a proven one.
+///
+/// Marked `#[non_exhaustive]` so new relaxation shapes can be added without
+/// breaking downstream `match` arms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MatchQuality {
+    /// The full 4-tuple matched a recorded socket.
+    ExactTuple,
+    /// Matched only after zeroing the local address, i.e. the socket was
+    /// recorded while bound to a wildcard address.
+    WildcardLocalAddress,
+    /// Matched a listening socket (the recorded entry has no remote peer).
+    ListenerSocket,
+    /// Exact 4-tuple match in the procfs socket table.
+    ProcfsExact,
+    /// procfs match that needed a relaxed key.
+    ProcfsRelaxed,
+    /// The backend reported an owner but not how it matched. Produced by the
+    /// compatibility bridge in [`ProcessLookup::get_process_attribution`] for
+    /// platforms that still only implement the tuple API.
+    Unspecified,
+}
+
+impl MatchQuality {
+    /// Whether the connection's exact 4-tuple was found, with no relaxation.
+    pub fn is_exact(self) -> bool {
+        matches!(self, Self::ExactTuple | Self::ProcfsExact)
+    }
+}
+
+impl std::fmt::Display for MatchQuality {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::ExactTuple => "exact tuple",
+            Self::WildcardLocalAddress => "wildcard local address",
+            Self::ListenerSocket => "listener socket",
+            Self::ProcfsExact => "procfs exact",
+            Self::ProcfsRelaxed => "procfs relaxed",
+            Self::Unspecified => "unspecified",
+        };
+        f.write_str(name)
+    }
+}
+
+/// A rich process-attribution result.
+///
+/// Everything past `tgid`/`name` is best effort: a backend fills in what it
+/// actually observed and leaves the rest `None` rather than guessing. Only the
+/// Linux eBPF backends currently report thread ids, credentials, and an
+/// observation timestamp.
+///
+/// Marked `#[non_exhaustive]` because cgroup and container fields are expected
+/// to land here later. Build values with [`ProcessAttribution::new`] plus the
+/// `with_*` methods instead of a struct literal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ProcessAttribution {
+    /// Thread group id, i.e. the PID as user space understands it.
+    pub tgid: u32,
+    /// Kernel thread id that performed the operation, when the backend sees
+    /// per-thread identity. `None` for socket-table backends, and equal to
+    /// `tgid` when the main thread did the work.
+    pub tid: Option<u32>,
+    /// Process name: `/proc/<tgid>/comm` on Linux, the OS-reported name elsewhere.
+    pub name: String,
+    /// Effective user id of the owning process.
+    pub uid: Option<u32>,
+    /// Effective group id of the owning process.
+    pub gid: Option<u32>,
+    /// Absolute executable path, resolved once at attribution time. `None` when
+    /// the process already exited or the path is unreadable.
+    pub executable: Option<PathBuf>,
+    /// Backend that produced this result.
+    pub backend: AttributionBackend,
+    /// How the connection key matched the backend's records.
+    pub quality: MatchQuality,
+    /// Observation time in nanoseconds on a **monotonic** clock
+    /// (`CLOCK_MONOTONIC` on Linux). This is not wall-clock time: it is only
+    /// meaningful relative to other monotonic readings from the same boot, and
+    /// must never be formatted as a date.
+    pub observed_at_ns: Option<u64>,
+}
+
+impl ProcessAttribution {
+    /// Create an attribution with only the fields every backend can supply.
+    pub fn new(
+        tgid: u32,
+        name: impl Into<String>,
+        backend: AttributionBackend,
+        quality: MatchQuality,
+    ) -> Self {
+        Self {
+            tgid,
+            tid: None,
+            name: name.into(),
+            uid: None,
+            gid: None,
+            executable: None,
+            backend,
+            quality,
+            observed_at_ns: None,
+        }
+    }
+
+    /// Attach the kernel thread id that performed the operation.
+    pub fn with_tid(mut self, tid: u32) -> Self {
+        self.tid = Some(tid);
+        self
+    }
+
+    /// Attach the effective user and group id.
+    pub fn with_credentials(mut self, uid: u32, gid: u32) -> Self {
+        self.uid = Some(uid);
+        self.gid = Some(gid);
+        self
+    }
+
+    /// Attach the resolved executable path. `None` is a valid outcome and is
+    /// stored as such: failing to read the path never fails the attribution.
+    pub fn with_executable(mut self, executable: Option<PathBuf>) -> Self {
+        self.executable = executable;
+        self
+    }
+
+    /// Attach a **monotonic** observation timestamp in nanoseconds.
+    pub fn with_observed_at_ns(mut self, observed_at_ns: u64) -> Self {
+        self.observed_at_ns = Some(observed_at_ns);
+        self
+    }
+
+    /// Reduce to the legacy `(pid, process_name)` pair.
+    pub fn into_pid_name(self) -> (u32, String) {
+        (self.tgid, self.name)
+    }
+}
+
+impl From<ProcessAttribution> for (u32, String) {
+    fn from(attribution: ProcessAttribution) -> Self {
+        attribution.into_pid_name()
     }
 }
 
@@ -231,6 +387,29 @@ pub trait ProcessLookup: Send + Sync {
     /// Returns (pid, process_name) if found
     fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)>;
 
+    /// Rich attribution for a connection: identity, credentials, executable
+    /// path, and the provenance of the match.
+    ///
+    /// The default implementation bridges the legacy tuple returned by
+    /// [`ProcessLookup::get_process_for_connection`], so platforms that have
+    /// not been ported keep working unchanged. It reports
+    /// [`MatchQuality::Unspecified`] because the tuple API carries no
+    /// provenance, and never claims an exact match it cannot prove.
+    ///
+    /// Overriding is only half the contract: an implementation whose
+    /// `get_process_for_connection` delegates *to this method* **must** also
+    /// override this method, otherwise the two default paths call each other
+    /// forever.
+    fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
+        let (tgid, name) = self.get_process_for_connection(conn)?;
+        Some(ProcessAttribution::new(
+            tgid,
+            name,
+            self.get_attribution_backend(),
+            MatchQuality::Unspecified,
+        ))
+    }
+
     /// Refresh internal caches if any (best-effort)
     fn refresh(&self) -> Result<()> {
         Ok(()) // Default no-op
@@ -257,16 +436,11 @@ pub trait ProcessLookup: Send + Sync {
         AttributionCapabilities::empty()
     }
 
-    /// Fallback lookup that relaxes the connection key to handle sockets stored with
-    /// wildcard addresses in OS-level tables.
+    /// Fallback lookup that relaxes the connection key to handle sockets stored
+    /// with wildcard addresses in OS-level tables.
     ///
-    /// Three shapes that actually appear in OS socket tables:
-    ///   1. (lip:lport, 0:0)      — listening on a specific local IP
-    ///   2. (0:lport,  rip:rport) — INADDR_ANY socket connected to a known remote
-    ///   3. (0:lport,  0:0)       — listening on INADDR_ANY
-    ///
-    /// If two candidates resolve to different processes the result is ambiguous and
-    /// `None` is returned to avoid mis-attribution.
+    /// Thin wrapper over [`relaxed_lookup`] for callers that only want the
+    /// owner and not the match provenance.
     fn fallback_lookup(
         map: &HashMap<ConnectionKey, (u32, String)>,
         key: &ConnectionKey,
@@ -274,52 +448,73 @@ pub trait ProcessLookup: Send + Sync {
     where
         Self: Sized,
     {
-        // Only TCP and UDP sockets appear in OS network tables with wildcard
-        // addresses. Other protocols (ICMP, IGMP, ARP) have no entries to fall back to.
-        if !matches!(key.protocol, Protocol::Tcp | Protocol::Udp) {
-            return None;
-        }
-
-        let zero = |addr: SocketAddr| -> IpAddr {
-            match addr {
-                SocketAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                SocketAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-            }
-        };
-
-        let lip = key.local_addr.ip();
-        let lport = key.local_addr.port();
-        let rip = key.remote_addr.ip();
-        let rport = key.remote_addr.port();
-        let zlip = zero(key.local_addr);
-        let zrip = zero(key.remote_addr);
-
-        let candidates: [(IpAddr, u16, IpAddr, u16); 3] = [
-            (lip, lport, zrip, 0),     // 1. listening on specific local IP
-            (zlip, lport, rip, rport), // 2. INADDR_ANY with known remote
-            (zlip, lport, zrip, 0),    // 3. INADDR_ANY listener
-        ];
-
-        // Collect all matches across every candidate. If two candidates resolve to
-        // different processes the result is ambiguous — return nothing to avoid
-        // attributing traffic to the wrong process.
-        let mut found: Option<(u32, String)> = None;
-        for (l_ip, l_port, r_ip, r_port) in candidates {
-            let candidate = ConnectionKey {
-                protocol: key.protocol,
-                local_addr: SocketAddr::new(l_ip, l_port),
-                remote_addr: SocketAddr::new(r_ip, r_port),
-            };
-            if let Some(entry) = map.get(&candidate) {
-                match &found {
-                    None => found = Some(entry.clone()),
-                    Some(existing) if existing == entry => {} // same result, no conflict
-                    Some(_) => return None,                   // two different processes → ambiguous
-                }
-            }
-        }
-        found
+        relaxed_lookup(map, key).map(|(entry, _quality)| entry.clone())
     }
+}
+
+/// Match a connection key against an OS socket table keyed by exact 4-tuples,
+/// progressively relaxing the key, and report which shape matched.
+///
+/// Three shapes actually appear in OS socket tables:
+///   1. (0:lport,  rip:rport) — wildcard-bound socket with a known remote
+///   2. (lip:lport, 0:0)      — listening on a specific local IP
+///   3. (0:lport,  0:0)       — listening on the wildcard address
+///
+/// Candidates are tried most-specific first, so the reported
+/// [`MatchQuality`] describes the tightest shape that matched.
+///
+/// Every candidate is still probed even after a hit: if two candidates resolve
+/// to *different* owners the answer is ambiguous and `None` is returned rather
+/// than a coin flip. Candidates that agree are not a conflict.
+pub fn relaxed_lookup<'map, V: PartialEq>(
+    map: &'map HashMap<ConnectionKey, V>,
+    key: &ConnectionKey,
+) -> Option<(&'map V, MatchQuality)> {
+    // Only TCP and UDP sockets appear in OS network tables with wildcard
+    // addresses. Other protocols (ICMP, IGMP, ARP) have no entries to fall back to.
+    if !matches!(key.protocol, Protocol::Tcp | Protocol::Udp) {
+        return None;
+    }
+
+    let zero = |addr: SocketAddr| -> IpAddr {
+        match addr {
+            SocketAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            SocketAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+        }
+    };
+
+    let lip = key.local_addr.ip();
+    let lport = key.local_addr.port();
+    let rip = key.remote_addr.ip();
+    let rport = key.remote_addr.port();
+    let zlip = zero(key.local_addr);
+    let zrip = zero(key.remote_addr);
+
+    let candidates: [(IpAddr, u16, IpAddr, u16, MatchQuality); 3] = [
+        // 1. wildcard local address, known remote
+        (zlip, lport, rip, rport, MatchQuality::WildcardLocalAddress),
+        // 2. listening on a specific local IP
+        (lip, lport, zrip, 0, MatchQuality::ListenerSocket),
+        // 3. listening on the wildcard address
+        (zlip, lport, zrip, 0, MatchQuality::ListenerSocket),
+    ];
+
+    let mut found: Option<(&V, MatchQuality)> = None;
+    for (l_ip, l_port, r_ip, r_port, quality) in candidates {
+        let candidate = ConnectionKey {
+            protocol: key.protocol,
+            local_addr: SocketAddr::new(l_ip, l_port),
+            remote_addr: SocketAddr::new(r_ip, r_port),
+        };
+        if let Some(entry) = map.get(&candidate) {
+            match found {
+                None => found = Some((entry, quality)),
+                Some((existing, _)) if existing == entry => {} // same owner, no conflict
+                Some(_) => return None, // two different processes → ambiguous
+            }
+        }
+    }
+    found
 }
 
 /// Connection identifier for lookups
@@ -337,5 +532,262 @@ impl ConnectionKey {
             local_addr: conn.local_addr,
             remote_addr: conn.remote_addr,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustnet_core::network::types::{ProtocolState, TcpState};
+    use std::path::Path;
+
+    fn connection(local: &str, remote: &str) -> Connection {
+        Connection::new(
+            Protocol::Tcp,
+            local.parse().unwrap(),
+            remote.parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Established),
+        )
+    }
+
+    fn key(protocol: Protocol, local: &str, remote: &str) -> ConnectionKey {
+        ConnectionKey {
+            protocol,
+            local_addr: local.parse().unwrap(),
+            remote_addr: remote.parse().unwrap(),
+        }
+    }
+
+    fn owner(pid: u32, name: &str) -> (u32, String) {
+        (pid, name.to_string())
+    }
+
+    /// A platform that only implements the legacy tuple API, standing in for
+    /// the macOS/Windows/FreeBSD lookups.
+    struct LegacyOnlyLookup {
+        result: Option<(u32, String)>,
+    }
+
+    impl ProcessLookup for LegacyOnlyLookup {
+        fn get_process_for_connection(&self, _conn: &Connection) -> Option<(u32, String)> {
+            self.result.clone()
+        }
+
+        fn get_detection_method(&self) -> &str {
+            "legacy"
+        }
+    }
+
+    #[test]
+    fn attribution_reduces_to_the_legacy_pid_and_name_pair() {
+        let attribution = ProcessAttribution::new(
+            42,
+            "curl",
+            AttributionBackend::EbpfFentry,
+            MatchQuality::ExactTuple,
+        )
+        .with_tid(43)
+        .with_credentials(1000, 100)
+        .with_executable(Some(PathBuf::from("/usr/bin/curl")))
+        .with_observed_at_ns(9_000);
+
+        assert_eq!(attribution.tid, Some(43));
+        assert_eq!(attribution.uid, Some(1000));
+        assert_eq!(attribution.gid, Some(100));
+        assert_eq!(
+            attribution.executable.as_deref(),
+            Some(Path::new("/usr/bin/curl"))
+        );
+        assert_eq!(attribution.observed_at_ns, Some(9_000));
+
+        let (pid, name) = <(u32, String)>::from(attribution);
+        assert_eq!(pid, 42);
+        assert_eq!(name, "curl");
+    }
+
+    #[test]
+    fn attribution_leaves_unobserved_fields_empty() {
+        let attribution = ProcessAttribution::new(
+            7,
+            "sshd",
+            AttributionBackend::Procfs,
+            MatchQuality::ProcfsExact,
+        )
+        .with_executable(None);
+
+        assert_eq!(attribution.tid, None);
+        assert_eq!(attribution.uid, None);
+        assert_eq!(attribution.gid, None);
+        assert_eq!(attribution.executable, None);
+        assert_eq!(attribution.observed_at_ns, None);
+    }
+
+    #[test]
+    fn only_exact_tuple_matches_count_as_exact() {
+        assert!(MatchQuality::ExactTuple.is_exact());
+        assert!(MatchQuality::ProcfsExact.is_exact());
+        assert!(!MatchQuality::WildcardLocalAddress.is_exact());
+        assert!(!MatchQuality::ListenerSocket.is_exact());
+        assert!(!MatchQuality::ProcfsRelaxed.is_exact());
+        assert!(!MatchQuality::Unspecified.is_exact());
+    }
+
+    #[test]
+    fn default_rich_lookup_bridges_the_legacy_tuple_without_claiming_an_exact_match() {
+        let lookup = LegacyOnlyLookup {
+            result: Some(owner(99, "Safari")),
+        };
+
+        let attribution = lookup
+            .get_process_attribution(&connection("192.168.1.10:5000", "1.1.1.1:443"))
+            .expect("legacy tuple must bridge to an attribution");
+
+        assert_eq!(attribution.tgid, 99);
+        assert_eq!(attribution.name, "Safari");
+        assert_eq!(attribution.backend, AttributionBackend::PlatformNative);
+        // The tuple API carries no provenance, so the bridge must not pretend
+        // the exact 4-tuple was proven.
+        assert_eq!(attribution.quality, MatchQuality::Unspecified);
+        assert!(!attribution.quality.is_exact());
+        assert_eq!(attribution.tid, None);
+        assert_eq!(attribution.executable, None);
+    }
+
+    #[test]
+    fn default_rich_lookup_propagates_a_legacy_miss() {
+        let lookup = LegacyOnlyLookup { result: None };
+        assert!(
+            lookup
+                .get_process_attribution(&connection("192.168.1.10:5000", "1.1.1.1:443"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn relaxed_lookup_reports_a_wildcard_local_address_match() {
+        let mut map = HashMap::new();
+        map.insert(
+            key(Protocol::Udp, "0.0.0.0:5353", "224.0.0.251:5353"),
+            owner(10, "avahi"),
+        );
+
+        let (entry, quality) = relaxed_lookup(
+            &map,
+            &key(Protocol::Udp, "192.168.1.10:5353", "224.0.0.251:5353"),
+        )
+        .expect("wildcard-bound socket must match");
+
+        assert_eq!(entry, &owner(10, "avahi"));
+        assert_eq!(quality, MatchQuality::WildcardLocalAddress);
+    }
+
+    #[test]
+    fn relaxed_lookup_reports_a_listener_bound_to_a_specific_address() {
+        let mut map = HashMap::new();
+        map.insert(
+            key(Protocol::Tcp, "192.168.1.10:8080", "0.0.0.0:0"),
+            owner(11, "nginx"),
+        );
+
+        let (entry, quality) = relaxed_lookup(
+            &map,
+            &key(Protocol::Tcp, "192.168.1.10:8080", "203.0.113.5:44321"),
+        )
+        .expect("specific-address listener must match");
+
+        assert_eq!(entry, &owner(11, "nginx"));
+        assert_eq!(quality, MatchQuality::ListenerSocket);
+    }
+
+    #[test]
+    fn relaxed_lookup_reports_a_wildcard_listener() {
+        let mut map = HashMap::new();
+        map.insert(
+            key(Protocol::Tcp, "0.0.0.0:22", "0.0.0.0:0"),
+            owner(12, "sshd"),
+        );
+
+        let (entry, quality) = relaxed_lookup(
+            &map,
+            &key(Protocol::Tcp, "192.168.1.10:22", "203.0.113.5:51000"),
+        )
+        .expect("wildcard listener must match");
+
+        assert_eq!(entry, &owner(12, "sshd"));
+        assert_eq!(quality, MatchQuality::ListenerSocket);
+    }
+
+    #[test]
+    fn relaxed_lookup_prefers_the_tightest_shape_when_several_agree() {
+        let mut map = HashMap::new();
+        map.insert(
+            key(Protocol::Tcp, "0.0.0.0:8080", "203.0.113.5:44321"),
+            owner(13, "envoy"),
+        );
+        map.insert(
+            key(Protocol::Tcp, "0.0.0.0:8080", "0.0.0.0:0"),
+            owner(13, "envoy"),
+        );
+
+        let (entry, quality) = relaxed_lookup(
+            &map,
+            &key(Protocol::Tcp, "192.168.1.10:8080", "203.0.113.5:44321"),
+        )
+        .expect("agreeing candidates are not a conflict");
+
+        assert_eq!(entry, &owner(13, "envoy"));
+        assert_eq!(quality, MatchQuality::WildcardLocalAddress);
+    }
+
+    #[test]
+    fn relaxed_lookup_refuses_to_pick_between_conflicting_owners() {
+        let mut map = HashMap::new();
+        map.insert(
+            key(Protocol::Tcp, "0.0.0.0:8080", "203.0.113.5:44321"),
+            owner(14, "envoy"),
+        );
+        map.insert(
+            key(Protocol::Tcp, "0.0.0.0:8080", "0.0.0.0:0"),
+            owner(15, "nginx"),
+        );
+
+        assert!(
+            relaxed_lookup(
+                &map,
+                &key(Protocol::Tcp, "192.168.1.10:8080", "203.0.113.5:44321")
+            )
+            .is_none(),
+            "two candidates naming different processes must produce no attribution"
+        );
+    }
+
+    #[test]
+    fn relaxed_lookup_skips_protocols_without_socket_table_entries() {
+        let mut map = HashMap::new();
+        map.insert(
+            key(Protocol::Icmp, "0.0.0.0:0", "0.0.0.0:0"),
+            owner(16, "ping"),
+        );
+
+        assert!(
+            relaxed_lookup(&map, &key(Protocol::Icmp, "192.168.1.10:0", "8.8.8.8:0")).is_none()
+        );
+    }
+
+    #[test]
+    fn fallback_lookup_still_returns_the_plain_tuple() {
+        let mut map = HashMap::new();
+        map.insert(
+            key(Protocol::Tcp, "0.0.0.0:22", "0.0.0.0:0"),
+            owner(17, "sshd"),
+        );
+
+        assert_eq!(
+            LegacyOnlyLookup::fallback_lookup(
+                &map,
+                &key(Protocol::Tcp, "192.168.1.10:22", "203.0.113.5:51000")
+            ),
+            Some(owner(17, "sshd"))
+        );
     }
 }

--- a/crates/rustnet-host/src/linux/ebpf/mod.rs
+++ b/crates/rustnet-host/src/linux/ebpf/mod.rs
@@ -9,13 +9,38 @@ pub mod tracker_libbpf;
 
 pub use tracker_libbpf::LibbpfSocketTracker as EbpfSocketTracker;
 
+use crate::MatchQuality;
+
 /// Process information from eBPF
 #[derive(Debug, Clone)]
 pub struct ProcessInfo {
+    /// Thread group id (the PID as user space understands it).
     pub pid: u32,
+    /// Kernel thread id that created the socket.
     pub tid: u32,
+    /// Effective user id at socket creation.
     pub uid: u32,
+    /// Effective group id at socket creation.
     pub gid: u32,
+    /// Short `comm` of the task, as recorded by the BPF program.
     pub comm: String,
+    /// `bpf_ktime_get_ns` reading: nanoseconds on a **monotonic** clock, not
+    /// wall-clock time.
     pub timestamp: u64,
+}
+
+/// A socket-map hit together with how the lookup key matched it.
+///
+/// The tracker retries a miss with a zeroed source address, so the caller can
+/// no longer assume a hit means the exact tuple was recorded.
+#[derive(Debug, Clone)]
+pub struct SocketMatch {
+    pub info: ProcessInfo,
+    pub quality: MatchQuality,
+}
+
+impl SocketMatch {
+    fn new(info: ProcessInfo, quality: MatchQuality) -> Self {
+        Self { info, quality }
+    }
 }

--- a/crates/rustnet-host/src/linux/ebpf/tracker_libbpf.rs
+++ b/crates/rustnet-host/src/linux/ebpf/tracker_libbpf.rs
@@ -1,11 +1,11 @@
 //! eBPF socket tracker implementation using libbpf-rs
 
 use super::{
-    ProcessInfo,
+    SocketMatch,
     loader::EbpfLoader,
     maps_libbpf::{ConnKey, MapReader},
 };
-use crate::{AttributionBackend, AttributionCapabilities, DegradationReason};
+use crate::{AttributionBackend, AttributionCapabilities, DegradationReason, MatchQuality};
 use anyhow::Result;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -50,7 +50,7 @@ impl LibbpfSocketTracker {
         src_port: u16,
         dst_port: u16,
         is_tcp: bool,
-    ) -> Option<ProcessInfo> {
+    ) -> Option<SocketMatch> {
         let required = if is_tcp {
             AttributionCapabilities::TCP_V4_CONNECT
         } else {
@@ -66,7 +66,7 @@ impl LibbpfSocketTracker {
         let key = ConnKey::new_v4(src_ip, dst_ip, src_port, dst_port, is_tcp);
         match MapReader::lookup_connection(socket_map, key) {
             Ok(Some(result)) => {
-                return Some(result);
+                return Some(SocketMatch::new(result, MatchQuality::ExactTuple));
             }
             Ok(None) => {
                 log::debug!("eBPF exact lookup miss, trying with zero source address");
@@ -90,13 +90,13 @@ impl LibbpfSocketTracker {
         );
         match MapReader::lookup_connection(socket_map, zero_src_key) {
             Ok(Some(result)) => {
-                log::info!(
-                    "🎉 eBPF lookup succeeded with zero source address! PID: {}, comm: {}",
+                log::debug!(
+                    "eBPF lookup succeeded with zero source address: PID {}, comm {}",
                     result.pid,
                     result.comm
                 );
                 // Let cleanup handle entry deletion based on age
-                Some(result)
+                Some(SocketMatch::new(result, MatchQuality::WildcardLocalAddress))
             }
             Ok(None) => {
                 // Debug both keys for comparison
@@ -121,7 +121,7 @@ impl LibbpfSocketTracker {
         src_port: u16,
         dst_port: u16,
         is_tcp: bool,
-    ) -> Option<ProcessInfo> {
+    ) -> Option<SocketMatch> {
         let required = if is_tcp {
             AttributionCapabilities::TCP_V6_CONNECT
         } else {
@@ -137,7 +137,7 @@ impl LibbpfSocketTracker {
         match MapReader::lookup_connection(socket_map, key) {
             Ok(Some(result)) => {
                 // Let cleanup handle entry deletion based on age
-                return Some(result);
+                return Some(SocketMatch::new(result, MatchQuality::ExactTuple));
             }
             Ok(None) => {
                 log::debug!("eBPF IPv6 exact lookup miss, trying zero source address");
@@ -150,7 +150,7 @@ impl LibbpfSocketTracker {
         let zero_src_key =
             ConnKey::new_v6(Ipv6Addr::UNSPECIFIED, dst_ip, src_port, dst_port, is_tcp);
         match MapReader::lookup_connection(socket_map, zero_src_key) {
-            Ok(Some(result)) => Some(result),
+            Ok(Some(result)) => Some(SocketMatch::new(result, MatchQuality::WildcardLocalAddress)),
             Ok(None) => {
                 if let Err(e) = MapReader::debug_lookup_miss(socket_map, &key) {
                     log::debug!("Failed to debug lookup: {}", e);
@@ -172,7 +172,7 @@ impl LibbpfSocketTracker {
         src_port: u16,
         dst_port: u16,
         is_tcp: bool,
-    ) -> Option<ProcessInfo> {
+    ) -> Option<SocketMatch> {
         match (src_ip, dst_ip) {
             (IpAddr::V4(src), IpAddr::V4(dst)) => {
                 self.lookup_v4(src, dst, src_port, dst_port, is_tcp)
@@ -193,7 +193,7 @@ impl LibbpfSocketTracker {
         src_ip: IpAddr,
         dst_ip: IpAddr,
         icmp_id: u16,
-    ) -> Option<ProcessInfo> {
+    ) -> Option<SocketMatch> {
         match (src_ip, dst_ip) {
             (IpAddr::V4(src), IpAddr::V4(dst))
                 if self
@@ -222,13 +222,13 @@ impl LibbpfSocketTracker {
         src_ip: Ipv4Addr,
         dst_ip: Ipv4Addr,
         icmp_id: u16,
-    ) -> Option<ProcessInfo> {
+    ) -> Option<SocketMatch> {
         let socket_map = self.loader.socket_map();
 
         // Try exact match first
         let key = ConnKey::new_icmp_v4(src_ip, dst_ip, icmp_id);
         match MapReader::lookup_connection(socket_map, key) {
-            Ok(Some(result)) => return Some(result),
+            Ok(Some(result)) => return Some(SocketMatch::new(result, MatchQuality::ExactTuple)),
             Ok(None) => {
                 log::debug!("eBPF ICMP exact lookup miss, trying with zero source address");
             }
@@ -247,7 +247,7 @@ impl LibbpfSocketTracker {
                     result.pid,
                     result.comm
                 );
-                Some(result)
+                Some(SocketMatch::new(result, MatchQuality::WildcardLocalAddress))
             }
             Ok(None) => {
                 log::debug!("eBPF ICMP lookup miss for ID: {}", icmp_id);
@@ -265,13 +265,13 @@ impl LibbpfSocketTracker {
         src_ip: Ipv6Addr,
         dst_ip: Ipv6Addr,
         icmp_id: u16,
-    ) -> Option<ProcessInfo> {
+    ) -> Option<SocketMatch> {
         let socket_map = self.loader.socket_map();
 
         // Try exact match first
         let key = ConnKey::new_icmp_v6(src_ip, dst_ip, icmp_id);
         match MapReader::lookup_connection(socket_map, key) {
-            Ok(Some(result)) => return Some(result),
+            Ok(Some(result)) => return Some(SocketMatch::new(result, MatchQuality::ExactTuple)),
             Ok(None) => {
                 log::debug!("eBPF ICMP exact lookup miss, trying with zero source address");
             }
@@ -290,7 +290,7 @@ impl LibbpfSocketTracker {
                     result.pid,
                     result.comm
                 );
-                Some(result)
+                Some(SocketMatch::new(result, MatchQuality::WildcardLocalAddress))
             }
             Ok(None) => {
                 log::debug!("eBPF ICMP lookup miss for ID: {}", icmp_id);
@@ -334,11 +334,27 @@ impl LibbpfSocketTracker {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
+    use crate::linux::ebpf::ProcessInfo;
+    use crate::linux::process::resolve_executable;
     use std::net::{Ipv4Addr, Ipv6Addr, TcpListener, TcpStream, UdpSocket};
     use std::thread;
     use std::time::Duration;
 
-    fn assert_current_identity(info: &ProcessInfo) {
+    fn current_tid() -> u32 {
+        // SAFETY: gettid takes no arguments and cannot fail.
+        unsafe { libc::syscall(libc::SYS_gettid) as u32 }
+    }
+
+    /// Whether BPF-reported ids can be compared against `gettid`/`getpid` and
+    /// `/proc` paths. `bpf_get_current_pid_tgid` always reports initial-PID-
+    /// namespace values; inside a container those name different tasks than
+    /// our own view does, and the comparison would be meaningless.
+    fn ids_are_comparable(info: &ProcessInfo) -> bool {
+        info.pid == std::process::id()
+    }
+
+    fn assert_current_identity(matched: &SocketMatch) {
+        let info = &matched.info;
         // bpf_get_current_pid_tgid reports the initial PID namespace value.
         // Some VM/container procfs mounts hide that value, so the portable
         // integration assertion can only require a nonzero TGID and TID.
@@ -348,6 +364,35 @@ mod integration_tests {
         assert!(info.tid > 0);
         assert!(info.timestamp > 0);
         assert!(!info.comm.is_empty());
+
+        // The socket belongs to this test process, so a hit is either the
+        // exact tuple or the zero-source retry. Nothing else may be reported.
+        assert!(
+            matches!(
+                matched.quality,
+                MatchQuality::ExactTuple | MatchQuality::WildcardLocalAddress
+            ),
+            "unexpected match quality {}",
+            matched.quality
+        );
+
+        assert_executable_resolves(info);
+    }
+
+    fn assert_executable_resolves(info: &ProcessInfo) {
+        if !ids_are_comparable(info) {
+            eprintln!(
+                "skipping executable check: BPF TGID {} differs from our PID {}",
+                info.pid,
+                std::process::id()
+            );
+            return;
+        }
+        assert_eq!(
+            resolve_executable(info.pid),
+            std::env::current_exe().ok(),
+            "/proc/<tgid>/exe must resolve to the test binary"
+        );
     }
 
     fn lookup_with_retry(
@@ -357,12 +402,12 @@ mod integration_tests {
         source_port: u16,
         destination_port: u16,
         is_tcp: bool,
-    ) -> ProcessInfo {
+    ) -> SocketMatch {
         for _ in 0..20 {
-            if let Some(info) =
+            if let Some(matched) =
                 tracker.lookup(source, destination, source_port, destination_port, is_tcp)
             {
-                return info;
+                return matched;
             }
             thread::sleep(Duration::from_millis(10));
         }
@@ -397,6 +442,49 @@ mod integration_tests {
             true,
         );
         assert_current_identity(&accept_info);
+
+        // accept() ran on this thread, so the accepted socket must be recorded
+        // against it rather than against some other task in the process.
+        if ids_are_comparable(&accept_info.info) {
+            assert_eq!(accept_info.info.tid, current_tid());
+        }
+    }
+
+    /// A socket created by a worker thread must be attributed to that thread,
+    /// while the TGID stays the process. Without this the TID field would be
+    /// indistinguishable from a copy of the TGID.
+    fn test_worker_thread_tid(tracker: &mut LibbpfSocketTracker) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let server = listener.local_addr().unwrap();
+        let main_tid = current_tid();
+
+        let worker = thread::spawn(move || {
+            let client = TcpStream::connect(server).unwrap();
+            (current_tid(), client.local_addr().unwrap(), client)
+        });
+        let (worker_tid, client_local, _client) = worker.join().unwrap();
+        let (_accepted, _) = listener.accept().unwrap();
+        assert_ne!(worker_tid, main_tid, "worker must be a distinct thread");
+
+        let matched = lookup_with_retry(
+            tracker,
+            client_local.ip(),
+            server.ip(),
+            client_local.port(),
+            server.port(),
+            true,
+        );
+        assert_current_identity(&matched);
+
+        // Namespace-independent: the recording thread was not the group leader.
+        assert_ne!(
+            matched.info.tid, matched.info.pid,
+            "connect() from a worker thread must record a TID distinct from the TGID"
+        );
+        if ids_are_comparable(&matched.info) {
+            assert_eq!(matched.info.tid, worker_tid);
+            assert_eq!(matched.info.pid, std::process::id());
+        }
     }
 
     fn test_tcp_v6(tracker: &mut LibbpfSocketTracker) {
@@ -503,6 +591,7 @@ mod integration_tests {
         test_tcp_v6(&mut tracker);
         test_udp_v4(&mut tracker);
         test_udp_v6(&mut tracker);
+        test_worker_thread_tid(&mut tracker);
     }
 
     #[test]

--- a/crates/rustnet-host/src/linux/enhanced.rs
+++ b/crates/rustnet-host/src/linux/enhanced.rs
@@ -1,7 +1,8 @@
 //! Enhanced Linux process lookup combining eBPF and procfs approaches
 
 use crate::{
-    AttributionBackend, AttributionCapabilities, ConnectionKey, DegradationReason, ProcessLookup,
+    AttributionBackend, AttributionCapabilities, ConnectionKey, DegradationReason,
+    ProcessAttribution, ProcessLookup,
 };
 
 use super::process::LinuxProcessLookup;
@@ -20,6 +21,8 @@ use super::ebpf::EbpfSocketTracker;
 #[cfg(feature = "ebpf")]
 mod ebpf_enhanced {
     use super::*;
+    use crate::linux::ebpf::SocketMatch;
+    use crate::linux::process::resolve_executable;
     use rustnet_core::network::types::ProtocolState;
 
     /// Enhanced process lookup that combines eBPF (fast path) with procfs (fallback)
@@ -34,7 +37,10 @@ mod ebpf_enhanced {
     }
 
     pub struct ProcessCache {
-        lookup: HashMap<ConnectionKey, (u32, String)>,
+        // Full attributions, not just (pid, name): caching the tuple would drop
+        // the credentials, thread id, executable path, and match quality on the
+        // first hit and silently downgrade every subsequent lookup.
+        lookup: HashMap<ConnectionKey, ProcessAttribution>,
         last_refresh: Instant,
     }
 
@@ -112,7 +118,7 @@ mod ebpf_enhanced {
         }
 
         /// Try eBPF lookup first, fall back to procfs
-        fn lookup_process_enhanced(&self, conn: &Connection) -> Option<(u32, String)> {
+        fn lookup_process_enhanced(&self, conn: &Connection) -> Option<ProcessAttribution> {
             // Try eBPF first for TCP/UDP/ICMP connections
             match conn.protocol {
                 Protocol::Tcp | Protocol::Udp => {
@@ -133,8 +139,8 @@ mod ebpf_enhanced {
                         let mut stats = self.stats.write().expect("stats lock poisoned");
                         stats.ebpf_hits += 1;
                         debug!(
-                            "Enhanced lookup: eBPF hit for PID {} ({})",
-                            result.0, result.1
+                            "Enhanced lookup: eBPF hit for PID {} ({}, {} match)",
+                            result.tgid, result.name, result.quality
                         );
                         return Some(result);
                     } else {
@@ -158,8 +164,8 @@ mod ebpf_enhanced {
                             let mut stats = self.stats.write().expect("stats lock poisoned");
                             stats.ebpf_hits += 1;
                             debug!(
-                                "Enhanced lookup: eBPF ICMP hit for PID {} ({})",
-                                result.0, result.1
+                                "Enhanced lookup: eBPF ICMP hit for PID {} ({}, {} match)",
+                                result.tgid, result.name, result.quality
                             );
                             return Some(result);
                         } else {
@@ -171,7 +177,7 @@ mod ebpf_enhanced {
             }
 
             // Fall back to procfs approach
-            if let Some(result) = self.procfs_lookup.get_process_for_connection(conn) {
+            if let Some(result) = self.procfs_lookup.get_process_attribution(conn) {
                 let mut stats = self.stats.write().expect("stats lock poisoned");
                 stats.procfs_hits += 1;
                 return Some(result);
@@ -180,105 +186,141 @@ mod ebpf_enhanced {
             None
         }
 
-        fn try_ebpf_lookup(&self, conn: &Connection) -> Option<(u32, String)> {
-            let mut tracker_guard = self
-                .ebpf_tracker
-                .write()
-                .expect("ebpf_tracker lock poisoned");
-            let tracker = match tracker_guard.as_mut() {
-                Some(t) => {
-                    debug!("eBPF lookup: Tracker available, performing lookup");
-                    t
-                }
-                None => {
-                    debug!("eBPF lookup: No tracker available");
-                    return None;
+        /// Turn a socket-map hit into a rich attribution.
+        ///
+        /// Everything the kernel recorded is carried through unchanged: TGID,
+        /// TID, credentials, and the monotonic observation timestamp. Only the
+        /// process name and executable path are resolved in user space.
+        fn attribution_from_ebpf(
+            &self,
+            matched: SocketMatch,
+            backend: AttributionBackend,
+        ) -> ProcessAttribution {
+            let SocketMatch { info, quality } = matched;
+
+            // eBPF captures the group leader's short comm at socket creation.
+            // /proc/<tgid>/comm is the current main-process name and wins when
+            // the process is still alive. Short-lived tools (curl, dig) have
+            // already exited by the time we look, so the eBPF comm is the
+            // fallback rather than the other way round.
+            let name = self
+                .procfs_lookup
+                .get_process_name_by_pid(info.pid)
+                .unwrap_or_else(|| info.comm.clone());
+
+            // Resolve the executable now, while the process is most likely
+            // still around. Failure is not an attribution failure.
+            let executable = resolve_executable(info.pid);
+
+            debug!(
+                "eBPF attribution: TGID {}, TID {}, UID {}, GID {}, eBPF comm {}, resolved {}, exe {:?}, {} match, observed {}ns (monotonic)",
+                info.pid,
+                info.tid,
+                info.uid,
+                info.gid,
+                info.comm,
+                name,
+                executable,
+                quality,
+                info.timestamp
+            );
+
+            ProcessAttribution::new(info.pid, name, backend, quality)
+                .with_tid(info.tid)
+                .with_credentials(info.uid, info.gid)
+                .with_executable(executable)
+                .with_observed_at_ns(info.timestamp)
+        }
+
+        fn try_ebpf_lookup(&self, conn: &Connection) -> Option<ProcessAttribution> {
+            // Scoped so the tracker write lock is released before
+            // attribution_from_ebpf touches /proc. Note `backend()` is read
+            // here rather than via get_attribution_backend(), which would take
+            // the same non-reentrant lock again.
+            let (matched, backend) = {
+                let mut tracker_guard = self
+                    .ebpf_tracker
+                    .write()
+                    .expect("ebpf_tracker lock poisoned");
+                let tracker = match tracker_guard.as_mut() {
+                    Some(t) => {
+                        debug!("eBPF lookup: Tracker available, performing lookup");
+                        t
+                    }
+                    None => {
+                        debug!("eBPF lookup: No tracker available");
+                        return None;
+                    }
+                };
+
+                let is_tcp = matches!(conn.protocol, Protocol::Tcp);
+                let backend = tracker.backend();
+
+                match tracker.lookup(
+                    conn.local_addr.ip(),
+                    conn.remote_addr.ip(),
+                    conn.local_addr.port(),
+                    conn.remote_addr.port(),
+                    is_tcp,
+                ) {
+                    Some(matched) => (matched, backend),
+                    None => {
+                        debug!(
+                            "eBPF lookup missed for {}:{} -> {}:{}",
+                            conn.local_addr.ip(),
+                            conn.local_addr.port(),
+                            conn.remote_addr.ip(),
+                            conn.remote_addr.port()
+                        );
+                        return None;
+                    }
                 }
             };
 
-            let is_tcp = matches!(conn.protocol, Protocol::Tcp);
-
-            match tracker.lookup(
-                conn.local_addr.ip(),
-                conn.remote_addr.ip(),
-                conn.local_addr.port(),
-                conn.remote_addr.port(),
-                is_tcp,
-            ) {
-                Some(process_info) => {
-                    // Try to resolve the correct main process name using the PID.
-                    // eBPF captures the group leader's short comm. The procfs cache
-                    // can provide a current main-process name from /proc/<pid>/comm.
-                    // For short-lived processes (like curl), the PID won't be in the
-                    // cache (process already exited), so we fall back to the eBPF name.
-                    let resolved_name = self
-                        .procfs_lookup
-                        .get_process_name_by_pid(process_info.pid)
-                        .unwrap_or_else(|| process_info.comm.clone());
-
-                    debug!(
-                        "eBPF lookup successful for {}:{} -> {}:{} - TGID: {}, TID: {}, UID: {}, GID: {}, eBPF comm: {}, Resolved: {}, observed: {}ns",
-                        conn.local_addr.ip(),
-                        conn.local_addr.port(),
-                        conn.remote_addr.ip(),
-                        conn.remote_addr.port(),
-                        process_info.pid,
-                        process_info.tid,
-                        process_info.uid,
-                        process_info.gid,
-                        process_info.comm,
-                        resolved_name,
-                        process_info.timestamp
-                    );
-                    Some((process_info.pid, resolved_name))
-                }
-                None => {
-                    debug!(
-                        "eBPF lookup missed for {}:{} -> {}:{}",
-                        conn.local_addr.ip(),
-                        conn.local_addr.port(),
-                        conn.remote_addr.ip(),
-                        conn.remote_addr.port()
-                    );
-                    None
-                }
-            }
+            Some(self.attribution_from_ebpf(matched, backend))
         }
 
-        fn try_ebpf_icmp_lookup(&self, conn: &Connection, icmp_id: u16) -> Option<(u32, String)> {
-            let mut tracker_guard = self
-                .ebpf_tracker
+        fn try_ebpf_icmp_lookup(
+            &self,
+            conn: &Connection,
+            icmp_id: u16,
+        ) -> Option<ProcessAttribution> {
+            let (matched, backend) = {
+                let mut tracker_guard = self
+                    .ebpf_tracker
+                    .write()
+                    .expect("ebpf_tracker lock poisoned");
+                let tracker = tracker_guard.as_mut()?;
+                let backend = tracker.backend();
+
+                match tracker.lookup_icmp(conn.local_addr.ip(), conn.remote_addr.ip(), icmp_id) {
+                    Some(matched) => (matched, backend),
+                    None => {
+                        debug!(
+                            "eBPF ICMP lookup missed for {} -> {} (ID: {})",
+                            conn.local_addr.ip(),
+                            conn.remote_addr.ip(),
+                            icmp_id
+                        );
+                        return None;
+                    }
+                }
+            };
+
+            Some(self.attribution_from_ebpf(matched, backend))
+        }
+
+        /// Seed the unified cache with a ready-made attribution and mark it
+        /// fresh, so cache-preservation behaviour can be tested without a
+        /// loaded eBPF backend.
+        #[cfg(test)]
+        fn seed_cache(&self, key: ConnectionKey, attribution: ProcessAttribution) {
+            let mut cache = self
+                .unified_cache
                 .write()
-                .expect("ebpf_tracker lock poisoned");
-            let tracker = tracker_guard.as_mut()?;
-
-            match tracker.lookup_icmp(conn.local_addr.ip(), conn.remote_addr.ip(), icmp_id) {
-                Some(process_info) => {
-                    let resolved_name = self
-                        .procfs_lookup
-                        .get_process_name_by_pid(process_info.pid)
-                        .unwrap_or_else(|| process_info.comm.clone());
-
-                    debug!(
-                        "eBPF ICMP lookup successful for {} -> {} (ID: {}) - PID: {}, Resolved: {}",
-                        conn.local_addr.ip(),
-                        conn.remote_addr.ip(),
-                        icmp_id,
-                        process_info.pid,
-                        resolved_name
-                    );
-                    Some((process_info.pid, resolved_name))
-                }
-                None => {
-                    debug!(
-                        "eBPF ICMP lookup missed for {} -> {} (ID: {})",
-                        conn.local_addr.ip(),
-                        conn.remote_addr.ip(),
-                        icmp_id
-                    );
-                    None
-                }
-            }
+                .expect("unified_cache lock poisoned");
+            cache.last_refresh = Instant::now();
+            cache.lookup.insert(key, attribution);
         }
 
         /// Check if eBPF is available and functioning
@@ -324,6 +366,12 @@ mod ebpf_enhanced {
 
     impl ProcessLookup for EnhancedLinuxProcessLookup {
         fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
+            // Safe because get_process_attribution is overridden below: this
+            // does not fall through to the trait's default bridge.
+            self.get_process_attribution(conn).map(Into::into)
+        }
+
+        fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
             // Perform periodic cleanup of stale eBPF entries
             self.maybe_cleanup_ebpf_map();
 
@@ -358,11 +406,13 @@ mod ebpf_enhanced {
                     .read()
                     .expect("unified_cache lock poisoned");
                 if cache.last_refresh.elapsed() < Duration::from_secs(2)
-                    && let Some(process_info) = cache.lookup.get(&key)
+                    && let Some(attribution) = cache.lookup.get(&key)
                 {
                     let mut stats = self.stats.write().expect("stats lock poisoned");
                     stats.cache_hits += 1;
-                    return Some(process_info.clone());
+                    // Returned verbatim, match quality included: a cached
+                    // relaxed match stays a relaxed match.
+                    return Some(attribution.clone());
                 }
             }
 
@@ -500,6 +550,90 @@ mod ebpf_enhanced {
                     self.tcp_lookups, self.udp_lookups, self.cache_entries
                 )
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::MatchQuality;
+        use rustnet_core::network::types::{ProtocolState, TcpState};
+        use std::path::PathBuf;
+
+        fn connection(local: &str, remote: &str) -> Connection {
+            Connection::new(
+                Protocol::Tcp,
+                local.parse().unwrap(),
+                remote.parse().unwrap(),
+                ProtocolState::Tcp(TcpState::Established),
+            )
+        }
+
+        /// A result carrying everything only eBPF can observe, so a cache round
+        /// trip that drops any of it is visible.
+        fn ebpf_attribution() -> ProcessAttribution {
+            ProcessAttribution::new(
+                4242,
+                "curl",
+                AttributionBackend::EbpfFentry,
+                MatchQuality::WildcardLocalAddress,
+            )
+            .with_tid(4299)
+            .with_credentials(1000, 100)
+            .with_executable(Some(PathBuf::from("/usr/bin/curl")))
+            .with_observed_at_ns(123_456_789)
+        }
+
+        #[test]
+        fn cached_results_keep_every_field_the_backend_reported() {
+            let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
+            let conn = connection("192.168.1.10:5000", "1.1.1.1:443");
+            let expected = ebpf_attribution();
+            lookup.seed_cache(ConnectionKey::from_connection(&conn), expected.clone());
+
+            let cached = lookup
+                .get_process_attribution(&conn)
+                .expect("seeded entry must be served from the cache");
+
+            // The whole struct, not just (pid, name): storing the tuple would
+            // silently drop the TID, credentials, executable, and timestamp.
+            assert_eq!(cached, expected);
+        }
+
+        #[test]
+        fn a_cached_relaxed_match_is_not_upgraded_to_exact() {
+            let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
+            let conn = connection("192.168.1.10:5001", "1.1.1.1:443");
+            lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
+
+            for _ in 0..3 {
+                let cached = lookup.get_process_attribution(&conn).unwrap();
+                assert_eq!(cached.quality, MatchQuality::WildcardLocalAddress);
+                assert!(!cached.quality.is_exact());
+            }
+        }
+
+        #[test]
+        fn the_tuple_api_serves_the_cached_attribution() {
+            let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
+            let conn = connection("192.168.1.10:5002", "1.1.1.1:443");
+            lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
+
+            assert_eq!(
+                lookup.get_process_for_connection(&conn),
+                Some((4242, "curl".to_string()))
+            );
+        }
+
+        #[test]
+        fn refresh_clears_the_cache() {
+            let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
+            let conn = connection("192.168.1.10:5003", "1.1.1.1:443");
+            lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
+            lookup.refresh().expect("refresh must succeed");
+
+            // The synthetic entry is gone; a real /proc scan cannot produce it.
+            assert!(lookup.get_process_attribution(&conn).is_none());
         }
     }
 }

--- a/crates/rustnet-host/src/linux/process.rs
+++ b/crates/rustnet-host/src/linux/process.rs
@@ -1,13 +1,38 @@
 // network/platform/linux/process.rs - Linux procfs-based process lookup
 
-use crate::{AttributionBackend, ConnectionKey, ProcessLookup};
+use crate::{
+    AttributionBackend, ConnectionKey, MatchQuality, ProcessAttribution, ProcessLookup,
+    relaxed_lookup,
+};
 use anyhow::Result;
 use rustnet_core::network::types::{Connection, Protocol};
 use std::collections::HashMap;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::os::unix::fs::MetadataExt;
+use std::path::PathBuf;
 use std::sync::RwLock;
 use std::time::Instant;
+
+/// Resolve the executable path of a TGID from `/proc/<tgid>/exe`.
+///
+/// Resolved in user space immediately after a successful attribution, while the
+/// process is most likely still alive. `None` is a normal outcome and never
+/// fails the attribution: the process may have exited already, be a kernel
+/// thread (no `exe` link), or belong to another user, whose `exe` link needs
+/// `CAP_SYS_PTRACE` to read.
+pub(crate) fn resolve_executable(tgid: u32) -> Option<PathBuf> {
+    fs::read_link(format!("/proc/{tgid}/exe")).ok()
+}
+
+/// Read the effective UID/GID of a TGID from the ownership of `/proc/<tgid>`,
+/// which the kernel stamps with the task's effective credentials.
+///
+/// `None` when the process is gone or hidden (`hidepid`).
+pub(crate) fn resolve_credentials(tgid: u32) -> Option<(u32, u32)> {
+    let metadata = fs::metadata(format!("/proc/{tgid}")).ok()?;
+    Some((metadata.uid(), metadata.gid()))
+}
 
 /// Map of socket inode to (PID, process name)
 type InodeProcessMap = HashMap<u64, (u32, String)>;
@@ -43,6 +68,19 @@ impl LinuxProcessLookup {
         })
     }
 
+    /// Build a lookup over a caller-supplied socket table instead of scanning
+    /// `/proc/net/*`, so match-quality behaviour can be tested deterministically.
+    #[cfg(test)]
+    fn with_socket_table(lookup: ConnectionProcessMap) -> Self {
+        Self {
+            cache: RwLock::new(ProcessCache {
+                lookup,
+                last_refresh: Instant::now(),
+            }),
+            pid_names: RwLock::new(HashMap::new()),
+        }
+    }
+
     /// Get process name by PID. Tries the cached procfs scan first, then
     /// falls back to reading `/proc/<pid>/comm` directly: the cache only
     /// refreshes every few seconds, so a freshly started process — exactly
@@ -72,6 +110,50 @@ impl LinuxProcessLookup {
             .expect("pid_names lock poisoned")
             .insert(pid, name.clone());
         Some(name)
+    }
+
+    /// Match a connection against the cached procfs socket table.
+    ///
+    /// Returns the owner together with how it was matched, so callers can tell
+    /// a proven 4-tuple hit from a relaxed guess. Ambiguous relaxed matches
+    /// (two candidates, two different owners) yield `None`.
+    ///
+    /// Simple cache lookup with no refresh on cache miss. The enrichment thread
+    /// handles periodic refresh every 5 seconds.
+    /// IMPORTANT: Do NOT refresh here as it caused high CPU usage when called for every
+    /// connection without process info (flamegraph showed this was the main bottleneck).
+    fn lookup_match(&self, conn: &Connection) -> Option<(u32, String, MatchQuality)> {
+        let key = ConnectionKey::from_connection(conn);
+        let cache = self.cache.read().expect("process cache lock poisoned");
+
+        // Fast path: exact 4-tuple match (always works for TCP).
+        if let Some((pid, name)) = cache.lookup.get(&key) {
+            return Some((*pid, name.clone(), MatchQuality::ProcfsExact));
+        }
+
+        // Fallback: /proc/net may store sockets with wildcard addresses.
+        // Progressively relax the key until we find a match. The relaxation
+        // shape is deliberately collapsed into a single `ProcfsRelaxed`: what
+        // matters downstream is that procfs needed to guess, not which of the
+        // three wildcard shapes it guessed with.
+        let ((pid, name), _shape) = relaxed_lookup(&cache.lookup, &key)?;
+        Some((*pid, name.clone(), MatchQuality::ProcfsRelaxed))
+    }
+
+    /// Turn a procfs socket-table match into a rich attribution by reading the
+    /// live `/proc/<tgid>` entries for the owner.
+    ///
+    /// The name needs no extra work here: the socket table already sources it
+    /// from `/proc/<tgid>/comm` during the scan, so the tuple and rich APIs
+    /// report the same name for the same match.
+    fn build_attribution(tgid: u32, name: String, quality: MatchQuality) -> ProcessAttribution {
+        let attribution = ProcessAttribution::new(tgid, name, AttributionBackend::Procfs, quality)
+            .with_executable(resolve_executable(tgid));
+
+        match resolve_credentials(tgid) {
+            Some((uid, gid)) => attribution.with_credentials(uid, gid),
+            None => attribution,
+        }
     }
 
     /// Build connection -> process mapping and PID -> name mapping
@@ -244,22 +326,15 @@ impl LinuxProcessLookup {
 
 impl ProcessLookup for LinuxProcessLookup {
     fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
-        let key = ConnectionKey::from_connection(conn);
+        // Deliberately not routed through `get_process_attribution`: the tuple
+        // API has no use for the executable path or credentials, and resolving
+        // them costs two syscalls per hit.
+        self.lookup_match(conn).map(|(pid, name, _)| (pid, name))
+    }
 
-        // Simple cache lookup with no refresh on cache miss.
-        // The enrichment thread (app.rs:495-500) handles periodic refresh every 5 seconds.
-        // IMPORTANT: Do NOT refresh here as it caused high CPU usage when called for every
-        // connection without process info (flamegraph showed this was the main bottleneck).
-        let cache = self.cache.read().expect("process cache lock poisoned");
-
-        // Fast path: exact 4-tuple match (always works for TCP).
-        if let Some(entry) = cache.lookup.get(&key) {
-            Some(entry.clone())
-        } else {
-            // Fallback: /proc/net may store sockets with wildcard addresses.
-            // Progressively relax the key until we find a match.
-            Self::fallback_lookup(&cache.lookup, &key)
-        }
+    fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
+        let (tgid, name, quality) = self.lookup_match(conn)?;
+        Some(Self::build_attribution(tgid, name, quality))
     }
 
     fn refresh(&self) -> Result<()> {
@@ -280,5 +355,150 @@ impl ProcessLookup for LinuxProcessLookup {
 
     fn get_attribution_backend(&self) -> AttributionBackend {
         AttributionBackend::Procfs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustnet_core::network::types::{ProtocolState, TcpState};
+
+    fn connection(local: &str, remote: &str) -> Connection {
+        Connection::new(
+            Protocol::Tcp,
+            local.parse().unwrap(),
+            remote.parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Established),
+        )
+    }
+
+    fn key(local: &str, remote: &str) -> ConnectionKey {
+        ConnectionKey {
+            protocol: Protocol::Tcp,
+            local_addr: local.parse().unwrap(),
+            remote_addr: remote.parse().unwrap(),
+        }
+    }
+
+    /// Attribute to this very test process so the /proc reads have a live
+    /// target with known credentials and a known executable.
+    fn own_pid() -> u32 {
+        std::process::id()
+    }
+
+    #[test]
+    fn resolves_the_executable_of_a_live_process() {
+        assert_eq!(
+            resolve_executable(own_pid()),
+            std::env::current_exe().ok(),
+            "/proc/<tgid>/exe must resolve to the test binary"
+        );
+    }
+
+    #[test]
+    fn unreadable_executable_is_reported_as_none_rather_than_an_error() {
+        // u32::MAX is above every reachable pid_max, so /proc/<tgid>/exe cannot
+        // exist. Attribution must survive this, with executable = None.
+        assert_eq!(resolve_executable(u32::MAX), None);
+    }
+
+    #[test]
+    fn reads_the_credentials_of_a_live_process() {
+        let (uid, gid) = resolve_credentials(own_pid()).expect("own /proc entry must be readable");
+        assert_eq!(uid, unsafe { libc::geteuid() });
+        assert_eq!(gid, unsafe { libc::getegid() });
+    }
+
+    #[test]
+    fn missing_process_has_no_credentials() {
+        assert_eq!(resolve_credentials(u32::MAX), None);
+    }
+
+    #[test]
+    fn exact_socket_table_hit_is_reported_as_an_exact_procfs_match() {
+        let mut table = HashMap::new();
+        table.insert(
+            key("192.168.1.10:5000", "1.1.1.1:443"),
+            (own_pid(), "scanned-name".to_string()),
+        );
+        let lookup = LinuxProcessLookup::with_socket_table(table);
+
+        let attribution = lookup
+            .get_process_attribution(&connection("192.168.1.10:5000", "1.1.1.1:443"))
+            .expect("exact tuple must match");
+
+        assert_eq!(attribution.tgid, own_pid());
+        assert_eq!(attribution.name, "scanned-name");
+        assert_eq!(attribution.quality, MatchQuality::ProcfsExact);
+        assert_eq!(attribution.backend, AttributionBackend::Procfs);
+        assert_eq!(attribution.executable, std::env::current_exe().ok());
+        assert_eq!(attribution.uid, Some(unsafe { libc::geteuid() }));
+        assert_eq!(attribution.gid, Some(unsafe { libc::getegid() }));
+        // procfs is a socket-table snapshot: no thread id, no observation time.
+        assert_eq!(attribution.tid, None);
+        assert_eq!(attribution.observed_at_ns, None);
+    }
+
+    #[test]
+    fn wildcard_listener_hit_is_never_reported_as_exact() {
+        let mut table = HashMap::new();
+        table.insert(
+            key("0.0.0.0:8080", "0.0.0.0:0"),
+            (own_pid(), "listener".to_string()),
+        );
+        let lookup = LinuxProcessLookup::with_socket_table(table);
+
+        let attribution = lookup
+            .get_process_attribution(&connection("192.168.1.10:8080", "203.0.113.5:44321"))
+            .expect("wildcard listener must match");
+
+        assert_eq!(attribution.tgid, own_pid());
+        assert_eq!(attribution.quality, MatchQuality::ProcfsRelaxed);
+        assert!(!attribution.quality.is_exact());
+    }
+
+    #[test]
+    fn conflicting_relaxed_candidates_produce_no_attribution() {
+        let mut table = HashMap::new();
+        table.insert(
+            key("0.0.0.0:8080", "203.0.113.5:44321"),
+            (own_pid(), "envoy".to_string()),
+        );
+        table.insert(
+            key("0.0.0.0:8080", "0.0.0.0:0"),
+            (own_pid() + 1, "nginx".to_string()),
+        );
+        let lookup = LinuxProcessLookup::with_socket_table(table);
+
+        let conn = connection("192.168.1.10:8080", "203.0.113.5:44321");
+        assert!(lookup.get_process_attribution(&conn).is_none());
+        assert!(lookup.get_process_for_connection(&conn).is_none());
+    }
+
+    #[test]
+    fn the_tuple_api_agrees_with_the_rich_api() {
+        let mut table = HashMap::new();
+        table.insert(
+            key("192.168.1.10:5000", "1.1.1.1:443"),
+            (own_pid(), "scanned-name".to_string()),
+        );
+        table.insert(
+            key("0.0.0.0:8080", "0.0.0.0:0"),
+            (own_pid(), "listener".to_string()),
+        );
+        let lookup = LinuxProcessLookup::with_socket_table(table);
+
+        for (local, remote) in [
+            ("192.168.1.10:5000", "1.1.1.1:443"),
+            ("192.168.1.10:8080", "203.0.113.5:44321"),
+        ] {
+            let conn = connection(local, remote);
+            let tuple = lookup
+                .get_process_for_connection(&conn)
+                .expect("tuple API must keep working");
+            let attribution = lookup.get_process_attribution(&conn).unwrap();
+
+            assert_eq!(tuple, (attribution.tgid, attribution.name));
+        }
     }
 }


### PR DESCRIPTION
Attribution 2.0: `ProcessLookup` can now return a `ProcessAttribution` with TGID, TID, name, UID/GID, executable path, backend, match quality, and a monotonic observation timestamp, instead of only `(pid, name)`.

## What changed

- `MatchQuality` records how a connection was matched, so a relaxed wildcard/listener guess is never mistaken for a proven 4-tuple hit. `is_exact()` tells them apart.
- `get_process_attribution()` has a default bridge over the legacy tuple API reporting `MatchQuality::Unspecified`, so macOS, Windows, and FreeBSD keep working without changes.
- Linux eBPF carries the kernel-recorded TGID, TID, UID, GID, and monotonic timestamp through unchanged, and distinguishes exact from zero-source matches.
- The procfs fallback matcher returns the match quality and still rejects ambiguous relaxed candidates.
- The enhanced Linux cache stores the full `ProcessAttribution`, so metadata and match quality survive the first lookup.
- `/proc/<tgid>/exe` is resolved in user space right after a successful attribution; failure yields `executable: None` and never fails the attribution.

`ProcessAttribution` and `MatchQuality` are `#[non_exhaustive]` so cgroup and container fields can land later without breaking downstream matches. `observed_at_ns` is documented as monotonic, not wall clock.

Extracted `relaxed_lookup()` returning `(&V, MatchQuality)`; `fallback_lookup()` is now a thin wrapper over it, so the other platforms are untouched.

## Notes

- The tracker write lock is now released before the `/proc` reads, which it was not before.
- One pre-existing formatting hunk in `src/ui/tabs/overview.rs` came along from `cargo fmt`; it was already unformatted on main.
- `enhanced.rs` still contains a `procfs_only` module that compiles in no configuration (`mod enhanced` is gated on `feature = "ebpf"` while that module is gated on `not(feature = "ebpf")`). Left alone here, worth a separate cleanup.

## Testing

21 new unit tests covering attribution conversion, relaxation shapes, ambiguity, the compat bridge, procfs quality mapping, executable and credential failure, cache preservation, and no-upgrade-to-exact.

The ignored root integration test now also asserts match quality, `/proc/<tgid>/exe` resolution, accept-thread TID, and a new worker-thread case proving TID is not a copy of TGID. Namespace-sensitive assertions are guarded on the BPF TGID matching our own PID.

`cargo fmt`, `cargo clippy --workspace --all-targets`, and `cargo test --workspace --all-targets` are clean (582 tests), as is the procfs-only build (`-p rustnet-host` without `ebpf`, and `--workspace --no-default-features`).

The eBPF integration tests have not been run under root yet:

```
sudo -E cargo test -p rustnet-host --features ebpf -- --ignored --nocapture
```
