### PR TITLE
Add macOS process attribution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -235,13 +235,15 @@ RustNet uses platform-specific APIs to associate network connections with proces
 
 **PKTAP Mode (with sudo):**
 - Uses PKTAP (Packet Tap) kernel interface
-- Extracts process information directly from packet metadata
+- Extracts PID and process name directly from packet metadata
+- Uses libproc to add the executable path and effective UID/GID
 - Requires root privileges (privileged kernel interface)
 - Faster and more accurate than lsof
 
 **lsof Mode (without sudo or fallback):**
-- Uses `lsof -i -n -P` to list network connections
-- Parses output to associate sockets with processes
+- Uses `lsof -i -n -P -l` to list network connections with numeric UIDs
+- Parses output to associate sockets with processes, then uses libproc for the
+  executable path
 - Higher CPU overhead but works without root
 - Used automatically when PKTAP is unavailable
 

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -230,13 +230,14 @@ RustNet 使用平台特定的 API 将网络连接与进程关联：
 
 **PKTAP 模式（使用 sudo 时）：**
 - 使用 PKTAP（Packet Tap）内核接口
-- 直接从包元数据提取进程信息
+- 直接从包元数据提取 PID 和进程名称
+- 使用 libproc 补充可执行文件路径和有效 UID/GID
 - 需要 root 特权（特权内核接口）
 - 比 lsof 更快更准确
 
 **lsof 模式（无 sudo 或回退时）：**
-- 使用 `lsof -i -n -P` 列出网络连接
-- 解析输出以将 socket 与进程关联
+- 使用 `lsof -i -n -P -l` 列出网络连接及数字 UID
+- 解析输出以将 socket 与进程关联，然后使用 libproc 获取可执行文件路径
 - CPU 开销更高，但无需 root
 - 当 PKTAP 不可用时自动使用
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `attr=` but deliberately omit the executable path, which would repeat in every
   packet block. Executable paths are interned behind an `Arc`, so bulk connection
   snapshots stay allocation-free (#506, #511)
+- **Rich macOS Process Attribution**: PKTAP keeps its kernel-provided per-packet PID
+  and process name, marks the result as an exact PKTAP attribution, and uses libproc
+  to add the executable path and effective UID/GID. The lsof fallback requests and
+  parses numeric UIDs, resolves executable paths through libproc, and reports exact,
+  wildcard-address, or listener match quality. Packet-seeded PKTAP connections now
+  receive one rich-enrichment pass without making permanently unavailable optional
+  fields hot-loop retries (#510)
 
 ### Changed
 - **Modern Linux eBPF Attribution Backend**: Process attribution now prefers BPF

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -22,7 +22,8 @@ use std::time::{Duration, Instant, SystemTime};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum MatchQuality {
-    /// The full 4-tuple matched a recorded socket.
+    /// Attribution is tied to the observed flow without relaxation, either by
+    /// an exact 4-tuple match or by per-packet process metadata.
     ExactTuple,
     /// Matched only after zeroing the local address, i.e. the socket was
     /// recorded while bound to a wildcard address.

--- a/crates/rustnet-host/README.md
+++ b/crates/rustnet-host/README.md
@@ -9,7 +9,8 @@ Today this is **per-connection process attribution**: given a
 best strategy each platform offers, with graceful fallbacks:
 
 - **Linux**: fentry/fexit eBPF, legacy kprobes, then procfs.
-- **macOS**: PKTAP packet metadata when available (no lookup needed), else `lsof`.
+- **macOS**: PKTAP packet metadata plus libproc when available, else `lsof`
+  plus libproc.
 - **Windows**: kernel ETW events with an IP Helper API
   (`GetExtendedTcpTable` / `...UdpTable`) fallback.
 - **FreeBSD**: `sockstat`.
@@ -47,6 +48,12 @@ the thread id, effective UID/GID, and an observation timestamp taken from a
 **monotonic** clock (`bpf_ktime_get_ns`), which is not wall-clock time. The
 executable path is resolved once from `/proc/<tgid>/exe`; an unreadable link
 yields `executable: None` and never fails the attribution.
+
+On macOS, PKTAP supplies an exact PID and process name with each packet. Libproc
+adds the executable path and effective UID/GID. The fallback parses numeric UIDs
+from `lsof -l` and uses libproc for the executable path. PKTAP reports
+`AttributionBackend::Pktap` with `MatchQuality::ExactTuple`; lsof reports whether
+its socket-table match was exact, wildcard-bound, or a listener.
 
 Platforms that have not been ported get a compatibility bridge over
 `get_process_for_connection()` reporting `MatchQuality::Unspecified`, so every

--- a/crates/rustnet-host/src/lib.rs
+++ b/crates/rustnet-host/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! - **Linux** — eBPF socket tracking (with the `ebpf` feature) and a procfs
 //!   fallback.
-//! - **macOS** — PKTAP packet metadata when available (capture provides it
-//!   directly, so lookup is a no-op), otherwise `lsof`.
+//! - **macOS**: PKTAP packet metadata when available, enriched through libproc,
+//!   otherwise `lsof` plus libproc.
 //! - **Windows** — kernel ETW events with an IP Helper API
 //!   (`GetExtendedTcpTable`/`...UdpTable`) fallback.
 //! - **FreeBSD** — `sockstat`.
@@ -47,6 +47,10 @@ pub enum AttributionBackend {
     EbpfKprobe,
     /// Linux procfs socket-table scanning.
     Procfs,
+    /// macOS PKTAP packet metadata.
+    Pktap,
+    /// macOS `lsof` socket-table scanning.
+    Lsof,
     /// A platform-native backend outside the Linux eBPF stack.
     #[default]
     PlatformNative,
@@ -58,6 +62,8 @@ impl std::fmt::Display for AttributionBackend {
             Self::EbpfFentry => "eBPF fentry/fexit",
             Self::EbpfKprobe => "eBPF kprobe",
             Self::Procfs => "procfs",
+            Self::Pktap => "PKTAP",
+            Self::Lsof => "lsof",
             Self::PlatformNative => "platform native",
         };
         f.write_str(name)
@@ -94,8 +100,8 @@ pub use rustnet_core::network::types::MatchQuality;
 ///
 /// Everything past `tgid`/`name` is best effort: a backend fills in what it
 /// actually observed and leaves the rest `None` rather than guessing. Only the
-/// Linux eBPF backends currently report thread ids, credentials, and an
-/// observation timestamp.
+/// Linux eBPF backends currently report thread ids and an observation
+/// timestamp. Linux and macOS can report credentials and executable paths.
 ///
 /// Marked `#[non_exhaustive]` because cgroup and container fields are expected
 /// to land here later. Build values with [`ProcessAttribution::new`] plus the

--- a/crates/rustnet-host/src/macos/mod.rs
+++ b/crates/rustnet-host/src/macos/mod.rs
@@ -4,8 +4,11 @@ mod process;
 
 pub use process::MacOSProcessLookup;
 
-use crate::{DegradationReason, ProcessLookup};
+use crate::{
+    AttributionBackend, DegradationReason, MatchQuality, ProcessAttribution, ProcessLookup,
+};
 use anyhow::Result;
+use rustnet_core::network::types::Connection;
 use std::sync::OnceLock;
 
 /// Why the PKTAP fast path is unavailable, as reported by the orchestrator.
@@ -33,34 +36,105 @@ pub(crate) fn pktap_degradation() -> DegradationReason {
         .unwrap_or(DegradationReason::MissingRootPrivileges)
 }
 
-/// No-op process lookup for when PKTAP is providing process metadata
-pub struct NoOpProcessLookup;
+/// Enrich process identity carried directly in PKTAP packet metadata.
+pub struct PktapProcessLookup;
 
-impl ProcessLookup for NoOpProcessLookup {
-    fn get_process_for_connection(
-        &self,
-        _conn: &rustnet_core::network::types::Connection,
-    ) -> Option<(u32, String)> {
-        None // PKTAP provides this information directly
+impl ProcessLookup for PktapProcessLookup {
+    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
+        Some((conn.pid?, conn.process_name.clone()?))
+    }
+
+    fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
+        let pid = conn.pid?;
+        let name = conn.process_name.clone()?;
+        let mut attribution = ProcessAttribution::new(
+            pid,
+            name,
+            AttributionBackend::Pktap,
+            MatchQuality::ExactTuple,
+        )
+        .with_executable(process::resolve_executable(pid));
+        if let Some((uid, gid)) = process::resolve_credentials(pid) {
+            attribution = attribution.with_credentials(uid, gid);
+        }
+        Some(attribution)
     }
 
     fn refresh(&self) -> Result<()> {
-        Ok(()) // Nothing to refresh
+        Ok(())
     }
 
     fn get_detection_method(&self) -> &str {
         "pktap"
     }
+
+    fn get_attribution_backend(&self) -> AttributionBackend {
+        AttributionBackend::Pktap
+    }
 }
 
 /// Create a macOS process lookup implementation.
-/// Uses NoOp when PKTAP is active, otherwise falls back to lsof.
+/// Enriches PKTAP packet metadata when active, otherwise falls back to lsof.
 pub fn create_process_lookup(use_pktap: bool) -> Result<Box<dyn ProcessLookup>> {
     if use_pktap {
-        log::info!("Using no-op process lookup - PKTAP provides process metadata");
-        Ok(Box::new(NoOpProcessLookup))
+        log::info!("Using PKTAP process metadata with libproc enrichment");
+        Ok(Box::new(PktapProcessLookup))
     } else {
         log::info!("Using macOS process lookup (lsof)");
         Ok(Box::new(MacOSProcessLookup::new()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustnet_core::network::types::{Protocol, ProtocolState, TcpState};
+
+    fn connection() -> Connection {
+        Connection::new(
+            Protocol::Tcp,
+            "127.0.0.1:5000".parse().unwrap(),
+            "1.1.1.1:443".parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Established),
+        )
+    }
+
+    #[test]
+    fn pktap_identity_is_enriched_with_exact_libproc_attribution() {
+        let mut conn = connection();
+        conn.pid = Some(std::process::id());
+        conn.process_name = Some("rustnet-host-test".to_string());
+
+        let lookup = PktapProcessLookup;
+        let attribution = lookup.get_process_attribution(&conn).unwrap();
+
+        assert_eq!(attribution.tgid, std::process::id());
+        assert_eq!(attribution.name, "rustnet-host-test");
+        assert_eq!(attribution.backend, AttributionBackend::Pktap);
+        assert_eq!(attribution.quality, MatchQuality::ExactTuple);
+        assert_eq!(attribution.executable, std::env::current_exe().ok());
+        // SAFETY: these libc calls only read the credentials of this process.
+        let expected_credentials = unsafe { (libc::geteuid(), libc::getegid()) };
+        assert_eq!(
+            (attribution.uid, attribution.gid),
+            (Some(expected_credentials.0), Some(expected_credentials.1))
+        );
+    }
+
+    #[test]
+    fn pktap_lookup_requires_packet_process_identity() {
+        let lookup = PktapProcessLookup;
+        let mut conn = connection();
+        assert!(lookup.get_process_attribution(&conn).is_none());
+
+        conn.pid = Some(std::process::id());
+        assert!(lookup.get_process_attribution(&conn).is_none());
+    }
+
+    #[test]
+    fn pktap_factory_reports_its_backend() {
+        let lookup = create_process_lookup(true).unwrap();
+        assert_eq!(lookup.get_detection_method(), "pktap");
+        assert_eq!(lookup.get_attribution_backend(), AttributionBackend::Pktap);
     }
 }

--- a/crates/rustnet-host/src/macos/process.rs
+++ b/crates/rustnet-host/src/macos/process.rs
@@ -1,18 +1,85 @@
 // network/platform/macos/process.rs - macOS lsof-based process lookup
 
-use crate::{ConnectionKey, DegradationReason, ProcessLookup};
+use crate::{
+    AttributionBackend, ConnectionKey, DegradationReason, MatchQuality, ProcessAttribution,
+    ProcessLookup, relaxed_lookup,
+};
 use anyhow::Result;
 use log::{debug, error, info, warn};
 use rustnet_core::network::types::{Connection, Protocol};
 use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::mem::{MaybeUninit, size_of};
 use std::net::SocketAddr;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
 use std::process::Command;
 use std::sync::RwLock;
 
 const LSOF_PATH: &str = "/usr/sbin/lsof";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MacOSProcessInfo {
+    pid: u32,
+    name: String,
+    uid: u32,
+}
+
 pub struct MacOSProcessLookup {
-    cache: RwLock<HashMap<ConnectionKey, (u32, String)>>,
+    cache: RwLock<HashMap<ConnectionKey, MacOSProcessInfo>>,
+}
+
+pub(super) fn resolve_executable(pid: u32) -> Option<PathBuf> {
+    let pid = libc::c_int::try_from(pid).ok()?;
+    let mut buffer = [0_u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+
+    // SAFETY: libproc receives a valid writable buffer and its exact size.
+    let length = unsafe {
+        libc::proc_pidpath(
+            pid,
+            buffer.as_mut_ptr().cast(),
+            u32::try_from(buffer.len()).expect("path buffer fits in u32"),
+        )
+    };
+    if length <= 0 {
+        return None;
+    }
+
+    let returned = usize::try_from(length).ok()?.min(buffer.len());
+    let path_length = buffer[..returned]
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(returned);
+    if path_length == 0 {
+        return None;
+    }
+
+    Some(PathBuf::from(OsStr::from_bytes(&buffer[..path_length])))
+}
+
+pub(super) fn resolve_credentials(pid: u32) -> Option<(u32, u32)> {
+    let pid = libc::c_int::try_from(pid).ok()?;
+    let expected_size = size_of::<libc::proc_bsdshortinfo>();
+    let mut info = MaybeUninit::<libc::proc_bsdshortinfo>::zeroed();
+
+    // SAFETY: libproc writes at most `expected_size` bytes into an aligned
+    // buffer with the C layout of `proc_bsdshortinfo`.
+    let returned_size = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDT_SHORTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            libc::c_int::try_from(expected_size).expect("proc info size fits in c_int"),
+        )
+    };
+    if returned_size != libc::c_int::try_from(expected_size).ok()? {
+        return None;
+    }
+
+    // SAFETY: a full `proc_bsdshortinfo` was initialized by the successful call.
+    let info = unsafe { info.assume_init() };
+    Some((info.pbsi_uid, info.pbsi_gid))
 }
 
 impl MacOSProcessLookup {
@@ -22,14 +89,14 @@ impl MacOSProcessLookup {
         })
     }
 
-    fn parse_lsof() -> Result<HashMap<ConnectionKey, (u32, String)>> {
-        let mut lookup = HashMap::new();
+    fn parse_lsof() -> Result<HashMap<ConnectionKey, MacOSProcessInfo>> {
+        let lookup = HashMap::new();
 
         info!("Running lsof to get network connections");
 
         // Run lsof to get network connections
         let output = Command::new(LSOF_PATH)
-            .args(["-i", "-n", "-P", "+c", "0"])
+            .args(["-i", "-n", "-P", "-l", "+c", "0"])
             .output()?;
 
         if !output.status.success() {
@@ -39,12 +106,17 @@ impl MacOSProcessLookup {
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(Self::parse_lsof_output(&stdout))
+    }
+
+    fn parse_lsof_output(stdout: &str) -> HashMap<ConnectionKey, MacOSProcessInfo> {
+        let mut lookup = HashMap::new();
         let lines: Vec<&str> = stdout.lines().collect();
         info!("lsof returned {} lines", lines.len());
 
         if lines.is_empty() {
             warn!("lsof returned no output");
-            return Ok(lookup);
+            return lookup;
         }
 
         debug!("lsof header: {}", lines.first().unwrap_or(&""));
@@ -73,6 +145,13 @@ impl MacOSProcessLookup {
                 Ok(p) => p,
                 Err(e) => {
                     debug!("  Failed to parse PID '{}': {}", parts[1], e);
+                    continue;
+                }
+            };
+            let uid = match parts[2].parse::<u32>() {
+                Ok(uid) => uid,
+                Err(e) => {
+                    debug!("  Failed to parse numeric UID '{}': {}", parts[2], e);
                     continue;
                 }
             };
@@ -141,7 +220,14 @@ impl MacOSProcessLookup {
                     "  Successfully parsed connection: {:?} -> {} ({})",
                     key, process_name, pid
                 );
-                lookup.insert(key, (pid, process_name));
+                lookup.insert(
+                    key,
+                    MacOSProcessInfo {
+                        pid,
+                        name: process_name,
+                        uid,
+                    },
+                );
                 successful_parsers += 1;
             } else {
                 debug!("  Failed to parse connection from NAME field");
@@ -154,29 +240,46 @@ impl MacOSProcessLookup {
         );
         info!("Total connections in lookup table: {}", lookup.len());
 
-        Ok(lookup)
+        lookup
     }
-}
 
-impl ProcessLookup for MacOSProcessLookup {
-    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
+    fn lookup_match(&self, conn: &Connection) -> Option<(MacOSProcessInfo, MatchQuality)> {
         let key = ConnectionKey::from_connection(conn);
         let cache = self.cache.read().expect("cache lock poisoned");
 
         if let Some(result) = cache.get(&key).cloned() {
             debug!("Found process info for connection {:?}: {:?}", key, result);
-            Some(result)
+            Some((result, MatchQuality::ExactTuple))
         } else {
             debug!("No process info found for connection {:?}", key);
             debug!("Available keys in cache:");
-            for (cached_key, (pid, name)) in cache.iter().take(10) {
-                debug!("  {:?} -> {} ({})", cached_key, name, pid);
+            for (cached_key, process) in cache.iter().take(10) {
+                debug!("  {:?} -> {} ({})", cached_key, process.name, process.pid);
             }
             if cache.len() > 10 {
                 debug!("  ... and {} more entries", cache.len() - 10);
             }
-            Self::fallback_lookup(&cache, &key)
+            relaxed_lookup(&cache, &key).map(|(process, quality)| (process.clone(), quality))
         }
+    }
+}
+
+impl ProcessLookup for MacOSProcessLookup {
+    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
+        self.lookup_match(conn)
+            .map(|(process, _quality)| (process.pid, process.name))
+    }
+
+    fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
+        let (process, quality) = self.lookup_match(conn)?;
+        let mut attribution =
+            ProcessAttribution::new(process.pid, process.name, AttributionBackend::Lsof, quality)
+                .with_executable(resolve_executable(process.pid));
+        attribution.uid = Some(process.uid);
+        if let Some((_uid, gid)) = resolve_credentials(process.pid) {
+            attribution.gid = Some(gid);
+        }
+        Some(attribution)
     }
 
     fn refresh(&self) -> Result<()> {
@@ -196,6 +299,10 @@ impl ProcessLookup for MacOSProcessLookup {
         // The reason PKTAP wasn't used is injected by the application (which
         // learns it from the capture layer); see `super::report_pktap_degradation`.
         super::pktap_degradation()
+    }
+
+    fn get_attribution_backend(&self) -> AttributionBackend {
+        AttributionBackend::Lsof
     }
 }
 
@@ -346,6 +453,111 @@ fn decode_lsof_string(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustnet_core::network::types::{ProtocolState, TcpState};
+
+    fn tcp_connection(local: &str, remote: &str) -> Connection {
+        Connection::new(
+            Protocol::Tcp,
+            local.parse().unwrap(),
+            remote.parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Established),
+        )
+    }
+
+    #[test]
+    fn lsof_numeric_uid_and_exact_match_reach_rich_attribution() {
+        let output = "\
+COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+curl\\x20helper 4294967295 501 9u IPv4 0x1 0t0 TCP 127.0.0.1:5000->1.1.1.1:443 (ESTABLISHED)
+";
+        let lookup = MacOSProcessLookup {
+            cache: RwLock::new(MacOSProcessLookup::parse_lsof_output(output)),
+        };
+        let conn = tcp_connection("127.0.0.1:5000", "1.1.1.1:443");
+
+        let attribution = lookup.get_process_attribution(&conn).unwrap();
+
+        assert_eq!(attribution.tgid, u32::MAX);
+        assert_eq!(attribution.name, "curl helper");
+        assert_eq!(attribution.uid, Some(501));
+        assert_eq!(attribution.gid, None);
+        assert_eq!(attribution.executable, None);
+        assert_eq!(attribution.backend, AttributionBackend::Lsof);
+        assert_eq!(attribution.quality, MatchQuality::ExactTuple);
+        assert_eq!(
+            lookup.get_process_for_connection(&conn),
+            Some((u32::MAX, "curl helper".to_string()))
+        );
+    }
+
+    #[test]
+    fn lsof_relaxed_lookup_preserves_match_quality() {
+        let output = "\
+COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+server 4294967295 0 3u IPv4 0x1 0t0 TCP *:8080 (LISTEN)
+";
+        let lookup = MacOSProcessLookup {
+            cache: RwLock::new(MacOSProcessLookup::parse_lsof_output(output)),
+        };
+        let conn = tcp_connection("127.0.0.1:8080", "203.0.113.7:45000");
+
+        let attribution = lookup.get_process_attribution(&conn).unwrap();
+
+        assert_eq!(attribution.uid, Some(0));
+        assert_eq!(attribution.quality, MatchQuality::ListenerSocket);
+    }
+
+    #[test]
+    fn lsof_parser_requires_the_numeric_uid_enabled_by_dash_l() {
+        let output = "\
+COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+server 42 root 3u IPv4 0x1 0t0 TCP 127.0.0.1:8080 (LISTEN)
+";
+
+        assert!(MacOSProcessLookup::parse_lsof_output(output).is_empty());
+    }
+
+    #[test]
+    fn libproc_resolves_the_current_process() {
+        let pid = std::process::id();
+        let executable = resolve_executable(pid).expect("current executable should resolve");
+        assert!(executable.is_absolute());
+        assert_eq!(executable, std::env::current_exe().unwrap());
+
+        let credentials = resolve_credentials(pid).expect("current credentials should resolve");
+        // SAFETY: these libc calls only read the credentials of this process.
+        let expected = unsafe { (libc::geteuid(), libc::getegid()) };
+        assert_eq!(credentials, expected);
+    }
+
+    #[test]
+    fn libproc_failure_keeps_optional_fields_empty() {
+        assert_eq!(resolve_executable(u32::MAX), None);
+        assert_eq!(resolve_credentials(u32::MAX), None);
+    }
+
+    #[test]
+    fn real_lsof_scan_attributes_an_unprivileged_listener() {
+        use std::net::{Ipv4Addr, TcpListener};
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let local = listener.local_addr().unwrap();
+        let lookup = MacOSProcessLookup::new().unwrap();
+        lookup.refresh().expect("lsof scan should succeed");
+        let conn = tcp_connection(&local.to_string(), "0.0.0.0:0");
+
+        let attribution = lookup
+            .get_process_attribution(&conn)
+            .expect("the current process listener should be attributable");
+        // SAFETY: this libc call only reads the effective UID of this process.
+        let expected_uid = unsafe { libc::geteuid() };
+
+        assert_eq!(attribution.tgid, std::process::id());
+        assert_eq!(attribution.uid, Some(expected_uid));
+        assert_eq!(attribution.executable, std::env::current_exe().ok());
+        assert_eq!(attribution.backend, AttributionBackend::Lsof);
+        assert_eq!(attribution.quality, MatchQuality::ExactTuple);
+    }
 
     #[test]
     fn test_decode_lsof_string() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -51,6 +51,16 @@ use crate::network::platform::WindowsStatsProvider as PlatformStatsProvider;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
+#[inline]
+fn process_enrichment_complete(conn: &Connection, unknown_process_name: &str) -> bool {
+    conn.pid.is_some()
+        && conn
+            .process_name
+            .as_deref()
+            .is_some_and(|name| name != unknown_process_name)
+        && conn.attribution_quality.is_some()
+}
+
 /// Sandbox status information for UI display
 #[cfg(any(
     target_os = "linux",
@@ -1768,31 +1778,19 @@ impl App {
                 let wait_start = Instant::now();
                 while wait_start.elapsed() < Duration::from_secs(5)
                     && !should_stop.load(Ordering::Relaxed)
+                    && !pktap_active.load(Ordering::Relaxed)
                 {
-                    if pktap_active.load(Ordering::Relaxed) {
-                        info!(
-                            "🚫 Skipping process enrichment thread - PKTAP is active and provides process metadata"
-                        );
-                        if let Ok(mut status) = process_detection_status.write() {
-                            *status = ProcessDetectionStatus::with_method("pktap");
-                        }
-                        let _ = process_ready_tx.send(());
-                        return;
-                    }
                     // Check more frequently for faster detection
                     thread::sleep(Duration::from_millis(50));
                 }
 
-                // Final check after timeout
                 if pktap_active.load(Ordering::Relaxed) {
                     info!(
-                        "🚫 Skipping process enrichment thread - PKTAP became active during startup"
+                        "PKTAP is active, starting libproc enrichment for packet process metadata"
                     );
                     if let Ok(mut status) = process_detection_status.write() {
                         *status = ProcessDetectionStatus::with_method("pktap");
                     }
-                    let _ = process_ready_tx.send(());
-                    return;
                 } else {
                     info!(
                         "⚠️  PKTAP not detected after 5 seconds, starting process enrichment thread with lsof"
@@ -1836,6 +1834,10 @@ impl App {
         let use_pktap = pktap_active.load(Ordering::Relaxed);
 
         let process_lookup = create_process_lookup(use_pktap)?;
+        #[cfg(target_os = "macos")]
+        let mut process_lookup = process_lookup;
+        #[cfg(target_os = "macos")]
+        let mut using_pktap = use_pktap;
 
         // Linux capabilities are per-thread. This thread inherited the startup
         // capabilities before loading eBPF, so drop the ones it will not use
@@ -1924,13 +1926,16 @@ impl App {
                 break;
             }
 
-            // Check if PKTAP became active (abort immediately to prevent conflicts)
+            // If PKTAP activates after the startup grace period, stop polling
+            // lsof and enrich the packet-provided identity through libproc.
             #[cfg(target_os = "macos")]
-            if pktap_active.load(Ordering::Relaxed) {
-                info!(
-                    "🚫 PKTAP became active, stopping process enrichment thread to prevent conflicts"
-                );
-                break;
+            if !using_pktap && pktap_active.load(Ordering::Relaxed) {
+                process_lookup = create_process_lookup(true)?;
+                using_pktap = true;
+                if let Ok(mut status) = process_detection_status.write() {
+                    *status = ProcessDetectionStatus::with_method("pktap");
+                }
+                info!("PKTAP became active, switched process enrichment from lsof to libproc");
             }
 
             // Refresh process lookup periodically
@@ -1957,14 +1962,13 @@ impl App {
             // Enrich connections without process info
             let mut enriched = 0;
             for mut entry in tracker.connections().iter_mut() {
-                // Fully attributed — nothing to do (real names are permanent,
-                // placeholders stay eligible for an upgrade).
-                if entry.pid.is_some()
-                    && entry
-                        .process_name
-                        .as_deref()
-                        .is_some_and(|name| name != UNKNOWN_PROCESS_NAME)
-                {
+                // Match quality is also the completion marker for rich
+                // enrichment. PKTAP seeds PID and name in the capture path, so
+                // those connections remain eligible for exactly one libproc
+                // attempt. Optional fields are best effort; requiring every
+                // one would retry permanent permission or process-exit failures
+                // on every fast tick.
+                if process_enrichment_complete(&entry, UNKNOWN_PROCESS_NAME) {
                     continue;
                 }
                 // Fast ticks only retry young connections; older ones wait
@@ -2017,14 +2021,21 @@ impl App {
                         entry.executable = Some(interned);
                         did_enrich = true;
                     }
-                    if entry.process_uid.is_none() {
-                        entry.process_uid = attribution.uid;
+                    if entry.process_uid.is_none()
+                        && let Some(uid) = attribution.uid
+                    {
+                        entry.process_uid = Some(uid);
+                        did_enrich = true;
                     }
-                    if entry.process_gid.is_none() {
-                        entry.process_gid = attribution.gid;
+                    if entry.process_gid.is_none()
+                        && let Some(gid) = attribution.gid
+                    {
+                        entry.process_gid = Some(gid);
+                        did_enrich = true;
                     }
                     if entry.attribution_quality.is_none() {
                         entry.attribution_quality = Some(attribution.quality);
+                        did_enrich = true;
                     }
 
                     if did_enrich {
@@ -2054,6 +2065,10 @@ impl App {
                         entry.pid = Some(pid);
                         if entry.process_name.is_none() {
                             entry.process_name = crate::network::kubernetes::read_process_name(pid);
+                        }
+                        if entry.attribution_quality.is_none() {
+                            entry.attribution_quality =
+                                Some(crate::network::types::MatchQuality::ProcfsExact);
                         }
                         if entry.k8s_info.is_none() {
                             entry.k8s_info = Some(k8s);
@@ -3408,6 +3423,55 @@ impl Drop for App {
         self.stop();
         // Give threads time to stop gracefully
         thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+mod process_enrichment_tests {
+    use super::process_enrichment_complete;
+    use crate::network::types::{Connection, MatchQuality, Protocol, ProtocolState, TcpState};
+
+    fn connection() -> Connection {
+        Connection::new(
+            Protocol::Tcp,
+            "127.0.0.1:5000".parse().unwrap(),
+            "1.1.1.1:443".parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Established),
+        )
+    }
+
+    #[test]
+    fn packet_seeded_identity_still_gets_one_rich_enrichment_attempt() {
+        let mut conn = connection();
+        conn.pid = Some(42);
+        conn.process_name = Some("curl".to_string());
+
+        assert!(!process_enrichment_complete(&conn, "Unknown"));
+
+        conn.attribution_quality = Some(MatchQuality::ExactTuple);
+        assert!(process_enrichment_complete(&conn, "Unknown"));
+    }
+
+    #[test]
+    fn missing_optional_libproc_fields_do_not_cause_permanent_retries() {
+        let mut conn = connection();
+        conn.pid = Some(42);
+        conn.process_name = Some("curl".to_string());
+        conn.attribution_quality = Some(MatchQuality::ExactTuple);
+
+        assert!(conn.executable.is_none());
+        assert!(conn.process_uid.is_none());
+        assert!(process_enrichment_complete(&conn, "Unknown"));
+    }
+
+    #[test]
+    fn placeholder_identity_remains_eligible_for_an_upgrade() {
+        let mut conn = connection();
+        conn.pid = Some(42);
+        conn.process_name = Some("Unknown".to_string());
+        conn.attribution_quality = Some(MatchQuality::Unspecified);
+
+        assert!(!process_enrichment_complete(&conn, "Unknown"));
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1169,7 +1169,7 @@ mod snapshot_tests {
     }
 
     /// QUIC rides on UDP, so the Details tab used to label its Transport
-    /// Health card with TCP loss counters that can never be filled in — packet
+    /// Health card with TCP loss counters that can never be filled in, because packet
     /// numbers and ACK frames sit behind QUIC's header protection. The card
     /// must show what is actually observable instead, without changing height.
     #[test]


### PR DESCRIPTION
Enriches macOS connections with executable path, effective UID/GID, backend, and match quality. The TUI and export surface landed separately in #511; this wires the macOS backends into it.

- PKTAP keeps its kernel-provided per-packet PID and name, reports an exact match, and uses libproc for the executable path and UID/GID.
- The lsof fallback requests numeric UIDs (`-l`), resolves executables through libproc, and reports exact, wildcard-address, or listener match quality.
- Packet-seeded PKTAP connections get one rich-enrichment pass without hot-loop retries of permanently unavailable optional fields.

Checks: `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-targets --all-features`, `cargo build --release`, and `cargo audit`.