### PR TITLE
Recover comm-truncated Linux process names

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -212,17 +212,16 @@ RustNet uses platform-specific APIs to associate network connections with proces
 **Standard Mode (procfs):**
 - Parses `/proc/net/tcp` and `/proc/net/udp` to get socket inodes
 - Iterates through `/proc/<pid>/fd/` to find socket file descriptors
-- Maps inodes to process IDs and resolves process names from `/proc/<pid>/cmdline`
-- Resolves the PPID from `/proc/<pid>/status`
+- Maps inodes to process IDs and resolves process names from `/proc/<pid>/comm`, recovering comm-truncated names from the executable's file name
+- Resolves the executable path, PPID, and UID/GID from `/proc/<pid>/`
 
 **eBPF Mode (Default on Linux):**
 - Uses kernel eBPF programs attached to socket syscalls
 - Captures socket creation events with process context
 - Provides lower overhead than procfs scanning
+- Records the group leader's TGID, the acting TID, and credentials; the name, executable path, and PPID are enriched in user space via procfs
 - **Limitations:**
-  - Process names limited to 16 characters (kernel `comm` field)
-  - May show thread names instead of full executable names
-  - Multi-threaded applications show internal thread names
+  - Names originate from the 16-character kernel `comm` field; RustNet re-resolves them via `/proc/<tgid>/comm` and recovers truncated names from the executable's file name, but processes that exit before enrichment keep the short eBPF-recorded name
 - **Capability requirements:**
   - Modern Linux (5.8+): `CAP_NET_RAW` (packet capture), `CAP_BPF`, `CAP_PERFMON` (eBPF)
   - Legacy Linux (pre-5.8): eBPF requires broad `CAP_SYS_ADMIN`; RustNet packages do not grant it automatically and fall back to procfs instead

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -207,17 +207,16 @@ RustNet 使用平台特定的 API 将网络连接与进程关联：
 **标准模式（procfs）：**
 - 解析 `/proc/net/tcp` 和 `/proc/net/udp` 获取 socket inode
 - 遍历 `/proc/<pid>/fd/` 查找 socket 文件描述符
-- 将 inode 映射到进程 ID，并从 `/proc/<pid>/cmdline` 解析进程名
-- 从 `/proc/<pid>/status` 解析 PPID
+- 将 inode 映射到进程 ID，并从 `/proc/<pid>/comm` 解析进程名，同时借助可执行文件名恢复被 `comm` 截断的名称
+- 从 `/proc/<pid>/` 解析可执行路径、PPID 以及 UID/GID
 
 **eBPF 模式（Linux 默认）：**
 - 使用附加到 socket 系统调用的内核 eBPF 程序
 - 捕获带进程上下文的 socket 创建事件
 - 比 procfs 扫描开销更低
+- 记录进程组组长的 TGID、当前线程的 TID 以及凭据；进程名、可执行路径和 PPID 在用户态通过 procfs 富化
 - **局限性：**
-  - 进程名限制为 16 个字符（内核 `comm` 字段）
-  - 可能显示线程名而非完整可执行文件名
-  - 多线程应用显示内部线程名
+  - 进程名来源于内核 16 字符的 `comm` 字段；RustNet 会通过 `/proc/<tgid>/comm` 重新解析，并借助可执行文件名恢复被截断的名称，但在富化前就已退出的进程仍保留 eBPF 记录的短名称
 - **Linux capabilities 需求：**
   - 现代 Linux（5.8+）：`CAP_NET_RAW`（包捕获）、`CAP_BPF`、`CAP_PERFMON`（eBPF）
 	  - 旧版 Linux（pre-5.8）：eBPF 需要宽泛的 `CAP_SYS_ADMIN`；RustNet 安装包不会自动授予它，并会回退到 procfs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dropped on the capture workers after privileged initialization (#498)
 
 ### Fixed
+- **Comm-Truncated Linux Process Names**: The kernel `comm` field holds at most
+  15 bytes, so both the eBPF and procfs backends showed names like
+  "chromium-browse". When a name sits at that limit and the resolved
+  executable's file name strictly extends it, the executable name now wins
+  ("chromium-browse" becomes "chromium-browser"). Shorter names and interpreter
+  cases (comm "myscript", exe "python3") are left untouched, so deliberately
+  renamed comms keep working (#514)
 - **Initial RTT Measured Against The Wrong Clock**: `Initial RTT` in the Details
   pane reported round trips as `0.0ms`. RTT was timed with a clock read taken while
   processing a packet rather than from the packet's capture timestamp, and capture

--- a/README.md
+++ b/README.md
@@ -54,22 +54,16 @@ Built on ratatui, libpcap, eBPF (libbpf-rs), DashMap, crossbeam, ring, MaxMind G
 <details>
 <summary><b>eBPF Enhanced Process Identification (Linux Default)</b></summary>
 
-RustNet uses kernel eBPF programs by default on Linux for enhanced performance and lower overhead process identification. However, this comes with important limitations:
+RustNet uses kernel eBPF programs by default on Linux for enhanced performance and lower overhead process identification.
 
-**Process Name Limitations:**
-- eBPF uses the kernel's `comm` field, which is limited to 16 characters
-- Shows the task/thread command name, not the full executable path
-- Multi-threaded applications often show thread names instead of the main process name
-
-**Real-world Examples:**
-- **Firefox**: May appear as "Socket Thread", "Web Content", "Isolated Web Co", or "MainThread"
-- **Chrome**: May appear as "ThreadPoolForeg", "Chrome_IOThread", "BrokerProcess", or "SandboxHelper"
-- **Electron apps**: Often show as "electron", "node", or internal thread names
-- **System processes**: Show truncated names like "systemd-resolve" → "systemd-resolve"
+**Process Names:**
+- eBPF records the process group leader's TGID and `comm` name (a kernel field limited to 16 characters) rather than the acting thread's name, so multi-threaded applications show the main process name instead of thread names like "Socket Thread"
+- RustNet then re-resolves the current name via `/proc/<tgid>/comm`, recovers comm-truncated names from the executable's file name (e.g. "chromium-browse" becomes "chromium-browser"), and resolves the full executable path shown in the Details view
+- Short-lived processes that exit before this enrichment runs keep the eBPF-recorded 16-character name
 
 **Fallback Behavior:**
 - When eBPF fails to load or lacks sufficient permissions, RustNet automatically falls back to standard procfs-based process identification
-- Standard mode provides full process names but with higher CPU overhead
+- Standard mode resolves names the same way via procfs scanning, but with higher CPU overhead
 - eBPF is enabled by default; no special build flags needed
 
 To disable eBPF and use procfs-only mode, build with:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,22 +54,16 @@ RustNet 与抓包工具是互补关系。用 RustNet 看清*谁在发起连接*�
 <details>
 <summary><b>基于 eBPF 的增强型进程识别(Linux 默认)</b></summary>
 
-RustNet 在 Linux 上默认使用内核 eBPF 程序进行进程识别，从而获得更高的性能与更低的开销。但这种方式也有一些重要的限制需要了解：
+RustNet 在 Linux 上默认使用内核 eBPF 程序进行进程识别，从而获得更高的性能与更低的开销。
 
-**进程名长度限制：**
-- eBPF 使用内核的 `comm` 字段，该字段最多只有 16 个字符
-- 显示的是任务 / 线程的命令名，而非完整的可执行路径
-- 多线程应用往往展示线程名而非主进程名
-
-**真实场景示例：**
-- **Firefox**：可能显示为 "Socket Thread"、"Web Content"、"Isolated Web Co" 或 "MainThread"
-- **Chrome**：可能显示为 "ThreadPoolForeg"、"Chrome_IOThread"、"BrokerProcess" 或 "SandboxHelper"
-- **Electron 应用**：经常显示为 "electron"、"node" 或内部线程名
-- **系统进程**：展示截断后的名字，如 "systemd-resolve" → "systemd-resolve"
+**进程名：**
+- eBPF 记录的是进程组组长的 TGID 和 `comm` 名称（内核字段，最多 16 个字符），而非当前线程的名称，因此多线程应用显示的是主进程名，而不是 "Socket Thread" 之类的线程名
+- RustNet 随后会通过 `/proc/<tgid>/comm` 重新解析当前名称，并借助可执行文件名恢复被 `comm` 截断的名称（例如 "chromium-browse" 会恢复为 "chromium-browser"），同时解析完整可执行路径并显示在详情视图中
+- 在该富化流程运行前就已退出的短命进程，仍保留 eBPF 记录的 16 字符名称
 
 **回退行为：**
 - 当 eBPF 加载失败或权限不足时，RustNet 会自动回退到基于 procfs 的标准进程识别方式
-- 标准模式可以拿到完整进程名，但 CPU 开销更高
+- 标准模式通过 procfs 扫描以同样的方式解析进程名，但 CPU 开销更高
 - eBPF 默认启用，无需任何特殊编译参数
 
 如需关闭 eBPF、仅使用 procfs 模式，请这样构建：

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,15 +41,26 @@ This document outlines the planned features and improvements for RustNet.
 The experimental eBPF support provides efficient process identification but has several areas for improvement:
 
 ### Current Limitations
-- **Process Names Limited to 16 Characters**: Uses kernel `comm` field, causing truncation (e.g., "Firefox" → "Socket Thread")
-- **Thread Names vs Process Names**: Shows thread command names instead of full executable names
+- **Name recovery is best effort**: Names originate from the kernel `comm`
+  field (15 bytes). RustNet re-resolves the group leader's current name via
+  `/proc/<tgid>/comm` and recovers comm-truncated names from the executable's
+  file name, but a process that exits before enrichment runs keeps the short
+  eBPF-recorded name.
 
 ### Planned Improvements
-- **Hybrid eBPF + Procfs Approach**: Use eBPF for connection tracking, selectively lookup full process names via procfs for better accuracy
-- **Full Executable Path Resolution**: Investigate accessing full process executable path from eBPF programs
-- **Better Process-Thread Mapping**: Improve mapping from thread IDs to parent process information
-- **Enhanced BTF Support**: Better compatibility across different kernel versions and distributions
-- **Performance Optimizations**: Reduce eBPF map lookups and improve connection-to-process matching efficiency
+- [x] **Hybrid eBPF + Procfs Approach**: eBPF handles connection tracking; the
+  process name, executable path, parent PID, and credentials are resolved in
+  user space via procfs right after a successful attribution.
+- [x] **Full Executable Path Resolution**: `/proc/<tgid>/exe` is resolved in
+  user space immediately after attribution; kernel-side resolution turned out
+  to be unnecessary.
+- [x] **Better Process-Thread Mapping**: eBPF records the group leader's TGID,
+  the acting TID, and the leader's comm separately; the display name is
+  re-resolved from `/proc/<tgid>/comm`, and comm truncation is recovered from
+  the executable's file name.
+- [x] **Enhanced BTF Support**: Covered by the fentry/fexit backend selection
+  below, which uses actual BTF, load, and attach results per kernel.
+- [ ] **Performance Optimizations**: Reduce eBPF map lookups and improve connection-to-process matching efficiency
 - [x] **Prefer fentry/fexit with legacy kprobe fallback**: RustNet now tries a
   BPF trampoline backend first, then legacy kprobes, then procfs. Selection uses
   actual BTF, load, and attach results. The modern backend avoids
@@ -94,9 +105,9 @@ The experimental eBPF support provides efficient process identification but has 
 - [x] **Cross-platform Support**: Works on Linux, macOS, Windows, and FreeBSD
 - [x] **DNS Reverse Lookup**: Add optional hostname resolution (toggle between IP and hostname display) - `--resolve-dns` flag with `d` key toggle
 - [ ] **IPv6 Support**: Full IPv6 connection tracking and display, including DNS resolution (needs testing)
-- [ ] **VLAN Tag Detection**: Parse 802.1Q VLAN tags from packet headers to identify VLAN configurations
+- [ ] **VLAN Tag Detection**: Surface 802.1Q VLAN IDs per connection. The Ethernet link-layer parser already parses VLAN tags to reach the inner packet (the VID is extracted and trace-logged); what remains is carrying the VID onto connections and showing it in the TUI
 - [ ] **Passive Host Discovery**: Infer local network hosts from observed ARP requests/replies and other broadcast traffic without active scanning
-- [ ] **MAC Vendor Lookup (OUI)**: Resolve MAC addresses to hardware vendor names using a local OUI database (e.g. "Apple", "Intel", "Ubiquiti")
+- [x] **MAC Vendor Lookup (OUI)**: Resolve MAC addresses to hardware vendor names using a local OUI database (e.g. "Apple", "Intel", "Ubiquiti") - shown in the Details view, database bundled in `rustnet-core`
 
 ### Filtering & Search
 
@@ -147,11 +158,11 @@ The experimental eBPF support provides efficient process identification but has 
   - Per-packet comments include process/PID, direction, DPI/SNI, and GeoIP/ASN when available
   - Uses true capture timestamps and bounded attribution retry
 - [ ] **Enhanced PCAP Metadata**: Richer process information in sidecar file
-  - Process executable full path (not just name)
-  - Command line arguments
-  - Working directory
-  - User/UID information
-  - Parent process information
+  - [x] Process executable full path (not just name)
+  - [ ] Command line arguments
+  - [ ] Working directory
+  - [x] User/UID information (UID and GID)
+  - [x] Parent process information (PPID)
 - [ ] **Configuration File**: Support for persistent configuration:
   - Custom color themes and UI styling
   - Default filters and sort preferences
@@ -162,7 +173,7 @@ The experimental eBPF support provides efficient process identification but has 
 - [ ] **Connection Alerts**: Notifications for new connections or suspicious activity
 - [x] **GeoIP Integration**: Geographical location of remote IPs
 - [x] **GeoIP City-Level Resolution**: Extend GeoIP to include city-level location data using GeoLite2-City database
-- [ ] **Protocol Statistics**: Summary view of protocol distribution
+- [x] **Protocol Statistics**: Summary view of protocol distribution (Graph tab shows application protocol distribution and TCP state distribution)
 - [ ] **Rate Limiting Detection**: Identify connections with unusual traffic patterns
 - [ ] **Bufferbloat Detection**: Measure latency under load to identify bufferbloat issues on the network
 - [ ] **PCAP Import/Replay**: Load a PCAP file (with optional JSON process attribution sidecar) and replay it in the TUI for offline analysis. Enables remote monitoring workflows: capture on a remote host with `--pcap-export`, transfer files, and replay locally with full process-attributed view
@@ -182,8 +193,8 @@ The experimental eBPF support provides efficient process identification but has 
 - [x] **Connection Grouping**: Group connections by process with expandable tree view (press `a` to toggle, aggregated stats, Space/arrows to expand/collapse)
 - [x] **Reset View**: Reset all view settings (grouping, sort, filter) with `r` key
 - [ ] **Resizable Columns**: Dynamic column width adjustment
-- [ ] **ASCII Graphs**: Terminal-based graphs for bandwidth/packet visualization
-- [ ] **Mouse Support**: Click to select connections
+- [x] **ASCII Graphs**: Terminal-based graphs for bandwidth/packet visualization (Graph tab with braille traffic chart and connections sparkline)
+- [x] **Mouse Support**: Click to select connections, double-click to open Details, clickable tab bar
 - [ ] **Split Pane View**: Show multiple views simultaneously
 
 ## Architecture

--- a/crates/rustnet-host/src/linux/enhanced.rs
+++ b/crates/rustnet-host/src/linux/enhanced.rs
@@ -22,7 +22,7 @@ use super::ebpf::EbpfSocketTracker;
 mod ebpf_enhanced {
     use super::*;
     use crate::linux::ebpf::SocketMatch;
-    use crate::linux::process::{resolve_executable, resolve_parent_pid};
+    use crate::linux::process::{refine_truncated_name, resolve_executable, resolve_parent_pid};
     use rustnet_core::network::types::ProtocolState;
 
     /// Enhanced process lookup that combines eBPF (fast path) with procfs (fallback)
@@ -210,8 +210,10 @@ mod ebpf_enhanced {
                 .unwrap_or_else(|| info.comm.clone());
 
             // Resolve the executable now, while the process is most likely
-            // still around. Failure is not an attribution failure.
+            // still around. Failure is not an attribution failure. A
+            // comm-truncated name is recovered from the executable's file name.
             let executable = resolve_executable(info.pid);
+            let name = refine_truncated_name(name, executable.as_deref());
             let ppid = resolve_parent_pid(info.pid);
 
             debug!(

--- a/crates/rustnet-host/src/linux/process.rs
+++ b/crates/rustnet-host/src/linux/process.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::fs::MetadataExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use std::time::Instant;
 
@@ -32,6 +32,30 @@ pub(crate) fn resolve_executable(tgid: u32) -> Option<PathBuf> {
 pub(crate) fn resolve_credentials(tgid: u32) -> Option<(u32, u32)> {
     let metadata = fs::metadata(format!("/proc/{tgid}")).ok()?;
     Some((metadata.uid(), metadata.gid()))
+}
+
+/// Recover a comm-truncated process name from the executable's file name.
+///
+/// The kernel `comm` field holds at most 15 bytes, so both eBPF and the procfs
+/// scan see "chromium-browse" for chromium-browser. When a name sits exactly at
+/// that limit and the resolved executable's file name strictly extends it, the
+/// executable name is the untruncated original. Shorter names and interpreter
+/// cases (comm "myscript", exe "python3") never match and pass through
+/// unchanged.
+pub(crate) fn refine_truncated_name(name: String, executable: Option<&Path>) -> String {
+    const COMM_MAX: usize = 15;
+    if name.len() != COMM_MAX {
+        return name;
+    }
+    match executable
+        .and_then(|path| path.file_name())
+        .and_then(|file_name| file_name.to_str())
+    {
+        Some(basename) if basename.len() > COMM_MAX && basename.starts_with(name.as_str()) => {
+            basename.to_string()
+        }
+        _ => name,
+    }
 }
 
 /// Read the parent process id from `/proc/<tgid>/status`.
@@ -156,13 +180,14 @@ impl LinuxProcessLookup {
     /// Turn a procfs socket-table match into a rich attribution by reading the
     /// live `/proc/<tgid>` entries for the owner.
     ///
-    /// The name needs no extra work here: the socket table already sources it
-    /// from `/proc/<tgid>/comm` during the scan, so the tuple and rich APIs
-    /// report the same name for the same match.
+    /// The socket table sources the name from `/proc/<tgid>/comm` during the
+    /// scan, so a comm-truncated name is recovered from the executable here.
     fn build_attribution(tgid: u32, name: String, quality: MatchQuality) -> ProcessAttribution {
+        let executable = resolve_executable(tgid);
+        let name = refine_truncated_name(name, executable.as_deref());
         let mut attribution =
             ProcessAttribution::new(tgid, name, AttributionBackend::Procfs, quality)
-                .with_executable(resolve_executable(tgid));
+                .with_executable(executable);
         if let Some(ppid) = resolve_parent_pid(tgid) {
             attribution = attribution.with_parent_pid(ppid);
         }
@@ -401,6 +426,62 @@ mod tests {
     /// target with known credentials and a known executable.
     fn own_pid() -> u32 {
         std::process::id()
+    }
+
+    #[test]
+    fn truncated_comm_is_recovered_from_the_executable_name() {
+        assert_eq!(
+            refine_truncated_name(
+                "chromium-browse".to_string(),
+                Some(Path::new("/usr/lib/chromium/chromium-browser")),
+            ),
+            "chromium-browser"
+        );
+    }
+
+    #[test]
+    fn short_names_are_never_touched() {
+        // Below the 15-byte comm limit nothing was truncated, even when the
+        // executable name would extend it (a comm may be legitimately renamed).
+        assert_eq!(
+            refine_truncated_name(
+                "firefox".to_string(),
+                Some(Path::new("/usr/lib/firefox/firefox-esr")),
+            ),
+            "firefox"
+        );
+    }
+
+    #[test]
+    fn interpreter_executables_do_not_replace_the_comm() {
+        // comm at the limit but the executable is the interpreter, not an
+        // extension of the name: keep the comm.
+        assert_eq!(
+            refine_truncated_name(
+                "very-long-scrip".to_string(),
+                Some(Path::new("/usr/bin/python3")),
+            ),
+            "very-long-scrip"
+        );
+    }
+
+    #[test]
+    fn missing_executable_keeps_the_truncated_comm() {
+        assert_eq!(
+            refine_truncated_name("chromium-browse".to_string(), None),
+            "chromium-browse"
+        );
+    }
+
+    #[test]
+    fn executable_name_at_the_limit_is_not_an_extension() {
+        assert_eq!(
+            refine_truncated_name(
+                "chromium-browse".to_string(),
+                Some(Path::new("/opt/chromium-browse")),
+            ),
+            "chromium-browse"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- The kernel `comm` field holds at most 15 bytes, so both the eBPF and procfs backends showed names like "chromium-browse". When a name sits at that limit and the resolved executable's file name strictly extends it, the executable name now wins. Interpreter cases (comm "myscript", exe "python3") and shorter names are untouched.
- Sweeps stale ROADMAP checkboxes (hybrid eBPF+procfs, exe path resolution, thread mapping, OUI, protocol stats, ASCII graphs, mouse support, PCAP metadata sub-items) and updates the eBPF naming sections in README/ARCHITECTURE (en and zh-CN).

## Validation

- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace --all-targets` on macOS
- `cargo clippy -p rustnet-host --all-targets --features ebpf -- -D warnings` and `cargo test -p rustnet-host` with and without `ebpf` on Linux (Arch ARM)