### PR TITLE
Resolve Linux usernames in Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dropped on the capture workers after privileged initialization (#498)
 
 ### Fixed
+- **Linux User Names in Connection Details**: The Landlock profile now permits
+  read-only access to the public NSS account files, so the Details tab resolves
+  process UID/GID values to user/group names instead of showing numeric values
+  such as `1000:1000` (#519)
 - **Comm-Truncated Linux Process Names**: The kernel `comm` field holds at most
   15 bytes, so both the eBPF and procfs backends showed names like
   "chromium-browse". When a name sits at that limit and the resolved

--- a/src/network/platform/linux/sandbox/landlock.rs
+++ b/src/network/platform/linux/sandbox/landlock.rs
@@ -20,7 +20,9 @@
 //!
 //! # What We Restrict
 //!
-//! - Filesystem: Only allow read access to `/proc` (needed for process lookup)
+//! - Filesystem: Allow read access to `/proc` (needed for process lookup)
+//! - Filesystem: Allow read access to the public account databases used for
+//!   UID/GID names
 //! - Filesystem: Only allow read access to specified paths (e.g., GeoIP databases)
 //! - Filesystem: Only allow write access to specified paths (logs)
 //! - Network: Block TCP bind and connect (RustNet is passive)
@@ -54,6 +56,12 @@ const ABI_FS: ABI = ABI::V4;
 /// because V7 only adds audit-logging controls, which we don't use. The crate
 /// downgrades automatically (best effort) on kernels that support less.
 const ABI_SCOPE: ABI = ABI::V6;
+
+/// Public account files needed by libc's `getpwuid_r` and `getgrgid_r`.
+///
+/// These are file-scoped rules rather than an `/etc` subtree rule, so the
+/// sandbox does not expose unrelated system configuration or credentials.
+const ACCOUNT_DATABASE_PATHS: [&str; 3] = ["/etc/passwd", "/etc/group", "/etc/nsswitch.conf"];
 
 /// Result of Landlock application
 pub struct LandlockResult {
@@ -180,6 +188,22 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<LandlockResult> {
     // against reading sensitive /proc files of processes outside our domain.
     if let Err(e) = add_path_rule(&mut ruleset_created, "/proc", read_access) {
         log::warn!("Could not add /proc rule: {}", e);
+    }
+
+    // The Details tab resolves process UID/GID values through libc after the
+    // sandbox is active. NSS needs its service configuration and the local
+    // account databases for that lookup. Grant only ReadFile on the exact
+    // files, never the containing /etc directory or the shadow databases.
+    for account_path in ACCOUNT_DATABASE_PATHS {
+        if Path::new(account_path).exists()
+            && let Err(e) = add_path_rule(
+                &mut ruleset_created,
+                account_path,
+                AccessFs::ReadFile.into(),
+            )
+        {
+            log::warn!("Could not add account database rule for {account_path}: {e}");
+        }
     }
 
     // Add rules for sysfs (read-only). The interface-stats poller enumerates

--- a/src/network/platform/linux/sandbox/mod.rs
+++ b/src/network/platform/linux/sandbox/mod.rs
@@ -8,7 +8,8 @@
 //! # Security Model
 //!
 //! After sandboxing is applied:
-//! - Filesystem: Only `/proc` and specified read paths (e.g., GeoIP databases) readable
+//! - Filesystem: Only `/proc`, public account databases, and specified read paths
+//!   (e.g., GeoIP databases) readable
 //! - Filesystem: Only specified write paths writable (e.g., logs, exports)
 //! - Network: TCP bind/connect blocked (kernel 6.7+, ABI v4)
 //! - Scope: abstract UNIX socket connects + signals to outside processes blocked

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -2378,6 +2378,35 @@ mod path_shortening_tests {
         assert_eq!(format_user_group(uid, Some(gid)), format!("{user}:{group}"));
     }
 
+    #[cfg(all(target_os = "linux", feature = "landlock"))]
+    #[test]
+    fn current_account_ids_resolve_with_landlock_enforced() {
+        use crate::network::platform::sandbox::{SandboxConfig, SandboxMode, apply_sandbox};
+
+        let result = apply_sandbox(&SandboxConfig {
+            mode: SandboxMode::BestEffort,
+            block_network: false,
+            read_paths: vec![],
+            write_paths: vec![],
+            drop_uid: None,
+        })
+        .expect("best-effort sandbox must apply without error");
+        if !result.landlock_fs_applied {
+            return;
+        }
+
+        // SAFETY: these calls only read this process's effective credentials.
+        let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
+        assert!(
+            super::resolve_user_name(uid).is_some(),
+            "current user must resolve inside the sandbox"
+        );
+        assert!(
+            super::resolve_group_name(gid).is_some(),
+            "current group must resolve inside the sandbox"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn account_name_must_be_terminated_inside_the_supplied_buffer() {


### PR DESCRIPTION
## Summary
- Allow read-only NSS account lookups through Linux Landlock.
- Show user/group names in Details instead of numeric IDs.
- Add sandbox regression coverage.

## Checks
- `cargo test --workspace --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
