### PR TITLE
Surface process attribution in the TUI and exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the full result, so metadata and match quality survive the first lookup. Platforms
   that only implement the legacy tuple API are bridged automatically, so
   `get_process_for_connection()` keeps working everywhere (#505)
+- **Executable, User, and Match Quality in the UI and Exports**: Connections now
+  carry the owning process's executable path, effective UID/GID, and how confidently
+  the attribution matched. A new Attribution card in the Details pane shows them, and
+  appears only when a backend actually resolved something, so platforms that cannot
+  supply a field show nothing rather than a permanent placeholder. A relaxed
+  wildcard or listener match renders in the warning color instead of passing for a
+  proven one. The JSONL sidecar gains `process_executable`, `process_uid`,
+  `process_gid`, and `attribution_match`; PCAPNG packet comments gain `uid=` and
+  `attr=` but deliberately omit the executable path, which would repeat in every
+  packet block. Executable paths are interned behind an `Arc`, so bulk connection
+  snapshots stay allocation-free (#506, #511)
 
 ### Changed
 - **Modern Linux eBPF Attribution Backend**: Process attribution now prefers BPF

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -2,8 +2,84 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
+
+/// How closely a process attribution matched the connection it was asked about.
+///
+/// Attribution backends record sockets under the tuple they saw at creation
+/// time, which is not always the tuple the capture side observes on the wire. A
+/// lookup may therefore have to relax the key, and the caller deserves to know
+/// that it did: a relaxed hit is a plausible owner, not a proven one.
+///
+/// Defined here rather than in `rustnet-host` because [`Connection`] carries it
+/// and `rustnet-host` depends on this crate, not the other way round.
+/// `rustnet-host` re-exports it.
+///
+/// Marked `#[non_exhaustive]` so new relaxation shapes can be added without
+/// breaking downstream `match` arms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MatchQuality {
+    /// The full 4-tuple matched a recorded socket.
+    ExactTuple,
+    /// Matched only after zeroing the local address, i.e. the socket was
+    /// recorded while bound to a wildcard address.
+    WildcardLocalAddress,
+    /// Matched a listening socket (the recorded entry has no remote peer).
+    ListenerSocket,
+    /// Exact 4-tuple match in the procfs socket table.
+    ProcfsExact,
+    /// procfs match that needed a relaxed key.
+    ProcfsRelaxed,
+    /// The backend reported an owner but not how it matched. Produced by the
+    /// compatibility bridge for platforms that still only implement the
+    /// `(pid, name)` tuple API.
+    Unspecified,
+}
+
+impl MatchQuality {
+    /// Whether the connection's exact 4-tuple was found, with no relaxation.
+    pub fn is_exact(self) -> bool {
+        matches!(self, Self::ExactTuple | Self::ProcfsExact)
+    }
+
+    /// Human-readable label, for display to a person.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ExactTuple => "exact tuple",
+            Self::WildcardLocalAddress => "wildcard local address",
+            Self::ListenerSocket => "listener socket",
+            Self::ProcfsExact => "procfs exact",
+            Self::ProcfsRelaxed => "procfs relaxed",
+            Self::Unspecified => "unspecified",
+        }
+    }
+
+    /// Stable machine-readable token for exports.
+    ///
+    /// Separate from [`MatchQuality::as_str`] on purpose: the prose there is
+    /// free to be reworded for readability, while anything a user greps or
+    /// filters on must not change under them. It also contains no whitespace,
+    /// which matters for the space-delimited PCAPNG packet comment.
+    pub fn as_token(self) -> &'static str {
+        match self {
+            Self::ExactTuple => "exact-tuple",
+            Self::WildcardLocalAddress => "wildcard-local-address",
+            Self::ListenerSocket => "listener-socket",
+            Self::ProcfsExact => "procfs-exact",
+            Self::ProcfsRelaxed => "procfs-relaxed",
+            Self::Unspecified => "unspecified",
+        }
+    }
+}
+
+impl fmt::Display for MatchQuality {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Protocol {
@@ -2346,6 +2422,21 @@ pub struct Connection {
     // Process information
     pub pid: Option<u32>,
     pub process_name: Option<String>,
+    /// Absolute path of the owning process's executable, when the platform can
+    /// resolve it.
+    ///
+    /// `Arc<Path>` rather than `PathBuf`: every connection of a process shares
+    /// one executable path, and `Connection` is cloned in bulk on every
+    /// snapshot tick (see `snapshot_clone`). Interning keeps that clone from
+    /// allocating per connection.
+    pub executable: Option<Arc<Path>>,
+    /// Effective user id of the owning process, when the platform reports it.
+    pub process_uid: Option<u32>,
+    /// Effective group id of the owning process, when the platform reports it.
+    pub process_gid: Option<u32>,
+    /// How confidently the attribution was matched to this connection. `None`
+    /// until the connection is attributed.
+    pub attribution_quality: Option<MatchQuality>,
 
     // Kubernetes attribution (pod/container), populated on K8s nodes
     #[cfg(feature = "kubernetes")]
@@ -2425,6 +2516,10 @@ impl Connection {
             protocol_state: state,
             pid: None,
             process_name: None,
+            executable: None,
+            process_uid: None,
+            process_gid: None,
+            attribution_quality: None,
             #[cfg(feature = "kubernetes")]
             k8s_info: None,
             connection_direction: None,
@@ -3240,6 +3335,79 @@ mod tests {
         // The snapshot must not share the sample buffer with the original.
         assert_eq!(Arc::strong_count(&conn.rate_tracker.samples), 1);
         assert!(snap.rate_tracker.samples.is_empty());
+    }
+
+    /// The snapshot provider clones every connection on every tick, so the
+    /// executable path must be shared rather than reallocated per clone.
+    #[test]
+    fn snapshot_clone_shares_the_interned_executable_path() {
+        use std::path::Path;
+
+        let mut conn = Connection::new(
+            Protocol::Tcp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
+            ProtocolState::Tcp(TcpState::Established),
+        );
+        let executable: Arc<Path> = Arc::from(Path::new("/usr/bin/curl"));
+        conn.executable = Some(Arc::clone(&executable));
+        conn.process_uid = Some(1000);
+        conn.process_gid = Some(100);
+        conn.attribution_quality = Some(MatchQuality::ExactTuple);
+
+        let snap = conn.snapshot_clone();
+
+        assert_eq!(snap.executable.as_deref(), Some(Path::new("/usr/bin/curl")));
+        assert_eq!(snap.process_uid, Some(1000));
+        assert_eq!(snap.process_gid, Some(100));
+        assert_eq!(snap.attribution_quality, Some(MatchQuality::ExactTuple));
+        assert!(
+            Arc::ptr_eq(
+                conn.executable.as_ref().unwrap(),
+                snap.executable.as_ref().unwrap()
+            ),
+            "the clone must share the path allocation, not copy it"
+        );
+    }
+
+    #[test]
+    fn new_connections_carry_no_attribution() {
+        let conn = Connection::new(
+            Protocol::Tcp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 2),
+            ProtocolState::Tcp(TcpState::Established),
+        );
+
+        assert!(conn.executable.is_none());
+        assert!(conn.process_uid.is_none());
+        assert!(conn.process_gid.is_none());
+        assert!(conn.attribution_quality.is_none());
+    }
+
+    /// Export tokens are what users grep and filter on, so they are pinned
+    /// here: the prose in `as_str` may be reworded, these may not.
+    #[test]
+    fn match_quality_export_tokens_are_stable_and_whitespace_free() {
+        let all = [
+            (MatchQuality::ExactTuple, "exact-tuple"),
+            (MatchQuality::WildcardLocalAddress, "wildcard-local-address"),
+            (MatchQuality::ListenerSocket, "listener-socket"),
+            (MatchQuality::ProcfsExact, "procfs-exact"),
+            (MatchQuality::ProcfsRelaxed, "procfs-relaxed"),
+            (MatchQuality::Unspecified, "unspecified"),
+        ];
+
+        for (quality, token) in all {
+            assert_eq!(quality.as_token(), token);
+            // The PCAPNG packet comment is space-delimited `key=value`.
+            assert!(!token.contains(char::is_whitespace));
+        }
+
+        assert!(MatchQuality::ExactTuple.is_exact());
+        assert!(MatchQuality::ProcfsExact.is_exact());
+        assert!(!MatchQuality::ProcfsRelaxed.is_exact());
+        assert!(!MatchQuality::Unspecified.is_exact());
     }
 
     #[test]

--- a/crates/rustnet-host/src/lib.rs
+++ b/crates/rustnet-host/src/lib.rs
@@ -85,48 +85,10 @@ bitflags::bitflags! {
 /// therefore have to relax the key, and the caller deserves to know that it
 /// did: a relaxed hit is a plausible owner, not a proven one.
 ///
-/// Marked `#[non_exhaustive]` so new relaxation shapes can be added without
-/// breaking downstream `match` arms.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum MatchQuality {
-    /// The full 4-tuple matched a recorded socket.
-    ExactTuple,
-    /// Matched only after zeroing the local address, i.e. the socket was
-    /// recorded while bound to a wildcard address.
-    WildcardLocalAddress,
-    /// Matched a listening socket (the recorded entry has no remote peer).
-    ListenerSocket,
-    /// Exact 4-tuple match in the procfs socket table.
-    ProcfsExact,
-    /// procfs match that needed a relaxed key.
-    ProcfsRelaxed,
-    /// The backend reported an owner but not how it matched. Produced by the
-    /// compatibility bridge in [`ProcessLookup::get_process_attribution`] for
-    /// platforms that still only implement the tuple API.
-    Unspecified,
-}
-
-impl MatchQuality {
-    /// Whether the connection's exact 4-tuple was found, with no relaxation.
-    pub fn is_exact(self) -> bool {
-        matches!(self, Self::ExactTuple | Self::ProcfsExact)
-    }
-}
-
-impl std::fmt::Display for MatchQuality {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = match self {
-            Self::ExactTuple => "exact tuple",
-            Self::WildcardLocalAddress => "wildcard local address",
-            Self::ListenerSocket => "listener socket",
-            Self::ProcfsExact => "procfs exact",
-            Self::ProcfsRelaxed => "procfs relaxed",
-            Self::Unspecified => "unspecified",
-        };
-        f.write_str(name)
-    }
-}
+/// Defined in `rustnet-core` because [`Connection`] carries it and this crate
+/// depends on core, not the other way round. Re-exported here so attribution
+/// callers only need one import.
+pub use rustnet_core::network::types::MatchQuality;
 
 /// A rich process-attribution result.
 ///

--- a/crates/rustnet-host/src/linux/process.rs
+++ b/crates/rustnet-host/src/linux/process.rs
@@ -475,6 +475,42 @@ mod tests {
         assert!(lookup.get_process_for_connection(&conn).is_none());
     }
 
+    /// End-to-end against the real `/proc/net/tcp` table rather than an
+    /// injected one: open a listener, rescan, and confirm the attribution that
+    /// comes back is fully populated. Needs no privileges, because the socket
+    /// belongs to this process.
+    #[test]
+    fn attributes_a_real_listening_socket_from_procfs() {
+        use std::net::{Ipv4Addr, TcpListener};
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let local = listener.local_addr().unwrap();
+
+        let lookup = LinuxProcessLookup::new().expect("procfs scan must succeed");
+        // The listener was opened after the constructor's scan.
+        lookup.refresh().expect("refresh must succeed");
+
+        // /proc/net/tcp records a listener with a zeroed peer.
+        let conn = Connection::new(
+            Protocol::Tcp,
+            local,
+            "0.0.0.0:0".parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Unknown),
+        );
+
+        let attribution = lookup
+            .get_process_attribution(&conn)
+            .expect("our own listening socket must be attributable");
+
+        assert_eq!(attribution.tgid, own_pid());
+        assert_eq!(attribution.quality, MatchQuality::ProcfsExact);
+        assert_eq!(attribution.backend, AttributionBackend::Procfs);
+        assert_eq!(attribution.executable, std::env::current_exe().ok());
+        assert_eq!(attribution.uid, Some(unsafe { libc::geteuid() }));
+        assert_eq!(attribution.gid, Some(unsafe { libc::getegid() }));
+        assert!(!attribution.name.is_empty());
+    }
+
     #[test]
     fn the_tuple_api_agrees_with_the_rich_api() {
         let mut table = HashMap::new();

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,7 @@ use log::{debug, error, info, warn};
 use serde_json::json;
 use std::fs::File;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
@@ -323,6 +324,20 @@ fn log_connection_event(
     if let Some(process_name) = &conn.process_name {
         event["process_name"] = json!(process_name);
     }
+    // The sidecar is per connection, not per packet, so the verbose executable
+    // path costs nothing here (unlike a PCAPNG packet comment).
+    if let Some(executable) = &conn.executable {
+        event["process_executable"] = json!(executable.display().to_string());
+    }
+    if let Some(uid) = conn.process_uid {
+        event["process_uid"] = json!(uid);
+    }
+    if let Some(gid) = conn.process_gid {
+        event["process_gid"] = json!(gid);
+    }
+    if let Some(quality) = conn.attribution_quality {
+        event["attribution_match"] = json!(quality.as_token());
+    }
 
     // Add Kubernetes attribution if the process is part of a pod
     #[cfg(feature = "kubernetes")]
@@ -445,6 +460,20 @@ fn log_pcap_connection(writer: &JsonLineWriter, conn: &Connection) {
         "bytes_received": conn.bytes_received,
         "state": conn.state(),
     });
+
+    // Per-connection record, so the full executable path is affordable here.
+    if let Some(executable) = &conn.executable {
+        event["process_executable"] = json!(executable.display().to_string());
+    }
+    if let Some(uid) = conn.process_uid {
+        event["process_uid"] = json!(uid);
+    }
+    if let Some(gid) = conn.process_gid {
+        event["process_gid"] = json!(gid);
+    }
+    if let Some(quality) = conn.attribution_quality {
+        event["attribution_match"] = json!(quality.as_token());
+    }
 
     // Add Kubernetes attribution if the process is part of a pod
     #[cfg(feature = "kubernetes")]
@@ -1859,6 +1888,10 @@ impl App {
         // resolver can upgrade it once the real name is known.
         const UNKNOWN_PROCESS_NAME: &str = "Unknown";
         let mut last_full_pass = Instant::now() - full_pass_interval;
+        // Executable paths are shared by every connection of a process, and
+        // `Connection` is cloned in bulk on every snapshot tick. Interning here
+        // means the clone copies an Arc pointer instead of a fresh PathBuf.
+        let mut executables: HashMap<PathBuf, Arc<Path>> = HashMap::new();
 
         // Build and set the detection status from the process lookup implementation
         // Only set if not already detected as pktap (to handle race conditions)
@@ -1948,7 +1981,9 @@ impl App {
                 }
 
                 // Allow partial enrichment - fill in missing pieces without overwriting existing data
-                if let Some((pid, name)) = process_lookup.get_process_for_connection(&entry) {
+                if let Some(attribution) = process_lookup.get_process_attribution(&entry) {
+                    let pid = attribution.tgid;
+                    let name = attribution.name;
                     let mut did_enrich = false;
 
                     let upgrades_placeholder = name != UNKNOWN_PROCESS_NAME
@@ -1966,6 +2001,30 @@ impl App {
                         entry.pid = Some(pid);
                         did_enrich = true;
                         debug!("✓ Set PID for connection {}: {}", entry.key(), pid);
+                    }
+
+                    // The richer fields follow the same write-once rule as the
+                    // name and PID above: the first backend to answer owns the
+                    // connection, so a later relaxed guess cannot overwrite an
+                    // earlier exact one.
+                    if entry.executable.is_none()
+                        && let Some(path) = attribution.executable
+                    {
+                        let interned = executables
+                            .entry(path)
+                            .or_insert_with_key(|path| Arc::from(path.as_path()))
+                            .clone();
+                        entry.executable = Some(interned);
+                        did_enrich = true;
+                    }
+                    if entry.process_uid.is_none() {
+                        entry.process_uid = attribution.uid;
+                    }
+                    if entry.process_gid.is_none() {
+                        entry.process_gid = attribution.gid;
+                    }
+                    if entry.attribution_quality.is_none() {
+                        entry.attribution_quality = Some(attribution.quality);
                     }
 
                     if did_enrich {
@@ -3259,6 +3318,19 @@ fn build_pcapng_comment(conn: &Connection) -> Option<String> {
     if let Some(pid) = conn.pid {
         fields.push(format!("pid={pid}"));
     }
+    // Deliberately no `exe=` here. This comment is written into every Enhanced
+    // Packet Block, so a 40-character path would be repeated once per packet
+    // and bloat the capture by tens of megabytes over a long run. The full path
+    // lives in the per-connection JSONL sidecar instead. `uid` and the match
+    // quality are a handful of bytes and earn their place: uid=0 and a relaxed
+    // match are both things an analyst wants to see without leaving Wireshark.
+    if let Some(uid) = conn.process_uid {
+        fields.push(format!("uid={uid}"));
+    }
+    if let Some(quality) = conn.attribution_quality {
+        // Already whitespace-free, so no sanitization needed.
+        fields.push(format!("attr={}", quality.as_token()));
+    }
     #[cfg(feature = "kubernetes")]
     if let Some(k8s) = &conn.k8s_info {
         if let Some(name) = &k8s.pod_name {
@@ -3754,6 +3826,53 @@ mod pcapng_export_tests {
         assert!(comment.contains(
             "container_id=c16c7605305c854d8582a1db3d5bb3c4b6c89a08e914223e9d500682b3fb0b1b"
         ));
+    }
+
+    /// The packet comment is written once per Enhanced Packet Block, so the
+    /// cheap attribution fields belong there and the executable path does not.
+    #[test]
+    fn comment_carries_uid_and_match_quality_but_not_the_executable_path() {
+        use crate::network::types::{MatchQuality, ProtocolState, TcpState};
+        use std::path::Path;
+
+        let mut conn = Connection::new(
+            Protocol::Tcp,
+            SocketAddr::from(([10, 0, 0, 1], 4000)),
+            SocketAddr::from(([10, 0, 0, 2], 443)),
+            ProtocolState::Tcp(TcpState::Established),
+        );
+        conn.process_name = Some("curl".to_string());
+        conn.pid = Some(4242);
+        conn.executable = Some(Arc::from(Path::new("/usr/bin/curl")));
+        conn.process_uid = Some(0);
+        conn.process_gid = Some(0);
+        conn.attribution_quality = Some(MatchQuality::ProcfsRelaxed);
+
+        let comment = build_pcapng_comment(&conn).expect("attributed connection must comment");
+        assert!(comment.contains("process=curl"));
+        assert!(comment.contains("pid=4242"));
+        assert!(comment.contains("uid=0"));
+        assert!(comment.contains("attr=procfs-relaxed"));
+        assert!(
+            !comment.contains("/usr/bin/curl"),
+            "the executable path would repeat per packet; it belongs in the JSONL sidecar: {comment}"
+        );
+    }
+
+    /// Attribution fields alone are enough metadata to justify a comment, and
+    /// an unattributed connection still produces none.
+    #[test]
+    fn comment_is_absent_without_any_metadata() {
+        use crate::network::types::{ProtocolState, TcpState};
+
+        let conn = Connection::new(
+            Protocol::Tcp,
+            SocketAddr::from(([10, 0, 0, 1], 4000)),
+            SocketAddr::from(([10, 0, 0, 2], 443)),
+            ProtocolState::Tcp(TcpState::Established),
+        );
+
+        assert_eq!(build_pcapng_comment(&conn), None);
     }
 
     /// Records must leave the pending queue in arrival order: a keyless

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1277,6 +1277,100 @@ mod snapshot_tests {
         );
     }
 
+    /// The Attribution section follows the Kubernetes pattern: it appears only
+    /// when a backend actually resolved something, so platforms that cannot
+    /// supply a field never show a permanent placeholder.
+    #[test]
+    fn details_tab_shows_attribution_only_when_resolved() {
+        use crate::network::types::MatchQuality;
+        use std::path::Path;
+        use std::sync::Arc;
+
+        let app = test_app();
+        let mut connections = sample_connections();
+        app.set_connections_snapshot_for_test(connections.clone());
+        let stats = app.get_stats();
+
+        let render_connections = |connections: &[Connection]| {
+            let ui_state = UIState {
+                selected_tab: 1,
+                selected_connection_key: Some(connections[0].key()),
+                ..Default::default()
+            };
+            let mut click_regions = ClickableRegions::default();
+            render(140, 40, |f| {
+                draw(
+                    f,
+                    &app,
+                    &ui_state,
+                    connections,
+                    None,
+                    &stats,
+                    &mut click_regions,
+                )
+                .expect("draw details");
+            })
+        };
+
+        let unattributed = render_connections(&connections);
+        assert!(
+            !unattributed.contains("Attribution"),
+            "an unattributed connection must not render an empty Attribution card"
+        );
+
+        connections[0].executable = Some(Arc::from(Path::new("/usr/lib/firefox/firefox")));
+        connections[0].process_uid = Some(1000);
+        connections[0].process_gid = Some(1000);
+        connections[0].attribution_quality = Some(MatchQuality::ExactTuple);
+        app.set_connections_snapshot_for_test(connections.clone());
+
+        let attributed = render_connections(&connections);
+        assert!(attributed.contains("Attribution"));
+        assert!(attributed.contains("/usr/lib/firefox/firefox"));
+        assert!(attributed.contains("1000:1000"));
+        assert!(attributed.contains("exact tuple"));
+    }
+
+    /// Partial attribution is the common case off Linux: render the fields that
+    /// resolved and leave the rest out entirely.
+    #[test]
+    fn details_tab_renders_partial_attribution() {
+        use crate::network::types::MatchQuality;
+
+        let app = test_app();
+        let mut connections = sample_connections();
+        connections[0].attribution_quality = Some(MatchQuality::ListenerSocket);
+        app.set_connections_snapshot_for_test(connections.clone());
+        let stats = app.get_stats();
+
+        let ui_state = UIState {
+            selected_tab: 1,
+            selected_connection_key: Some(connections[0].key()),
+            ..Default::default()
+        };
+        let mut click_regions = ClickableRegions::default();
+        let output = render(140, 40, |f| {
+            draw(
+                f,
+                &app,
+                &ui_state,
+                &connections,
+                None,
+                &stats,
+                &mut click_regions,
+            )
+            .expect("draw details");
+        });
+
+        assert!(output.contains("Attribution"));
+        assert!(output.contains("listener socket"));
+        assert!(
+            !output.contains("Executable"),
+            "an unresolved executable must not leave a labelled blank row"
+        );
+        assert!(!output.contains("User "));
+    }
+
     #[test]
     fn details_tab_keeps_section_anchors_across_metadata_shapes() {
         let app = test_app();

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use crossterm::event::{KeyEvent, MouseEvent};
 
 use crate::network::dns::DnsResolver;
-use crate::network::types::{Connection, Protocol, ProtocolState};
+use crate::network::types::{Connection, MatchQuality, Protocol, ProtocolState};
 use crate::ui::{
     ClickAction, ClickableRegions, Component, ComponentContext, Effect, GroupedRow, HandlerContext,
     NONE_PLACEHOLDER,
@@ -698,6 +698,67 @@ pub(in crate::ui) fn draw_connection_details(
         label_style,
         location_value_style,
     );
+
+    // Richer process attribution, when the platform's lookup could resolve it.
+    // Rendered like the Kubernetes block below: each row appears only when the
+    // backend actually observed that field, and the whole section disappears
+    // when none of them did. That keeps platforms which structurally cannot
+    // supply a field (no executable path, no uid) from showing a permanent
+    // placeholder, and keeps this section out of the fixed-height card
+    // geometry that `APPLICATION_CARD_ROWS` anchors.
+    let has_attribution = conn.executable.is_some()
+        || conn.process_uid.is_some()
+        || conn.attribution_quality.is_some();
+    if has_attribution {
+        let process_value_style = theme::fg(theme::field_process());
+        push_detail_section(&mut details_text, &mut detail_fields, "Attribution");
+
+        if let Some(ref executable) = conn.executable {
+            push_detail_field_styled(
+                &mut details_text,
+                &mut detail_fields,
+                "Executable",
+                executable.display().to_string(),
+                label_style,
+                process_value_style,
+            );
+        }
+        if let Some(uid) = conn.process_uid {
+            // Numeric rather than resolved: a name lookup would mean parsing
+            // the passwd database on every render, and uid 0 is the case that
+            // actually matters at a glance.
+            let user = match conn.process_gid {
+                Some(gid) => format!("{uid}:{gid}"),
+                None => uid.to_string(),
+            };
+            push_detail_field(
+                &mut details_text,
+                &mut detail_fields,
+                "User",
+                user,
+                label_style,
+            );
+        }
+        if let Some(quality) = conn.attribution_quality {
+            // A relaxed match is a plausible owner, not a proven one, so it
+            // reads as a warning rather than as confirmed fact.
+            let quality_color = if quality.is_exact() {
+                theme::ok()
+            } else if quality == MatchQuality::Unspecified {
+                theme::muted()
+            } else {
+                theme::warn()
+            };
+            push_detail_field_styled(
+                &mut details_text,
+                &mut detail_fields,
+                "Match",
+                quality.to_string(),
+                label_style,
+                theme::fg(quality_color),
+            );
+        }
+    }
 
     // Kubernetes attribution (pod / container) when the owning process is in
     // a kubepods cgroup. Only rendered when the resolver populated `k8s_info`.


### PR DESCRIPTION
Re-lands #506. It was merged into the #505 feature branch about a minute after that branch had already been squash-merged to main, so its content never reached main.

- Identical to #506 except for one test-insertion conflict with the QUIC Transport Health test from #507, resolved by keeping both tests.
- The full rationale and review are in #506.

Checks: `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-targets --all-features`.