### PR TITLE
Limit CI job runtime

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Install dependencies
@@ -62,6 +63,7 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

- Add 60-minute timeouts to the Rust build and Docker jobs.
- Prevent runner-side hangs from lingering indefinitely.

## Verification

- `actionlint .github/workflows/rust.yml`
- `git diff --check`
