### PR TITLE
Fix QUIC Transport Health and handshake RTT measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dropped on the capture workers after privileged initialization (#498)
 
 ### Fixed
+- **Initial RTT Measured Against The Wrong Clock**: `Initial RTT` in the Details
+  pane reported round trips as `0.0ms`. RTT was timed with a clock read taken while
+  processing a packet rather than from the packet's capture timestamp, and capture
+  hands packets to processing in batches spanning up to 100 packets or 100ms — wide
+  enough that a whole handshake usually lands in one batch and gets timed as the
+  batch loop's own microseconds. Connections are now stamped with each packet's
+  libpcap timestamp, which costs no extra clock reads and also makes RTTs correct
+  when a saved pcap is replayed. Separately, RTT could be measured from an inbound
+  packet to this host's own reply, which spans no network at all; the clock now
+  starts only on a packet leaving this host. This affected TCP as well — any
+  connection to a local listener reported a handshake RTT of roughly 60µs
+- **Transport Health On QUIC Connections**: The Details pane labelled every
+  connection's Transport Health card with TCP loss counters, so a QUIC flow showed
+  `TCP Retransmits`, `Duplicate ACKs`, and `Window Size` sitting empty as if the
+  measurement had failed. QUIC encrypts its ACK frames and protects its packet
+  numbers, so those counters are unobservable on the wire rather than merely
+  unmeasured. QUIC connections now get their own rows — `Idle Timeout` and
+  `Connection Close` from the transport parameters and CONNECTION\_CLOSE frame,
+  plus a note about the encrypted counters — and `Initial RTT` is filled in from
+  the long-header handshake exchange, the QUIC analogue of SYN/SYN-ACK timing.
+  Other UDP flows say so instead of showing six blank TCP fields. All variants keep
+  the card's height so the dashboard doesn't resize between connections
 - **TCP Transport Health Counters**: `TCP Retransmits` in the Details pane stayed
   at 0 for the life of a connection while `Fast Retransmits` climbed into the
   dozens. Outbound sequence tracking desynchronized permanently the first time a

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -4,7 +4,8 @@
 //! managed table of [`Connection`]s. It owns everything needed to turn a stream
 //! of [`ParsedPacket`]s into the same connection view the `rustnet` TUI shows —
 //! the active table, an archive of recently-closed ("historic") connections,
-//! RTT estimation from TCP SYN/SYN-ACK timing, QUIC connection-ID coalescing,
+//! RTT estimation from TCP SYN/SYN-ACK and QUIC handshake timing, QUIC
+//! connection-ID coalescing,
 //! and timeout-based cleanup — **without** any UI, capture, or process-lookup
 //! dependency.
 //!
@@ -42,7 +43,9 @@
 
 use crate::network::merge::{create_connection_from_packet, merge_packet_into_connection};
 use crate::network::parser::ParsedPacket;
-use crate::network::types::{ApplicationProtocol, Connection, ConnectionKey, Protocol, RttTracker};
+use crate::network::types::{
+    ApplicationProtocol, Connection, ConnectionKey, Protocol, QuicPacketType, RttTracker,
+};
 use dashmap::DashMap;
 use rustc_hash::FxBuildHasher;
 use std::collections::HashMap;
@@ -59,6 +62,23 @@ const RECENTLY_CLOSED_TTL: Duration = Duration::from_secs(30);
 /// not strip them and reopen the phantom-connection window. Entries are a
 /// key and a timestamp; the TTL above bounds how long any of them live.
 const RECENTLY_CLOSED_MIN_ENTRIES: usize = 1024;
+
+/// Whether a QUIC packet belongs to the handshake exchange that RTT timing
+/// pairs up.
+///
+/// 0-RTT is deliberately excluded: it is client-only application data sent
+/// alongside the Initial, so treating it as a fresh send would restart the
+/// timer and report a fraction of the real round trip. 1-RTT packets carry a
+/// short header and reveal nothing to time against.
+fn is_quic_handshake_packet(packet_type: QuicPacketType) -> bool {
+    matches!(
+        packet_type,
+        QuicPacketType::Initial
+            | QuicPacketType::Handshake
+            | QuicPacketType::Retry
+            | QuicPacketType::VersionNegotiation
+    )
+}
 
 /// The active connection table: flow key -> connection.
 ///
@@ -146,7 +166,9 @@ pub struct IngestOutcome {
     pub out_of_order: u64,
     /// New TCP fast-retransmits detected by this packet.
     pub fast_retransmits: u64,
-    /// An RTT sample, if this packet was a TCP SYN-ACK that matched a prior SYN.
+    /// An RTT sample, if this packet completed a handshake round trip: a TCP
+    /// SYN-ACK matching a prior SYN, or a QUIC handshake packet answering one
+    /// sent the other way.
     pub measured_rtt: Option<Duration>,
 }
 
@@ -208,8 +230,16 @@ impl ConnectionTracker {
     /// Use this for deterministic offline processing (pcap replay, tests): pass
     /// the packet's capture timestamp so `created_at`/`last_activity` and the
     /// `cleanup` timeout sweep operate on trace time, not real time.
+    ///
+    /// Live callers should pass each packet's own capture timestamp too, not one
+    /// clock read shared across a batch of packets. Handshake RTT is the
+    /// difference between two packets' `now` values, so a shared timestamp
+    /// collapses every round trip that completes within one batch to zero.
     pub fn ingest_at(&self, parsed: &ParsedPacket, now: SystemTime) -> IngestOutcome {
-        // Track RTT for TCP connections using SYN/SYN-ACK timing.
+        // Track RTT for TCP connections using SYN/SYN-ACK timing, and for QUIC
+        // using the long-header handshake exchange. Everything QUIC sends after
+        // the handshake is behind header protection, so this initial flight is
+        // the only round trip an on-path observer can time.
         let mut measured_rtt: Option<Duration> = None;
         let base_key = parsed.connection_key();
         if parsed.protocol == Protocol::Tcp
@@ -217,14 +247,21 @@ impl ConnectionTracker {
         {
             if tcp_header.flags.syn && !tcp_header.flags.ack {
                 if let Ok(mut tracker) = self.rtt.lock() {
-                    tracker.record_syn(base_key);
+                    tracker.record_syn(base_key, now);
                 }
             } else if tcp_header.flags.syn
                 && tcp_header.flags.ack
                 && let Ok(mut tracker) = self.rtt.lock()
             {
-                measured_rtt = tracker.record_syn_ack(&base_key);
+                measured_rtt = tracker.record_syn_ack(&base_key, now);
             }
+        } else if parsed.protocol == Protocol::Udp
+            && let Some(dpi) = &parsed.dpi_result
+            && let ApplicationProtocol::Quic(quic) = &dpi.application
+            && is_quic_handshake_packet(quic.packet_type)
+            && let Ok(mut tracker) = self.rtt.lock()
+        {
+            measured_rtt = tracker.record_quic_handshake(base_key, parsed.is_outgoing, now);
         }
 
         // A read guard makes ordinary packet updates atomic with cleanup. The
@@ -807,6 +844,188 @@ mod tests {
             process_name: None,
             process_id: None,
         }
+    }
+
+    fn quic_packet(packet_type: QuicPacketType, is_outgoing: bool) -> ParsedPacket {
+        use crate::network::dpi::DpiResult;
+        use crate::network::types::{ProtocolState, QuicInfo};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        let mut quic = QuicInfo::new(1);
+        quic.packet_type = packet_type;
+
+        ParsedPacket {
+            protocol: Protocol::Udp,
+            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
+            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
+            protocol_state: ProtocolState::Udp,
+            tcp_header: None,
+            is_outgoing,
+            packet_len: 1_200,
+            dpi_result: Some(DpiResult {
+                application: ApplicationProtocol::Quic(Box::new(quic)),
+            }),
+            process_name: None,
+            process_id: None,
+        }
+    }
+
+    /// Capture time for a packet `millis` into a synthetic trace. Tests drive
+    /// `ingest_at` with these rather than the wall clock so an RTT assertion
+    /// pins a real duration instead of however long the test loop took.
+    fn capture_time(millis: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_millis(millis)
+    }
+
+    /// QUIC's handshake is the only round trip an on-path observer can time,
+    /// so the client Initial and the server's reply must pair up into the
+    /// connection's initial RTT the way SYN/SYN-ACK does for TCP.
+    ///
+    /// The RTT must come from the packets' capture timestamps. Capture hands
+    /// packets to processing in batches spanning up to 100 packets or 100ms, so
+    /// a handshake this quick is processed as one microseconds-wide burst; a
+    /// tracker that read its own clock would report 0.0ms here.
+    #[test]
+    fn quic_handshake_exchange_measures_initial_rtt() {
+        let tracker = ConnectionTracker::new();
+
+        let client_initial =
+            tracker.ingest_at(&quic_packet(QuicPacketType::Initial, true), capture_time(0));
+        assert!(
+            client_initial.measured_rtt.is_none(),
+            "the opening Initial has nothing to pair with yet"
+        );
+
+        let server_initial = tracker.ingest_at(
+            &quic_packet(QuicPacketType::Initial, false),
+            capture_time(18),
+        );
+        assert_eq!(
+            server_initial.measured_rtt,
+            Some(Duration::from_millis(18)),
+            "the RTT is the gap between the two capture timestamps"
+        );
+        assert_eq!(
+            tracker
+                .connections()
+                .get(&server_initial.key)
+                .and_then(|conn| conn.initial_rtt),
+            Some(Duration::from_millis(18)),
+            "the measured RTT should land on the connection"
+        );
+    }
+
+    /// A repeated client Initial is a retransmission, not a reply, so it must
+    /// not be read as a completed round trip.
+    #[test]
+    fn repeated_quic_initial_in_one_direction_measures_nothing() {
+        let tracker = ConnectionTracker::new();
+        tracker.ingest_at(&quic_packet(QuicPacketType::Initial, true), capture_time(0));
+        let retransmit = tracker.ingest_at(
+            &quic_packet(QuicPacketType::Initial, true),
+            capture_time(250),
+        );
+        assert!(retransmit.measured_rtt.is_none());
+        assert!(
+            tracker
+                .connections()
+                .get(&retransmit.key)
+                .and_then(|conn| conn.initial_rtt)
+                .is_none()
+        );
+    }
+
+    /// rustnet watches from an endpoint, so an arriving packet followed by this
+    /// host's own answer spans no network at all — it times the local stack's
+    /// turnaround. Only an outbound packet may start the clock.
+    ///
+    /// A server's first flight is several datagrams, so this ordering shows up
+    /// on ordinary connections once the first datagram has been paired off.
+    #[test]
+    fn inbound_quic_handshake_packet_does_not_start_the_clock() {
+        let tracker = ConnectionTracker::new();
+
+        tracker.ingest_at(
+            &quic_packet(QuicPacketType::Handshake, false),
+            capture_time(0),
+        );
+        let local_reply = tracker.ingest_at(
+            &quic_packet(QuicPacketType::Handshake, true),
+            capture_time(1),
+        );
+        assert!(
+            local_reply.measured_rtt.is_none(),
+            "this host's own turnaround is not a round trip"
+        );
+        assert!(
+            tracker
+                .connections()
+                .get(&local_reply.key)
+                .and_then(|conn| conn.initial_rtt)
+                .is_none()
+        );
+    }
+
+    /// Once the client Initial has been paired with the server's first
+    /// datagram, the rest of the server's flight must not overwrite the real
+    /// measurement with a local-turnaround one.
+    #[test]
+    fn later_server_flight_does_not_replace_the_handshake_rtt() {
+        let tracker = ConnectionTracker::new();
+
+        tracker.ingest_at(&quic_packet(QuicPacketType::Initial, true), capture_time(0));
+        tracker.ingest_at(
+            &quic_packet(QuicPacketType::Initial, false),
+            capture_time(18),
+        );
+
+        // Remainder of the server's first flight, then this host's ACK.
+        tracker.ingest_at(
+            &quic_packet(QuicPacketType::Handshake, false),
+            capture_time(19),
+        );
+        let ack = tracker.ingest_at(
+            &quic_packet(QuicPacketType::Handshake, true),
+            capture_time(19),
+        );
+        assert!(ack.measured_rtt.is_none());
+
+        assert_eq!(
+            tracker
+                .connections()
+                .get(&ack.key)
+                .and_then(|conn| conn.initial_rtt),
+            Some(Duration::from_millis(18))
+        );
+    }
+
+    /// 1-RTT packets carry a short header with nothing timeable in the clear.
+    #[test]
+    fn quic_one_rtt_packets_do_not_measure_rtt() {
+        let tracker = ConnectionTracker::new();
+        tracker.ingest_at(&quic_packet(QuicPacketType::OneRtt, true), capture_time(0));
+        let inbound = tracker.ingest_at(
+            &quic_packet(QuicPacketType::OneRtt, false),
+            capture_time(18),
+        );
+        assert!(inbound.measured_rtt.is_none());
+    }
+
+    /// The TCP handshake is timed from capture timestamps for the same reason
+    /// the QUIC one is: SYN and SYN-ACK routinely land in a single batch.
+    #[test]
+    fn tcp_handshake_rtt_comes_from_capture_timestamps() {
+        let tracker = ConnectionTracker::new();
+
+        tracker.ingest_at(
+            &tcp_packet(true, false, false, false, true),
+            capture_time(0),
+        );
+        let syn_ack = tracker.ingest_at(
+            &tcp_packet(true, true, false, false, false),
+            capture_time(12),
+        );
+        assert_eq!(syn_ack.measured_rtt, Some(Duration::from_millis(12)));
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -1750,11 +1750,22 @@ impl std::fmt::Display for ConnectionKey {
 // RTT Tracking Types (for latency measurement)
 // ============================================================================
 
-/// Tracks pending SYN packets and recent RTT measurements
+/// Tracks pending handshake packets and recent RTT measurements.
+///
+/// Every pending timestamp here is the packet's **capture** time, supplied by
+/// the caller, never a clock read taken while processing. Capture threads hand
+/// packets to processing in batches of up to 100 (or every 100ms), so a
+/// handshake that completes inside one batch window — which is most of them —
+/// is processed as a burst microseconds wide. Timing that burst measures the
+/// batch loop, not the network, and reports round trips as 0.0ms. Using capture
+/// time also makes RTTs correct when a saved pcap is replayed.
 #[derive(Debug)]
 pub struct RttTracker {
-    /// Pending SYN packets awaiting SYN-ACK: (connection_key -> timestamp)
-    pending_syns: HashMap<ConnectionKey, Instant>,
+    /// Pending SYN packets awaiting SYN-ACK: (connection_key -> capture time)
+    pending_syns: HashMap<ConnectionKey, SystemTime>,
+    /// Outbound QUIC handshake packets awaiting a reply from the peer:
+    /// (connection_key -> capture time)
+    pending_quic_handshakes: HashMap<ConnectionKey, SystemTime>,
     /// Recent RTT measurements for aggregation: (timestamp, rtt_duration)
     recent_rtts: VecDeque<(Instant, Duration)>,
     /// Maximum age for pending SYNs (cleanup stale entries)
@@ -1767,29 +1778,63 @@ impl RttTracker {
     pub fn new() -> Self {
         Self {
             pending_syns: HashMap::new(),
+            pending_quic_handshakes: HashMap::new(),
             recent_rtts: VecDeque::new(),
             max_pending_age: Duration::from_secs(30),
             max_recent_rtts: 100,
         }
     }
 
-    /// Record a SYN packet being sent/received
-    pub fn record_syn(&mut self, key: ConnectionKey) {
-        self.pending_syns.insert(key, Instant::now());
-        self.cleanup_stale();
+    /// Record a SYN packet being sent/received, stamped with its capture time.
+    pub fn record_syn(&mut self, key: ConnectionKey, at: SystemTime) {
+        self.pending_syns.insert(key, at);
+        self.cleanup_stale(at);
     }
 
     /// Try to match a SYN-ACK to a pending SYN and calculate RTT
     /// Returns the RTT if a match was found
-    pub fn record_syn_ack(&mut self, key: &ConnectionKey) -> Option<Duration> {
+    pub fn record_syn_ack(&mut self, key: &ConnectionKey, at: SystemTime) -> Option<Duration> {
         // SYN and SYN-ACK have the same (local_addr, remote_addr) from parser's perspective
         if let Some(syn_time) = self.pending_syns.remove(key) {
-            let rtt = syn_time.elapsed();
+            let rtt = at.duration_since(syn_time).unwrap_or_default();
             self.add_rtt_sample(rtt);
             Some(rtt)
         } else {
             None
         }
+    }
+
+    /// Record a QUIC long-header handshake packet, returning the RTT when it
+    /// completes a round trip with the peer.
+    ///
+    /// QUIC has no SYN/SYN-ACK flag to key on, so direction stands in for it —
+    /// but only in one order. rustnet observes from an endpoint, not from a
+    /// midpoint, so the timer must start on a packet leaving this host and stop
+    /// on the peer's answer coming back: that spans the network twice. Timing
+    /// the opposite order would measure how fast the local stack turned an
+    /// arriving packet around, which is tens of microseconds and reads as a
+    /// 0.0ms RTT. An inbound packet with nothing pending therefore starts
+    /// nothing, and a second outbound packet is a retransmission or a follow-up
+    /// flight, so it restarts the timer from the most recent send.
+    ///
+    /// This still measures connections where the local host is the QUIC server:
+    /// the client's Initial arrives and is ignored, our reply starts the timer,
+    /// and the client's next flight stops it.
+    pub fn record_quic_handshake(
+        &mut self,
+        key: ConnectionKey,
+        is_outgoing: bool,
+        at: SystemTime,
+    ) -> Option<Duration> {
+        self.cleanup_stale(at);
+        if is_outgoing {
+            self.pending_quic_handshakes.insert(key, at);
+            return None;
+        }
+        let sent_at = self.pending_quic_handshakes.remove(&key)?;
+        let rtt = at.duration_since(sent_at).unwrap_or_default();
+        self.add_rtt_sample(rtt);
+        Some(rtt)
     }
 
     /// Add an RTT sample
@@ -1819,15 +1864,20 @@ impl RttTracker {
         }
     }
 
-    /// Clean up stale pending SYNs
-    fn cleanup_stale(&mut self) {
-        let cutoff = Instant::now() - self.max_pending_age;
+    /// Clean up pending handshakes older than `max_pending_age` relative to the
+    /// capture time of the packet being processed.
+    fn cleanup_stale(&mut self, now: SystemTime) {
+        let Some(cutoff) = now.checked_sub(self.max_pending_age) else {
+            return;
+        };
         self.pending_syns.retain(|_, ts| *ts > cutoff);
+        self.pending_quic_handshakes.retain(|_, ts| *ts > cutoff);
     }
 
     /// Clear all RTT tracking data
     pub fn clear(&mut self) {
         self.pending_syns.clear();
+        self.pending_quic_handshakes.clear();
         self.recent_rtts.clear();
     }
 }
@@ -2335,7 +2385,8 @@ pub struct Connection {
     // TCP analytics (only for TCP connections)
     pub tcp_analytics: Option<TcpAnalytics>,
 
-    // Initial RTT measurement (from SYN-ACK timing)
+    // Initial RTT measurement: TCP SYN/SYN-ACK timing, or the QUIC long-header
+    // handshake exchange. Set once, from the first round trip observed.
     pub initial_rtt: Option<std::time::Duration>,
 
     // GeoIP information for remote address
@@ -3970,6 +4021,13 @@ mod tests {
     // RTT Tracker Tests
     // ========================================================================
 
+    /// Capture time `millis` into a synthetic trace. RTT is the difference
+    /// between two packets' capture timestamps, so tests supply them directly
+    /// rather than sleeping and reading a clock.
+    fn rtt_capture_time(millis: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_millis(millis)
+    }
+
     #[test]
     fn test_rtt_tracker_new() {
         let tracker = RttTracker::new();
@@ -3986,7 +4044,7 @@ mod tests {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
         );
 
-        tracker.record_syn(key);
+        tracker.record_syn(key, rtt_capture_time(0));
         assert_eq!(tracker.pending_syns.len(), 1);
         assert!(tracker.pending_syns.contains_key(&key));
     }
@@ -4001,7 +4059,7 @@ mod tests {
         );
 
         // Try to record SYN-ACK without prior SYN
-        let rtt = tracker.record_syn_ack(&key);
+        let rtt = tracker.record_syn_ack(&key, rtt_capture_time(0));
         assert!(rtt.is_none());
     }
 
@@ -4013,18 +4071,14 @@ mod tests {
 
         // Record SYN (outgoing: local -> remote)
         let syn_key = ConnectionKey::new(Protocol::Tcp, local, remote);
-        tracker.record_syn(syn_key);
+        tracker.record_syn(syn_key, rtt_capture_time(0));
 
-        // Simulate some delay
-        std::thread::sleep(Duration::from_millis(10));
-
-        // Record SYN-ACK (same key - parser normalizes to local,remote)
+        // Record SYN-ACK (same key - parser normalizes to local,remote) one
+        // network round trip later, per the packets' capture timestamps.
         let syn_ack_key = ConnectionKey::new(Protocol::Tcp, local, remote);
-        let rtt = tracker.record_syn_ack(&syn_ack_key);
+        let rtt = tracker.record_syn_ack(&syn_ack_key, rtt_capture_time(10));
 
-        assert!(rtt.is_some());
-        let rtt = rtt.unwrap();
-        assert!(rtt >= Duration::from_millis(10));
+        assert_eq!(rtt, Some(Duration::from_millis(10)));
         assert!(tracker.pending_syns.is_empty());
         assert_eq!(tracker.recent_rtts.len(), 1);
     }
@@ -4039,9 +4093,8 @@ mod tests {
         for port in 12345..12348 {
             let local_with_port = SocketAddr::new(local.ip(), port);
             let key = ConnectionKey::new(Protocol::Tcp, local_with_port, remote);
-            tracker.record_syn(key);
-            std::thread::sleep(Duration::from_millis(5));
-            tracker.record_syn_ack(&key);
+            tracker.record_syn(key, rtt_capture_time(0));
+            tracker.record_syn_ack(&key, rtt_capture_time(5));
         }
 
         // Get average RTT

--- a/src/app.rs
+++ b/src/app.rs
@@ -1469,11 +1469,13 @@ impl App {
                     // packet that panics a DPI parser cannot take down the
                     // whole pcap_rx thread and leave the monitor running
                     // blind.
-                    // One wall-clock read per batch instead of per packet.
-                    // Batches hold ≤100 packets and flush at least every
-                    // 100ms, so the timestamp skew is far below any
-                    // connection timeout or rate window.
-                    let batch_time = SystemTime::now();
+                    // Connections are stamped with each packet's own capture
+                    // time, not one clock read shared by the batch. Handshake
+                    // RTT is the gap between two packets' timestamps, and a
+                    // batch spans up to 100 packets or 100ms — wide enough to
+                    // swallow a whole handshake and report its round trip as
+                    // zero. libpcap already hands us the kernel's timestamp, so
+                    // this costs no extra clock reads.
                     parser.refresh_local_ips_if_due(LOCAL_ADDRESS_REFRESH_INTERVAL);
                     let mut parsed_count = 0;
                     let batch_len = batch.len();
@@ -1490,7 +1492,7 @@ impl App {
                                 let outcome = update_connection(
                                     &tracker,
                                     parsed,
-                                    batch_time,
+                                    packet_timestamp,
                                     &stats,
                                     &json_log_file,
                                     &pcap_sidecar_file,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1168,6 +1168,115 @@ mod snapshot_tests {
         });
     }
 
+    /// QUIC rides on UDP, so the Details tab used to label its Transport
+    /// Health card with TCP loss counters that can never be filled in — packet
+    /// numbers and ACK frames sit behind QUIC's header protection. The card
+    /// must show what is actually observable instead, without changing height.
+    #[test]
+    fn details_tab_quic_shows_transport_health_without_tcp_counters() {
+        use crate::network::types::{
+            ApplicationProtocol, DpiInfo, QuicCloseInfo, QuicConnectionState, QuicInfo,
+            QuicPacketType,
+        };
+
+        let app = test_app();
+        let mut connections = sample_connections();
+        let mut quic = QuicInfo::new(1);
+        quic.packet_type = QuicPacketType::OneRtt;
+        quic.connection_state = QuicConnectionState::Connected;
+        quic.idle_timeout = Some(Duration::from_secs(30));
+        quic.connection_close = Some(QuicCloseInfo {
+            frame_type: 0x1d,
+            error_code: 0x100,
+        });
+
+        let quic_conn = &mut connections[1];
+        quic_conn.remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(142, 250, 74, 138)), 443);
+        quic_conn.service_name = Some("https".to_string());
+        quic_conn.process_name = Some("firefox".to_string());
+        quic_conn.initial_rtt = Some(Duration::from_micros(23_400));
+        quic_conn.dpi_info = Some(DpiInfo {
+            application: ApplicationProtocol::Quic(Box::new(quic)),
+            last_update_time: std::time::Instant::now(),
+        });
+
+        app.set_connections_snapshot_for_test(connections.clone());
+        let stats = app.get_stats();
+        let ui_state = UIState {
+            selected_tab: 1, // Details
+            selected_connection_key: Some(connections[1].key()),
+            ..Default::default()
+        };
+        let mut click_regions = ClickableRegions::default();
+        let output = render(140, 40, |f| {
+            draw(
+                f,
+                &app,
+                &ui_state,
+                &connections,
+                None,
+                &stats,
+                &mut click_regions,
+            )
+            .expect("draw details");
+        });
+
+        for tcp_only in [
+            "TCP Retransmits",
+            "Out-of-Order Packets",
+            "Duplicate ACKs",
+            "Fast Retransmits",
+            "Window Size",
+        ] {
+            assert!(
+                !output.contains(tcp_only),
+                "{tcp_only} is a TCP counter and cannot be measured on a QUIC flow"
+            );
+        }
+        assert!(
+            output.contains("23.4ms"),
+            "QUIC handshake RTT should fill the Initial RTT row"
+        );
+        assert!(output.contains("Idle Timeout") && output.contains("30s"));
+        assert!(output.contains("Connection Close") && output.contains("application 0x100"));
+        assert!(
+            output.contains("Loss counters are encrypted in QUIC"),
+            "the card should say why the loss counters are absent"
+        );
+
+        // The card must not resize between protocols: Traffic Statistics is
+        // anchored below Transport Health, so a shorter QUIC card would pull
+        // the whole lower half of the dashboard upward.
+        let tcp_state = UIState {
+            selected_tab: 1,
+            selected_connection_key: Some(connections[0].key()),
+            ..Default::default()
+        };
+        let tcp_output = render(140, 40, |f| {
+            draw(
+                f,
+                &app,
+                &tcp_state,
+                &connections,
+                None,
+                &stats,
+                &mut click_regions,
+            )
+            .expect("draw details");
+        });
+        let heading_row = |render: &str, heading: &str| {
+            render
+                .lines()
+                .position(|line| line.contains(heading))
+                .unwrap_or_else(|| panic!("missing {heading}"))
+        };
+        assert_eq!(
+            heading_row(&output, "Traffic Statistics"),
+            heading_row(&tcp_output, "Traffic Statistics"),
+            "Traffic Statistics moved between the QUIC and TCP records"
+        );
+    }
+
     #[test]
     fn details_tab_keeps_section_anchors_across_metadata_shapes() {
         let app = test_app();

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -57,6 +57,12 @@ const DETAILS_MAX_CONTENT_WIDTH: u16 = 140;
 /// visible rows and align Transport Health with Network Context on the left.
 const APPLICATION_CARD_ROWS: usize = 11;
 
+/// Rows reserved for the Transport Health card, including its blank separator
+/// and heading. TCP fills all of them with counters; the shorter QUIC and
+/// generic-transport variants pad to the same height so switching between
+/// connections of different protocols doesn't resize the dashboard.
+const TRANSPORT_CARD_ROWS: usize = 8;
+
 /// Details tab. Pulls DNS resolver per-render from the app — no
 /// per-tab state today.
 pub(in crate::ui) struct DetailsTab;
@@ -148,6 +154,41 @@ fn push_detail_field_styled<'a>(
         Span::styled(value.clone(), value_style),
     ]));
     fields.push(Some((label.to_string(), value)));
+}
+
+/// Format a QUIC idle timeout, as advertised in the peer's transport
+/// parameters. Values are whole seconds in practice (30s, 120s), so only sub-
+/// second timeouts fall back to milliseconds.
+fn format_idle_timeout(timeout: std::time::Duration) -> String {
+    if timeout.as_secs() > 0 {
+        format!("{}s", timeout.as_secs())
+    } else {
+        format!("{}ms", timeout.as_millis())
+    }
+}
+
+/// Format a QUIC CONNECTION_CLOSE frame. Frame type 0x1d carries an
+/// application-level error code (an HTTP/3 code, say), anything else is a
+/// transport-level one, and the two number spaces are unrelated — so the
+/// origin has to be shown alongside the code (RFC 9000 §19.19).
+fn format_quic_close(close: &crate::network::types::QuicCloseInfo) -> String {
+    let origin = if close.frame_type == 0x1d {
+        "application"
+    } else {
+        "transport"
+    };
+    format!("{} 0x{:x}", origin, close.error_code)
+}
+
+/// Push a muted explanatory line into a card. Unlike a field row this carries
+/// no label/value pair, so it registers no click-to-copy target.
+fn push_detail_note<'a>(
+    lines: &mut Vec<Line<'a>>,
+    fields: &mut Vec<Option<(String, String)>>,
+    note: &'a str,
+) {
+    lines.push(Line::from(Span::styled(note, theme::fg(theme::muted()))));
+    fields.push(None);
 }
 
 /// Pad a detail section to a stable height. Padding rows deliberately have no
@@ -1399,12 +1440,32 @@ pub(in crate::ui) fn draw_connection_details(
     );
     right_ranges.push(application_start..details_text.len());
 
-    // Transport Health is also a fixed card. Non-TCP connections retain the
-    // same field positions with muted placeholders, so switching protocols no
-    // longer changes the dashboard geometry.
+    // Transport Health is also a fixed card, but its rows are protocol
+    // specific. QUIC has no equivalent of the TCP loss counters: packet numbers
+    // are header-protected and ACK frames are encrypted (RFC 9001 §5.4), so
+    // they aren't merely unmeasured, they're unobservable from the wire.
+    // Rendering them as empty TCP labels read as "rustnet failed to measure
+    // this". Each branch pads to TRANSPORT_CARD_ROWS so the geometry still
+    // holds still when flipping between connections.
+    let quic_info = conn
+        .dpi_info
+        .as_ref()
+        .and_then(|dpi| match &dpi.application {
+            crate::network::types::ApplicationProtocol::Quic(info) => Some(info.as_ref()),
+            _ => None,
+        });
     let metrics_start = details_text.len();
     push_detail_section(&mut details_text, &mut detail_fields, "Transport Health");
-    if let Some(rtt) = conn.initial_rtt {
+    let show_rtt = conn.protocol == Protocol::Tcp || quic_info.is_some();
+    if !show_rtt {
+        // Nothing on a bare UDP/ICMP flow is timeable or countable: no
+        // handshake to pair up, no sequence numbers to track.
+        push_detail_note(
+            &mut details_text,
+            &mut detail_fields,
+            "No transport metrics for this protocol",
+        );
+    } else if let Some(rtt) = conn.initial_rtt {
         let rtt_ms = rtt.as_secs_f64() * 1000.0;
         let rtt_color = if rtt_ms < 50.0 {
             theme::ok()
@@ -1430,59 +1491,67 @@ pub(in crate::ui) fn draw_connection_details(
             label_style,
         );
     }
-    if let Some(analytics) = &conn.tcp_analytics {
+    if let Some(quic) = quic_info {
         push_detail_field(
             &mut details_text,
             &mut detail_fields,
-            "TCP Retransmits",
-            analytics.retransmit_count.to_string(),
+            "Idle Timeout",
+            quic.idle_timeout
+                .map(format_idle_timeout)
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
             label_style,
         );
         push_detail_field(
             &mut details_text,
             &mut detail_fields,
-            "Out-of-Order Packets",
-            analytics.out_of_order_count.to_string(),
+            "Connection Close",
+            quic.connection_close
+                .as_ref()
+                .map(format_quic_close)
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
             label_style,
         );
-        push_detail_field(
+        // Separated from the fields above so it reads as a footnote on the
+        // card rather than another value that failed to resolve.
+        details_text.push(Line::from(""));
+        detail_fields.push(None);
+        push_detail_note(
             &mut details_text,
             &mut detail_fields,
-            "Duplicate ACKs",
-            analytics.duplicate_ack_count.to_string(),
-            label_style,
+            "Loss counters are encrypted in QUIC",
         );
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Fast Retransmits",
-            analytics.fast_retransmit_count.to_string(),
-            label_style,
-        );
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Window Size",
-            analytics.last_window_size.to_string(),
-            label_style,
-        );
-    } else {
-        for label in [
-            "TCP Retransmits",
-            "Out-of-Order Packets",
-            "Duplicate ACKs",
-            "Fast Retransmits",
-            "Window Size",
+    } else if conn.protocol == Protocol::Tcp {
+        let counters = conn.tcp_analytics.as_ref();
+        for (label, value) in [
+            ("TCP Retransmits", counters.map(|a| a.retransmit_count)),
+            (
+                "Out-of-Order Packets",
+                counters.map(|a| a.out_of_order_count),
+            ),
+            ("Duplicate ACKs", counters.map(|a| a.duplicate_ack_count)),
+            (
+                "Fast Retransmits",
+                counters.map(|a| a.fast_retransmit_count),
+            ),
+            ("Window Size", counters.map(|a| a.last_window_size as u64)),
         ] {
             push_detail_field(
                 &mut details_text,
                 &mut detail_fields,
                 label,
-                NONE_PLACEHOLDER.to_string(),
+                value
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
                 label_style,
             );
         }
     }
+    pad_detail_section(
+        &mut details_text,
+        &mut detail_fields,
+        metrics_start,
+        TRANSPORT_CARD_ROWS,
+    );
     right_ranges.push(metrics_start..details_text.len());
 
     // Continuity: the header band echoes the selected row so users feel


### PR DESCRIPTION
The Details pane showed TCP loss counters on QUIC connections, where they can never be filled — QUIC encrypts its ACK frames and protects its packet numbers. QUIC now gets `Idle Timeout` and `Connection Close`; other UDP flows say no metrics apply.

`Initial RTT` also read `0.0ms`. It was timed from a clock read taken during processing rather than the packet capture timestamp, and capture batches up to 100 packets or 100ms — enough to swallow a whole handshake. It could also be timed from an inbound packet to this host's own reply, which spans no network. Both affected TCP as well.