### PR TITLE
NTP RTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **NTP RTT**: NTP client connections now show the latest request→response
+  round trip in the Details Transport Health card, along with the server
+  stratum. Polls pair with responses through the originate timestamp echo
+  (RFC 5905), so daemons polling several servers stay distinct. Pending
+  requests are bounded (hard cap plus 10s expiry) like DNS queries
 - **STUN RTT**: STUN connections now show the latest request→response round
   trip in the Details Transport Health card, paired by the 96-bit transaction
   ID that retransmits reuse. Pending requests are bounded (hard cap plus 10s

--- a/crates/rustnet-core/src/network/dpi/ntp.rs
+++ b/crates/rustnet-core/src/network/dpi/ntp.rs
@@ -28,11 +28,27 @@ pub fn analyze_ntp(payload: &[u8]) -> Option<NtpInfo> {
         return None;
     }
 
+    // A server echoes the client's transmit timestamp back as the originate
+    // timestamp (RFC 5905 §8), which is what pairs a request with its
+    // response for round-trip timing.
+    let origin_timestamp = read_u64(payload, 24);
+    let transmit_timestamp = read_u64(payload, 40);
+
     Some(NtpInfo {
         version,
         mode: NtpMode::from(mode),
         stratum,
+        origin_timestamp,
+        transmit_timestamp,
     })
+}
+
+/// Read a big-endian u64 at `offset`; the caller guarantees the bounds via
+/// the minimum packet size check.
+fn read_u64(payload: &[u8], offset: usize) -> u64 {
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&payload[offset..offset + 8]);
+    u64::from_be_bytes(bytes)
 }
 
 #[cfg(test)]
@@ -54,6 +70,16 @@ mod tests {
         assert_eq!(info.version, 4);
         assert_eq!(info.mode, NtpMode::Client);
         assert_eq!(info.stratum, 0);
+    }
+
+    #[test]
+    fn test_ntp_extracts_origin_and_transmit_timestamps() {
+        let mut packet = build_ntp_packet(4, 4, 2);
+        packet[24..32].copy_from_slice(&0x1122_3344_5566_7788u64.to_be_bytes());
+        packet[40..48].copy_from_slice(&0x99AA_BBCC_DDEE_FF00u64.to_be_bytes());
+        let info = analyze_ntp(&packet).expect("should parse");
+        assert_eq!(info.origin_timestamp, 0x1122_3344_5566_7788);
+        assert_eq!(info.transmit_timestamp, 0x99AA_BBCC_DDEE_FF00);
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -182,6 +182,9 @@ pub struct IngestOutcome {
     /// The latest completed STUN request→response round trip, if this packet
     /// was a response matching a pending request by transaction ID.
     pub stun_rtt: Option<Duration>,
+    /// The latest completed NTP request→response round trip, if this packet
+    /// was a server response echoing a pending client transmit timestamp.
+    pub ntp_rtt: Option<Duration>,
 }
 
 /// Timing measurements extracted from one packet, carried together through
@@ -192,6 +195,7 @@ struct PacketTimings {
     dns_response_time: Option<Duration>,
     icmp_echo_rtt: Option<Duration>,
     stun_rtt: Option<Duration>,
+    ntp_rtt: Option<Duration>,
 }
 
 /// A live, lifecycle-managed table of network connections built from parsed
@@ -355,11 +359,23 @@ impl ConnectionTracker {
             );
         }
 
+        // NTP servers echo the client's transmit timestamp as the originate
+        // timestamp, pairing each poll with its response.
+        let mut ntp_rtt: Option<Duration> = None;
+        if parsed.protocol == Protocol::Udp
+            && let Some(dpi) = &parsed.dpi_result
+            && let ApplicationProtocol::Ntp(ntp) = &dpi.application
+            && let Ok(mut tracker) = self.rtt.lock()
+        {
+            ntp_rtt = tracker.record_ntp(base_key, ntp, parsed.is_outgoing, now);
+        }
+
         let timings = PacketTimings {
             measured_rtt,
             dns_response_time,
             icmp_echo_rtt,
             stun_rtt,
+            ntp_rtt,
         };
 
         // A read guard makes ordinary packet updates atomic with cleanup. The
@@ -385,6 +401,7 @@ impl ConnectionTracker {
                 dns_response_time: timings.dns_response_time,
                 icmp_echo_rtt: timings.icmp_echo_rtt,
                 stun_rtt: timings.stun_rtt,
+                ntp_rtt: timings.ntp_rtt,
             };
         }
 
@@ -429,6 +446,7 @@ impl ConnectionTracker {
                 dns_response_time: timings.dns_response_time,
                 icmp_echo_rtt: timings.icmp_echo_rtt,
                 stun_rtt: timings.stun_rtt,
+                ntp_rtt: timings.ntp_rtt,
             };
         }
 
@@ -454,6 +472,9 @@ impl ConnectionTracker {
                 if let Some(rtt) = timings.stun_rtt {
                     conn.stun_rtt = Some(rtt);
                 }
+                if let Some(rtt) = timings.ntp_rtt {
+                    conn.ntp_rtt = Some(rtt);
+                }
             })
             .or_insert_with(|| {
                 created = true;
@@ -469,6 +490,9 @@ impl ConnectionTracker {
                 }
                 if let Some(rtt) = timings.stun_rtt {
                     conn.stun_rtt = Some(rtt);
+                }
+                if let Some(rtt) = timings.ntp_rtt {
+                    conn.ntp_rtt = Some(rtt);
                 }
                 conn
             });
@@ -498,6 +522,7 @@ impl ConnectionTracker {
             dns_response_time: timings.dns_response_time,
             icmp_echo_rtt: timings.icmp_echo_rtt,
             stun_rtt: timings.stun_rtt,
+            ntp_rtt: timings.ntp_rtt,
         }
     }
 
@@ -1436,6 +1461,63 @@ mod tests {
             .expect("stun connection should exist")
             .clone();
         assert_eq!(conn.stun_rtt, Some(Duration::from_millis(31)));
+    }
+
+    fn ntp_packet(
+        mode: crate::network::types::NtpMode,
+        is_outgoing: bool,
+        origin_timestamp: u64,
+        transmit_timestamp: u64,
+    ) -> ParsedPacket {
+        use crate::network::dpi::DpiResult;
+        use crate::network::types::{NtpInfo, ProtocolState};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        ParsedPacket {
+            protocol: Protocol::Udp,
+            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 47_000),
+            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)), 123),
+            protocol_state: ProtocolState::Udp,
+            tcp_header: None,
+            is_outgoing,
+            packet_len: 90,
+            dpi_result: Some(DpiResult {
+                application: ApplicationProtocol::Ntp(NtpInfo {
+                    version: 4,
+                    mode,
+                    stratum: 2,
+                    origin_timestamp,
+                    transmit_timestamp,
+                }),
+            }),
+            process_name: None,
+            process_id: None,
+        }
+    }
+
+    /// An NTP poll pairs with its response through the originate timestamp
+    /// echo, giving the UDP flow a request→response time.
+    #[test]
+    fn ntp_server_response_measures_rtt() {
+        use crate::network::types::NtpMode;
+
+        let tracker = ConnectionTracker::new();
+        tracker.ingest_at(
+            &ntp_packet(NtpMode::Client, true, 0, 0xAABB),
+            capture_time(0),
+        );
+        let response = tracker.ingest_at(
+            &ntp_packet(NtpMode::Server, false, 0xAABB, 0xCCDD),
+            capture_time(21),
+        );
+
+        assert_eq!(response.ntp_rtt, Some(Duration::from_millis(21)));
+        let conn = tracker
+            .connections()
+            .get(&response.key)
+            .expect("ntp connection should exist")
+            .clone();
+        assert_eq!(conn.ntp_rtt, Some(Duration::from_millis(21)));
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -735,6 +735,12 @@ pub struct NtpInfo {
     pub version: u8,
     pub mode: NtpMode,
     pub stratum: u8,
+    /// Originate timestamp (raw 64-bit NTP format): in a server response,
+    /// the echo of the client's transmit timestamp.
+    pub origin_timestamp: u64,
+    /// Transmit timestamp (raw 64-bit NTP format): when the sender put the
+    /// packet on the wire, by its own clock.
+    pub transmit_timestamp: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1894,6 +1900,9 @@ pub struct RttTracker {
     /// Outbound STUN requests awaiting their response, keyed by connection
     /// and the 96-bit transaction ID.
     pending_stun: HashMap<(ConnectionKey, [u8; 12]), SystemTime>,
+    /// Outbound NTP client requests awaiting a server response, keyed by
+    /// connection and the transmit timestamp the response echoes back.
+    pending_ntp: HashMap<(ConnectionKey, u64), SystemTime>,
     /// Recent RTT measurements for aggregation: (timestamp, rtt_duration)
     recent_rtts: VecDeque<(Instant, Duration)>,
     /// Maximum age for pending SYNs (cleanup stale entries)
@@ -1905,6 +1914,8 @@ pub struct RttTracker {
     /// Maximum age for pending STUN requests, past the RFC 5389 retransmit
     /// window's useful range
     max_pending_stun_age: Duration,
+    /// Maximum age for pending NTP requests, well past any sane response
+    max_pending_ntp_age: Duration,
     /// Maximum number of recent RTTs to keep
     max_recent_rtts: usize,
 }
@@ -1920,6 +1931,9 @@ const MAX_PENDING_ICMP_ECHOES: usize = 4096;
 /// Hard cap on pending STUN requests, mirroring the DNS guardrail.
 const MAX_PENDING_STUN: usize = 4096;
 
+/// Hard cap on pending NTP requests, mirroring the DNS guardrail.
+const MAX_PENDING_NTP: usize = 4096;
+
 impl RttTracker {
     pub fn new() -> Self {
         Self {
@@ -1928,11 +1942,13 @@ impl RttTracker {
             pending_dns: HashMap::new(),
             pending_icmp_echoes: HashMap::new(),
             pending_stun: HashMap::new(),
+            pending_ntp: HashMap::new(),
             recent_rtts: VecDeque::new(),
             max_pending_age: Duration::from_secs(30),
             max_pending_dns_age: Duration::from_secs(10),
             max_pending_icmp_age: Duration::from_secs(10),
             max_pending_stun_age: Duration::from_secs(10),
+            max_pending_ntp_age: Duration::from_secs(10),
             max_recent_rtts: 100,
         }
     }
@@ -2098,6 +2114,39 @@ impl RttTracker {
         }
     }
 
+    /// Record an NTP packet, returning the round trip when an incoming
+    /// server response matches a pending outgoing client request.
+    ///
+    /// A server echoes the client's transmit timestamp back as the originate
+    /// timestamp (RFC 5905 §8), which pairs each exchange exactly even when
+    /// a daemon polls several servers from one socket. Broadcast and
+    /// symmetric modes have no such echo and are not timed.
+    pub fn record_ntp(
+        &mut self,
+        key: ConnectionKey,
+        info: &NtpInfo,
+        is_outgoing: bool,
+        at: SystemTime,
+    ) -> Option<Duration> {
+        self.cleanup_stale(at);
+        match (is_outgoing, info.mode) {
+            (true, NtpMode::Client) => {
+                let pending_key = (key, info.transmit_timestamp);
+                if self.pending_ntp.len() < MAX_PENDING_NTP
+                    || self.pending_ntp.contains_key(&pending_key)
+                {
+                    self.pending_ntp.insert(pending_key, at);
+                }
+                None
+            }
+            (false, NtpMode::Server) => {
+                let sent_at = self.pending_ntp.remove(&(key, info.origin_timestamp))?;
+                Some(at.duration_since(sent_at).unwrap_or_default())
+            }
+            _ => None,
+        }
+    }
+
     /// Record a completed data round trip (segment to covering ACK) measured
     /// by the per-connection estimator, so the aggregate RTT view reflects
     /// established connections rather than only fresh handshakes.
@@ -2149,6 +2198,9 @@ impl RttTracker {
         if let Some(stun_cutoff) = now.checked_sub(self.max_pending_stun_age) {
             self.pending_stun.retain(|_, ts| *ts > stun_cutoff);
         }
+        if let Some(ntp_cutoff) = now.checked_sub(self.max_pending_ntp_age) {
+            self.pending_ntp.retain(|_, ts| *ts > ntp_cutoff);
+        }
     }
 
     /// Clear all RTT tracking data
@@ -2158,6 +2210,7 @@ impl RttTracker {
         self.pending_dns.clear();
         self.pending_icmp_echoes.clear();
         self.pending_stun.clear();
+        self.pending_ntp.clear();
         self.recent_rtts.clear();
     }
 }
@@ -2718,6 +2771,10 @@ pub struct Connection {
     // Like `dns_response_time`, kept separate from the transport-level RTT.
     pub stun_rtt: Option<std::time::Duration>,
 
+    // Latest NTP request→response round trip, paired by the originate
+    // timestamp echo. Kept separate from the transport-level RTT.
+    pub ntp_rtt: Option<std::time::Duration>,
+
     // GeoIP information for remote address
     pub geoip_info: Option<crate::network::geoip::GeoIpInfo>,
 
@@ -2780,6 +2837,7 @@ impl Connection {
             dns_response_time: None,
             icmp_echo_rtt: None,
             stun_rtt: None,
+            ntp_rtt: None,
             geoip_info: None,
             is_historic: false,
             closed_at: None,
@@ -4722,6 +4780,75 @@ mod tests {
         );
         assert!(rtt.is_none(), "the pending request expired after 10s");
         assert!(tracker.pending_stun.is_empty());
+    }
+
+    fn ntp_info(mode: NtpMode, origin_timestamp: u64, transmit_timestamp: u64) -> NtpInfo {
+        NtpInfo {
+            version: 4,
+            mode,
+            stratum: 2,
+            origin_timestamp,
+            transmit_timestamp,
+        }
+    }
+
+    #[test]
+    fn test_rtt_tracker_ntp_pairs_by_originate_timestamp() {
+        let mut tracker = RttTracker::new();
+        let key = ConnectionKey::new(
+            Protocol::Udp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 47_000),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)), 123),
+        );
+
+        tracker.record_ntp(
+            key,
+            &ntp_info(NtpMode::Client, 0, 0xAABB),
+            true,
+            rtt_capture_time(0),
+        );
+        // The server echoes the client's transmit timestamp as originate.
+        let rtt = tracker.record_ntp(
+            key,
+            &ntp_info(NtpMode::Server, 0xAABB, 0xCCDD),
+            false,
+            rtt_capture_time(17),
+        );
+        assert_eq!(rtt, Some(Duration::from_millis(17)));
+
+        // A response whose originate echo matches nothing measures nothing.
+        let rtt = tracker.record_ntp(
+            key,
+            &ntp_info(NtpMode::Server, 0x1234, 0xCCDD),
+            false,
+            rtt_capture_time(30),
+        );
+        assert!(rtt.is_none());
+    }
+
+    #[test]
+    fn test_rtt_tracker_pending_ntp_expires() {
+        let mut tracker = RttTracker::new();
+        let key = ConnectionKey::new(
+            Protocol::Udp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 47_000),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)), 123),
+        );
+
+        tracker.record_ntp(
+            key,
+            &ntp_info(NtpMode::Client, 0, 0xAABB),
+            true,
+            rtt_capture_time(0),
+        );
+        let rtt = tracker.record_ntp(
+            key,
+            &ntp_info(NtpMode::Server, 0xAABB, 0xCCDD),
+            false,
+            rtt_capture_time(11_000),
+        );
+        assert!(rtt.is_none(), "the pending request expired after 10s");
+        assert!(tracker.pending_ntp.is_empty());
     }
 
     // ========================================================================

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1533,6 +1533,56 @@ mod snapshot_tests {
         assert!(!output.contains("No transport metrics for this protocol"));
     }
 
+    /// An NTP poll is timeable through the originate timestamp echo, so its
+    /// Transport Health card shows a real RTT plus the server stratum.
+    #[test]
+    fn details_tab_ntp_shows_rtt_in_transport_health() {
+        use crate::network::types::{ApplicationProtocol, DpiInfo, NtpInfo, NtpMode};
+
+        let app = test_app();
+        let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)), 47_000);
+        let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)), 123);
+        let mut ntp = Connection::new(Protocol::Udp, local, remote, ProtocolState::Udp);
+        ntp.ntp_rtt = Some(Duration::from_micros(6_500));
+        ntp.dpi_info = Some(DpiInfo {
+            application: ApplicationProtocol::Ntp(NtpInfo {
+                version: 4,
+                mode: NtpMode::Server,
+                stratum: 2,
+                origin_timestamp: 0xAABB,
+                transmit_timestamp: 0xCCDD,
+            }),
+            last_update_time: std::time::Instant::now(),
+        });
+        let connections = vec![ntp];
+
+        app.set_connections_snapshot_for_test(connections.clone());
+        let stats = app.get_stats();
+        let ui_state = UIState {
+            selected_tab: 1,
+            selected_connection_key: Some(connections[0].key()),
+            ..Default::default()
+        };
+        let mut click_regions = ClickableRegions::default();
+        let output = render(140, 40, |f| {
+            draw(
+                f,
+                &app,
+                &ui_state,
+                &connections,
+                None,
+                &stats,
+                &mut click_regions,
+            )
+            .expect("draw ntp details");
+        });
+
+        assert!(output.contains("NTP RTT") && output.contains("6.5ms"));
+        assert!(output.contains("Stratum"));
+        assert!(output.contains("Paired by originate timestamp echo"));
+        assert!(!output.contains("No transport metrics for this protocol"));
+    }
+
     /// The Attribution section repeats PID beside the richer process fields so
     /// the identity remains visible as one self-contained block.
     #[test]

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -1866,6 +1866,15 @@ pub(in crate::ui) fn draw_connection_details(
             crate::network::types::ApplicationProtocol::Stun(info) => Some(info),
             _ => None,
         });
+    // NTP responses echo the client's transmit timestamp, so polls are
+    // timeable the same way.
+    let ntp_info = conn
+        .dpi_info
+        .as_ref()
+        .and_then(|dpi| match &dpi.application {
+            crate::network::types::ApplicationProtocol::Ntp(info) => Some(info),
+            _ => None,
+        });
     let icmp_echo_sequence = match &conn.protocol_state {
         crate::network::types::ProtocolState::Icmp {
             icmp_type: 0 | 8 | 128 | 129,
@@ -1975,6 +1984,51 @@ pub(in crate::ui) fn draw_connection_details(
             &mut details_text,
             &mut detail_fields,
             "Paired by 96-bit transaction ID",
+        );
+    } else if let Some(ntp) = ntp_info {
+        if let Some(rtt) = conn.ntp_rtt {
+            let rtt_ms = rtt.as_secs_f64() * 1000.0;
+            let rtt_color = if rtt_ms < 50.0 {
+                theme::ok()
+            } else if rtt_ms < 150.0 {
+                theme::warn()
+            } else {
+                theme::err()
+            };
+            push_detail_field_styled(
+                &mut details_text,
+                &mut detail_fields,
+                "NTP RTT",
+                format!("{:.1}ms", rtt_ms),
+                label_style,
+                theme::fg(rtt_color),
+            );
+        } else {
+            push_detail_field(
+                &mut details_text,
+                &mut detail_fields,
+                "NTP RTT",
+                NONE_PLACEHOLDER.to_string(),
+                label_style,
+            );
+        }
+        push_detail_field(
+            &mut details_text,
+            &mut detail_fields,
+            "Stratum",
+            if ntp.stratum == 0 {
+                NONE_PLACEHOLDER.to_string()
+            } else {
+                ntp.stratum.to_string()
+            },
+            label_style,
+        );
+        details_text.push(Line::from(""));
+        detail_fields.push(None);
+        push_detail_note(
+            &mut details_text,
+            &mut detail_fields,
+            "Paired by originate timestamp echo",
         );
     } else if let Some(sequence) = icmp_echo_sequence {
         // A flow the remote side initiated is only ever answered here, so


### PR DESCRIPTION
- Pair NTP client polls with server responses via the originate timestamp echo and show the RTT in Details Transport Health.
- Tests and clippy pass.
- Stacked on #526; retargets once that merges.