### PR TITLE
Render broadcast/multicast endpoints as bcast/mcast labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Broadcast/Multicast Endpoint Display**: A broadcast or multicast datagram
+  sent by a peer (e.g. NetBIOS to 192.168.0.255) used to render its
+  destination as a normal-looking Local address. Such endpoints now render as
+  `bcast:PORT` / `mcast:PORT` in the Overview table, the Details tab annotates
+  the full address with `(broadcast)` / `(multicast)`, and the Scope field
+  reports BROADCAST for subnet-directed broadcasts instead of PRIVATE.
+  Interface prefixes are now collected alongside local addresses to recognize
+  each subnet's broadcast address; recognized broadcasts no longer trigger
+  ambiguous-endpoint interface re-enumeration. JSONL logs gain
+  `local_addr_kind`/`remote_addr_kind` (sidecar) and
+  `source_addr_kind`/`destination_addr_kind` (event log) keys, emitted only
+  for non-unicast endpoints
+
 ### Added
 - **DNS Response Time**: Unicast UDP DNS connections now show a transport
   metric in the Details Transport Health card instead of "No transport metrics

--- a/benches/connection_merge.rs
+++ b/benches/connection_merge.rs
@@ -34,6 +34,8 @@ fn make_parsed_packet() -> rustnet_monitor::network::parser::ParsedPacket {
         protocol: Protocol::Tcp,
         local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321),
         remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
+        local_addr_kind: AddrKind::Unicast,
+        remote_addr_kind: AddrKind::Unicast,
         tcp_header: Some(TcpHeaderInfo {
             seq: 1000,
             ack: 2000,

--- a/benches/tracker_ingest.rs
+++ b/benches/tracker_ingest.rs
@@ -16,6 +16,8 @@ fn make_packet(flow: u16, seq: u32) -> ParsedPacket {
         protocol: Protocol::Tcp,
         local_addr,
         remote_addr,
+        local_addr_kind: AddrKind::Unicast,
+        remote_addr_kind: AddrKind::Unicast,
         tcp_header: Some(TcpHeaderInfo {
             seq,
             ack: seq.wrapping_add(1),

--- a/crates/rustnet-core/src/network/local_addresses.rs
+++ b/crates/rustnet-core/src/network/local_addresses.rs
@@ -1,20 +1,66 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-/// Collect every address currently assigned to the host.
+/// Snapshot of the host's assigned addresses plus the IPv4 subnet-directed
+/// broadcast address of every assigned network (e.g. 192.168.0.255 for a /24).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct LocalAddresses {
+    pub ips: HashSet<IpAddr>,
+    /// Subnet-directed broadcasts only; the limited broadcast
+    /// (255.255.255.255) needs no prefix knowledge and is handled statelessly.
+    pub v4_broadcasts: HashSet<Ipv4Addr>,
+}
+
+#[cfg(test)]
+impl LocalAddresses {
+    /// Test helper: a snapshot with the given addresses and no broadcast set.
+    pub(crate) fn from_ips(ips: impl IntoIterator<Item = IpAddr>) -> Self {
+        Self {
+            ips: ips.into_iter().collect(),
+            v4_broadcasts: HashSet::new(),
+        }
+    }
+}
+
+/// Directed-broadcast address of `ip`'s subnet, or `None` when the prefix has
+/// no broadcast (/31 point-to-point per RFC 3021, /32 host routes).
+fn v4_subnet_broadcast(ip: Ipv4Addr, prefix: u8) -> Option<Ipv4Addr> {
+    if prefix >= 31 {
+        return None;
+    }
+    let mask = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    Some(Ipv4Addr::from(u32::from(ip) | !mask))
+}
+
+/// Collect every address currently assigned to the host, together with the
+/// broadcast addresses of its IPv4 subnets.
 ///
 /// `pnet_datalink` supplies the portable implementation. Its Windows backend
 /// still uses the IPv4-only `GetAdaptersInfo`, so Windows supplements it with
 /// `GetAdaptersAddresses` to include all IPv4 and IPv6 unicast addresses.
-pub(crate) fn collect_local_ips() -> HashSet<IpAddr> {
-    let mut local_ips = HashSet::new();
+pub(crate) fn collect_local_addresses() -> LocalAddresses {
+    let mut local = LocalAddresses::default();
     for interface in pnet_datalink::interfaces() {
-        local_ips.extend(interface.ips.into_iter().map(|network| network.ip()));
+        for network in interface.ips {
+            let ip = network.ip();
+            local.ips.insert(ip);
+            if let IpAddr::V4(v4) = ip
+                && let Some(broadcast) = v4_subnet_broadcast(v4, network.prefix())
+            {
+                local.v4_broadcasts.insert(broadcast);
+            }
+        }
     }
 
+    // The Windows supplement stays IP-only: its added value is IPv6 (which
+    // has no broadcast concept); IPv4 prefixes are already covered above.
     #[cfg(windows)]
     match windows_unicast_addresses() {
-        Ok(addresses) => local_ips.extend(addresses),
+        Ok(addresses) => local.ips.extend(addresses),
         Err(code) => {
             // Warn once so a persistent failure is visible at default log
             // levels without repeating every refresh interval.
@@ -32,9 +78,9 @@ pub(crate) fn collect_local_ips() -> HashSet<IpAddr> {
         }
     }
 
-    local_ips.insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
-    local_ips.insert(IpAddr::V6(Ipv6Addr::LOCALHOST));
-    local_ips
+    local.ips.insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    local.ips.insert(IpAddr::V6(Ipv6Addr::LOCALHOST));
+    local
 }
 
 #[cfg(windows)]
@@ -135,16 +181,38 @@ mod tests {
 
     #[test]
     fn collector_always_includes_loopback_addresses() {
-        let addresses = collect_local_ips();
-        assert!(addresses.contains(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
-        assert!(addresses.contains(&IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        let addresses = collect_local_addresses();
+        assert!(addresses.ips.contains(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(addresses.ips.contains(&IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn subnet_broadcast_is_derived_from_prefix() {
+        assert_eq!(
+            v4_subnet_broadcast(Ipv4Addr::new(192, 168, 0, 52), 24),
+            Some(Ipv4Addr::new(192, 168, 0, 255))
+        );
+        assert_eq!(
+            v4_subnet_broadcast(Ipv4Addr::new(10, 1, 2, 3), 8),
+            Some(Ipv4Addr::new(10, 255, 255, 255))
+        );
+        assert_eq!(
+            v4_subnet_broadcast(Ipv4Addr::new(0, 0, 0, 0), 0),
+            Some(Ipv4Addr::BROADCAST)
+        );
+    }
+
+    #[test]
+    fn point_to_point_prefixes_have_no_broadcast() {
+        assert_eq!(v4_subnet_broadcast(Ipv4Addr::new(10, 0, 0, 1), 31), None);
+        assert_eq!(v4_subnet_broadcast(Ipv4Addr::new(10, 0, 0, 1), 32), None);
     }
 
     #[cfg(windows)]
     #[test]
     fn combined_snapshot_contains_windows_native_addresses() {
         let native = windows_unicast_addresses().expect("GetAdaptersAddresses should succeed");
-        let combined = collect_local_ips();
+        let combined = collect_local_addresses().ips;
 
         for address in native {
             assert!(

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -256,6 +256,11 @@ pub fn merge_packet_into_connection(
     let observation_time = conn.last_activity.max(now);
     conn.last_activity = observation_time;
 
+    // Deterministic for a given interface snapshot; last-wins self-heals
+    // connections whose first packet raced interface enumeration.
+    conn.local_addr_kind = parsed.local_addr_kind;
+    conn.remote_addr_kind = parsed.remote_addr_kind;
+
     // Update packet counts and bytes
     if parsed.is_outgoing {
         conn.packets_sent += 1;
@@ -428,6 +433,8 @@ pub fn create_connection_from_packet(parsed: &ParsedPacket, now: SystemTime) -> 
         parsed.remote_addr,
         parsed.protocol_state.clone(),
     );
+    conn.local_addr_kind = parsed.local_addr_kind;
+    conn.remote_addr_kind = parsed.remote_addr_kind;
 
     // Set initial TCP state based on flags if TCP
     if let Some(tcp_header) = parsed.tcp_header {
@@ -1036,7 +1043,7 @@ fn update_connection_rates(conn: &mut Connection) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::network::types::{Protocol, ProtocolState, TcpState};
+    use crate::network::types::{AddrKind, Protocol, ProtocolState, TcpState};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     fn create_test_connection() -> Connection {
@@ -1055,6 +1062,8 @@ mod tests {
             protocol: Protocol::Tcp,
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 12345),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
             protocol_state: ProtocolState::Tcp(TcpState::Unknown),
             tcp_header: Some(TcpHeaderInfo {
                 seq: 1000,
@@ -1166,6 +1175,23 @@ mod tests {
         assert_eq!(conn.packets_received, 1);
         assert_eq!(conn.bytes_received, 100);
         assert_eq!(conn.packets_sent, 0);
+    }
+
+    #[test]
+    fn endpoint_kinds_are_copied_and_refreshed_on_merge() {
+        let mut packet = create_test_packet(false, false);
+        packet.local_addr_kind = AddrKind::Broadcast;
+        let conn = create_connection_from_packet(&packet, SystemTime::now());
+        assert_eq!(conn.local_addr_kind, AddrKind::Broadcast);
+        assert_eq!(conn.remote_addr_kind, AddrKind::Unicast);
+
+        // A connection first seen before a refresh added its subnet self-heals
+        // when a later packet carries the corrected kind.
+        let stale = create_test_packet(false, false);
+        let mut conn = create_connection_from_packet(&stale, SystemTime::now());
+        assert_eq!(conn.local_addr_kind, AddrKind::Unicast);
+        merge_packet_into_connection(&mut conn, &packet, SystemTime::now());
+        assert_eq!(conn.local_addr_kind, AddrKind::Broadcast);
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/parser.rs
+++ b/crates/rustnet-core/src/network/parser.rs
@@ -5,7 +5,7 @@ use crate::network::link_layer;
 use crate::network::link_layer::ethernet;
 #[cfg(target_os = "macos")]
 use crate::network::link_layer::pktap;
-use crate::network::local_addresses::collect_local_ips;
+use crate::network::local_addresses::{LocalAddresses, collect_local_addresses};
 use crate::network::oui::OuiLookup;
 use crate::network::protocol;
 use crate::network::protocol::TransportParams;
@@ -25,6 +25,10 @@ pub struct ParsedPacket {
     pub protocol: Protocol,
     pub local_addr: SocketAddr,
     pub remote_addr: SocketAddr,
+    /// Endpoint address kinds, stamped centrally in `PacketParser::parse_packet`
+    /// (subnet-broadcast detection needs the parser's interface snapshot).
+    pub local_addr_kind: AddrKind,
+    pub remote_addr_kind: AddrKind,
     pub tcp_header: Option<TcpHeaderInfo>, // TCP header info (seq, ack, window, flags)
     pub protocol_state: ProtocolState,
     pub is_outgoing: bool,
@@ -125,6 +129,9 @@ impl ParserConfig {
 /// Packet parser with a refreshable snapshot of the host's local addresses.
 pub struct PacketParser {
     local_ips: std::collections::HashSet<IpAddr>,
+    /// Subnet-directed broadcast addresses of the host's IPv4 networks,
+    /// refreshed together with `local_ips`.
+    v4_broadcasts: std::collections::HashSet<Ipv4Addr>,
     last_local_ip_refresh: Instant,
     last_ambiguous_endpoint_refresh: Option<Instant>,
     unchanged_ambiguous_refreshes: u32,
@@ -143,20 +150,14 @@ impl PacketParser {
     /// Create a new packet parser with default configuration
     /// Automatically detects local IP addresses from network interfaces
     pub fn new() -> Self {
-        Self {
-            local_ips: collect_local_ips(),
-            last_local_ip_refresh: Instant::now(),
-            last_ambiguous_endpoint_refresh: None,
-            unchanged_ambiguous_refreshes: 0,
-            config: ParserConfig::default(),
-            linktype: None,
-            oui_lookup: None,
-        }
+        Self::with_config(ParserConfig::default())
     }
 
     pub fn with_config(config: ParserConfig) -> Self {
+        let local = collect_local_addresses();
         Self {
-            local_ips: collect_local_ips(),
+            local_ips: local.ips,
+            v4_broadcasts: local.v4_broadcasts,
             last_local_ip_refresh: Instant::now(),
             last_ambiguous_endpoint_refresh: None,
             unchanged_ambiguous_refreshes: 0,
@@ -207,7 +208,7 @@ impl PacketParser {
     /// rotation do not leave endpoint orientation stale for the lifetime of
     /// the process.
     pub fn refresh_local_ips(&mut self) -> bool {
-        self.refresh_local_ips_with(collect_local_ips)
+        self.refresh_local_ips_with(collect_local_addresses)
     }
 
     /// Refresh the local-address snapshot once `interval` has elapsed.
@@ -226,11 +227,42 @@ impl PacketParser {
     /// by unrelated forwarded traffic are rate-limited with exponential
     /// backoff while they keep observing no change.
     pub fn parse_packet_with_refresh(&mut self, data: &[u8]) -> Option<ParsedPacket> {
-        self.parse_packet_with_local_ip_collector(data, collect_local_ips)
+        self.parse_packet_with_local_ip_collector(data, collect_local_addresses)
+    }
+
+    /// Classify an endpoint address against the current interface snapshot.
+    fn classify_addr(&self, ip: IpAddr) -> AddrKind {
+        match ip {
+            IpAddr::V4(v4) if v4.is_multicast() => AddrKind::Multicast,
+            IpAddr::V4(v4) if v4 == Ipv4Addr::BROADCAST || self.v4_broadcasts.contains(&v4) => {
+                AddrKind::Broadcast
+            }
+            IpAddr::V6(v6) if v6.is_multicast() => AddrKind::Multicast,
+            _ => AddrKind::Unicast,
+        }
+    }
+
+    /// Whether `ip` can plausibly be a local unicast endpoint. Subnet-directed
+    /// broadcasts are recognized via the interface prefix snapshot, so they do
+    /// not trigger ambiguous-endpoint interface re-enumeration.
+    fn is_unicast_endpoint(&self, ip: IpAddr) -> bool {
+        !ip.is_unspecified() && self.classify_addr(ip) == AddrKind::Unicast
+    }
+
+    /// Parse a raw packet and stamp both endpoint address kinds.
+    ///
+    /// The kinds are stamped here, at the single chokepoint every link-layer
+    /// path funnels through, because subnet-broadcast detection needs this
+    /// parser's interface snapshot.
+    pub fn parse_packet(&self, data: &[u8]) -> Option<ParsedPacket> {
+        let mut parsed = self.parse_packet_link_layer(data)?;
+        parsed.local_addr_kind = self.classify_addr(parsed.local_addr.ip());
+        parsed.remote_addr_kind = self.classify_addr(parsed.remote_addr.ip());
+        Some(parsed)
     }
 
     /// Parse a raw packet using the appropriate link-layer parser
-    pub fn parse_packet(&self, data: &[u8]) -> Option<ParsedPacket> {
+    fn parse_packet_link_layer(&self, data: &[u8]) -> Option<ParsedPacket> {
         if let Some(linktype) = self.linktype {
             // Determine the link layer type
             let link_type = link_layer::LinkLayerType::from_dlt(linktype);
@@ -284,7 +316,7 @@ impl PacketParser {
         collector: F,
     ) -> Option<ParsedPacket>
     where
-        F: FnOnce() -> std::collections::HashSet<IpAddr>,
+        F: FnOnce() -> LocalAddresses,
     {
         let parsed = self.parse_packet(data)?;
         let local_ip = parsed.local_addr.ip();
@@ -292,8 +324,8 @@ impl PacketParser {
 
         if self.local_ips.contains(&local_ip)
             || self.local_ips.contains(&remote_ip)
-            || !is_unicast_endpoint(local_ip)
-            || !is_unicast_endpoint(remote_ip)
+            || !self.is_unicast_endpoint(local_ip)
+            || !self.is_unicast_endpoint(remote_ip)
         {
             return Some(parsed);
         }
@@ -318,11 +350,12 @@ impl PacketParser {
 
     /// Interval between ambiguous-endpoint refresh attempts.
     ///
-    /// Sustained traffic with no local endpoint (e.g. subnet-directed
-    /// broadcasts, which `is_unicast_endpoint` cannot recognize without prefix
-    /// information, or mirrored traffic) would otherwise re-enumerate
-    /// interfaces every second forever, so each fruitless refresh doubles the
-    /// interval up to a cap. Any refresh that observes a change resets it.
+    /// Sustained traffic with no local endpoint (e.g. mirrored or forwarded
+    /// traffic) would otherwise re-enumerate interfaces every second forever,
+    /// so each fruitless refresh doubles the interval up to a cap. Any refresh
+    /// that observes a change resets it. Subnet-directed broadcasts are
+    /// recognized by `is_unicast_endpoint` via the interface prefix snapshot
+    /// and never reach this path.
     fn ambiguous_refresh_interval(&self) -> Duration {
         let factor = 1u32 << self.unchanged_ambiguous_refreshes.min(6);
         AMBIGUOUS_ENDPOINT_REFRESH_INTERVAL
@@ -332,20 +365,21 @@ impl PacketParser {
 
     fn refresh_local_ips_with<F>(&mut self, collector: F) -> bool
     where
-        F: FnOnce() -> std::collections::HashSet<IpAddr>,
+        F: FnOnce() -> LocalAddresses,
     {
         let refreshed = collector();
         self.last_local_ip_refresh = Instant::now();
-        if refreshed == self.local_ips {
+        if refreshed.ips == self.local_ips && refreshed.v4_broadcasts == self.v4_broadcasts {
             return false;
         }
 
         log::debug!(
             "Local address set changed: {} -> {} address(es)",
             self.local_ips.len(),
-            refreshed.len()
+            refreshed.ips.len()
         );
-        self.local_ips = refreshed;
+        self.local_ips = refreshed.ips;
+        self.v4_broadcasts = refreshed.v4_broadcasts;
         self.unchanged_ambiguous_refreshes = 0;
         true
     }
@@ -638,6 +672,9 @@ impl PacketParser {
             protocol: Protocol::Arp,
             local_addr,
             remote_addr,
+            // Overwritten centrally in PacketParser::parse_packet
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
             tcp_header: None,
             protocol_state: ProtocolState::Arp(arp_info),
             is_outgoing,
@@ -861,13 +898,6 @@ impl PacketParser {
     }
 }
 
-fn is_unicast_endpoint(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(ip) => !ip.is_unspecified() && !ip.is_multicast() && ip != Ipv4Addr::BROADCAST,
-        IpAddr::V6(ip) => !ip.is_unspecified() && !ip.is_multicast(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -905,6 +935,17 @@ mod tests {
             0x45, 0x00, 0x00, 0x20, 0x00, 0x01, 0x00, 0x00, 0x40, 0x11, 0x00, 0x00, 192, 168, 1,
             100, 8, 8, 8, 8, // UDP
             0x04, 0xd2, 0x00, 0x35, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04,
+        ]
+    }
+
+    fn ethernet_ipv4_udp(src: [u8; 4], dst: [u8; 4]) -> Vec<u8> {
+        vec![
+            // Ethernet
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x08, 0x00,
+            // IPv4
+            0x45, 0x00, 0x00, 0x20, 0x00, 0x01, 0x00, 0x00, 0x40, 0x11, 0x00, 0x00, src[0], src[1],
+            src[2], src[3], dst[0], dst[1], dst[2], dst[3], // UDP: 60236 -> 51234
+            0xeb, 0x4c, 0xc8, 0x22, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04,
         ]
     }
 
@@ -1112,6 +1153,85 @@ mod tests {
     }
 
     #[test]
+    fn classify_addr_recognizes_broadcast_and_multicast() {
+        let mut parser = create_parser_with_linktype(1);
+        parser.v4_broadcasts.insert(Ipv4Addr::new(192, 168, 1, 255));
+
+        assert_eq!(
+            parser.classify_addr(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255))),
+            AddrKind::Broadcast,
+            "subnet-directed broadcast from the interface snapshot"
+        );
+        assert_eq!(
+            parser.classify_addr(IpAddr::V4(Ipv4Addr::BROADCAST)),
+            AddrKind::Broadcast
+        );
+        assert_eq!(
+            parser.classify_addr(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 251))),
+            AddrKind::Multicast
+        );
+        assert_eq!(
+            parser.classify_addr(IpAddr::V6(
+                "ff02::fb".parse().expect("valid fixture address")
+            )),
+            AddrKind::Multicast
+        );
+        assert_eq!(
+            parser.classify_addr(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 254))),
+            AddrKind::Unicast,
+            "adjacent host must not be mistaken for the broadcast address"
+        );
+        assert_eq!(
+            parser.classify_addr(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))),
+            AddrKind::Unicast
+        );
+    }
+
+    #[test]
+    fn incoming_subnet_broadcast_is_stamped_and_skips_refresh() {
+        use std::cell::Cell;
+
+        let mut parser = create_parser_with_linktype(1);
+        parser.v4_broadcasts.insert(Ipv4Addr::new(192, 168, 1, 255));
+        // Peer -> subnet broadcast; neither endpoint is a local unicast address
+        let packet = ethernet_ipv4_udp([192, 168, 1, 52], [192, 168, 1, 255]);
+        let collector_calls = Cell::new(0u32);
+
+        let parsed = parser
+            .parse_packet_with_local_ip_collector(&packet, || {
+                collector_calls.set(collector_calls.get() + 1);
+                LocalAddresses::default()
+            })
+            .expect("packet should parse");
+
+        assert_eq!(
+            parsed.local_addr.ip(),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255))
+        );
+        assert_eq!(parsed.local_addr_kind, AddrKind::Broadcast);
+        assert_eq!(parsed.remote_addr_kind, AddrKind::Unicast);
+        assert_eq!(
+            collector_calls.get(),
+            0,
+            "a recognized subnet broadcast must not re-enumerate interfaces"
+        );
+    }
+
+    #[test]
+    fn outgoing_broadcast_marks_the_remote_side() {
+        let mut parser = create_parser_with_linktype(1);
+        parser.v4_broadcasts.insert(Ipv4Addr::new(192, 168, 1, 255));
+        // The local host (192.168.1.100) sends to the subnet broadcast
+        let packet = ethernet_ipv4_udp([192, 168, 1, 100], [192, 168, 1, 255]);
+
+        let parsed = parser.parse_packet(&packet).expect("packet should parse");
+
+        assert!(parsed.is_outgoing);
+        assert_eq!(parsed.local_addr_kind, AddrKind::Unicast);
+        assert_eq!(parsed.remote_addr_kind, AddrKind::Broadcast);
+    }
+
+    #[test]
     fn ambiguous_ipv6_packet_refreshes_local_addresses_and_reorients_endpoints() {
         let mut parser = create_parser_with_linktype(1);
         parser.local_ips.clear();
@@ -1126,13 +1246,11 @@ mod tests {
         let new_local = IpAddr::V6("2001:db8::1".parse().expect("valid fixture address"));
         let corrected = parser
             .parse_packet_with_local_ip_collector(&packet, || {
-                [
+                LocalAddresses::from_ips([
                     IpAddr::V4(Ipv4Addr::LOCALHOST),
                     IpAddr::V6(Ipv6Addr::LOCALHOST),
                     new_local,
-                ]
-                .into_iter()
-                .collect()
+                ])
             })
             .expect("packet should be reparsed");
 
@@ -1149,7 +1267,7 @@ mod tests {
         let new = IpAddr::V6("2001:db8::2".parse().expect("valid new address"));
         parser.local_ips = [old].into_iter().collect();
 
-        assert!(parser.refresh_local_ips_with(|| [new].into_iter().collect()));
+        assert!(parser.refresh_local_ips_with(|| LocalAddresses::from_ips([new])));
         assert!(!parser.local_ips.contains(&old));
         assert!(parser.local_ips.contains(&new));
     }
@@ -1165,7 +1283,7 @@ mod tests {
         let collector_calls = Cell::new(0u32);
         let unchanged_collector = || {
             collector_calls.set(collector_calls.get() + 1);
-            [IpAddr::V4(Ipv4Addr::LOCALHOST)].into_iter().collect()
+            LocalAddresses::from_ips([IpAddr::V4(Ipv4Addr::LOCALHOST)])
         };
 
         parser
@@ -1197,7 +1315,7 @@ mod tests {
         );
 
         let new = IpAddr::V6("2001:db8::99".parse().expect("valid address"));
-        assert!(parser.refresh_local_ips_with(|| [new].into_iter().collect()));
+        assert!(parser.refresh_local_ips_with(|| LocalAddresses::from_ips([new])));
         assert_eq!(
             parser.unchanged_ambiguous_refreshes, 0,
             "a refresh that observes a change must reset the backoff"

--- a/crates/rustnet-core/src/network/protocol/icmp.rs
+++ b/crates/rustnet-core/src/network/protocol/icmp.rs
@@ -3,7 +3,7 @@
 
 use crate::network::parser::ParsedPacket;
 use crate::network::protocol::TransportParams;
-use crate::network::types::{Protocol, ProtocolState};
+use crate::network::types::{AddrKind, Protocol, ProtocolState};
 use std::net::SocketAddr;
 
 /// Parse an ICMP (IPv4) packet
@@ -44,6 +44,9 @@ pub fn parse(
         protocol: Protocol::Icmp,
         local_addr,
         remote_addr,
+        // Overwritten centrally in PacketParser::parse_packet
+        local_addr_kind: AddrKind::Unicast,
+        remote_addr_kind: AddrKind::Unicast,
         tcp_header: None,
         protocol_state: ProtocolState::Icmp { icmp_type, icmp_id },
         is_outgoing,
@@ -92,6 +95,9 @@ pub fn parse_v6(
         protocol: Protocol::Icmp,
         local_addr,
         remote_addr,
+        // Overwritten centrally in PacketParser::parse_packet
+        local_addr_kind: AddrKind::Unicast,
+        remote_addr_kind: AddrKind::Unicast,
         tcp_header: None,
         protocol_state: ProtocolState::Icmp { icmp_type, icmp_id },
         is_outgoing,

--- a/crates/rustnet-core/src/network/protocol/igmp.rs
+++ b/crates/rustnet-core/src/network/protocol/igmp.rs
@@ -2,7 +2,7 @@
 
 use crate::network::parser::ParsedPacket;
 use crate::network::protocol::TransportParams;
-use crate::network::types::{Protocol, ProtocolState};
+use crate::network::types::{AddrKind, Protocol, ProtocolState};
 use std::net::{Ipv4Addr, SocketAddr};
 
 /// Parse an IGMP packet
@@ -62,6 +62,9 @@ pub fn parse(
         protocol: Protocol::Igmp,
         local_addr,
         remote_addr,
+        // Overwritten centrally in PacketParser::parse_packet
+        local_addr_kind: AddrKind::Unicast,
+        remote_addr_kind: AddrKind::Unicast,
         tcp_header: None,
         protocol_state: ProtocolState::Igmp {
             igmp_type,

--- a/crates/rustnet-core/src/network/protocol/tcp.rs
+++ b/crates/rustnet-core/src/network/protocol/tcp.rs
@@ -3,7 +3,7 @@
 use crate::network::dpi;
 use crate::network::parser::{ParsedPacket, ParserConfig};
 use crate::network::protocol::TransportParams;
-use crate::network::types::{Protocol, ProtocolState, TcpState};
+use crate::network::types::{AddrKind, Protocol, ProtocolState, TcpState};
 use std::net::SocketAddr;
 
 // Define TCP flags as bit masks
@@ -139,6 +139,9 @@ pub fn parse(
         protocol: Protocol::Tcp,
         local_addr,
         remote_addr,
+        // Overwritten centrally in PacketParser::parse_packet
+        local_addr_kind: AddrKind::Unicast,
+        remote_addr_kind: AddrKind::Unicast,
         tcp_header: Some(tcp_header),
         protocol_state: ProtocolState::Tcp(TcpState::Unknown),
         is_outgoing,

--- a/crates/rustnet-core/src/network/protocol/udp.rs
+++ b/crates/rustnet-core/src/network/protocol/udp.rs
@@ -3,7 +3,7 @@
 use crate::network::dpi;
 use crate::network::parser::{ParsedPacket, ParserConfig};
 use crate::network::protocol::TransportParams;
-use crate::network::types::{Protocol, ProtocolState};
+use crate::network::types::{AddrKind, Protocol, ProtocolState};
 use std::net::SocketAddr;
 
 /// Parse a UDP packet
@@ -47,6 +47,9 @@ pub fn parse(
         protocol: Protocol::Udp,
         local_addr,
         remote_addr,
+        // Overwritten centrally in PacketParser::parse_packet
+        local_addr_kind: AddrKind::Unicast,
+        remote_addr_kind: AddrKind::Unicast,
         tcp_header: None,
         protocol_state: ProtocolState::Udp,
         is_outgoing,

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -867,13 +867,15 @@ mod tests {
 
     fn tcp_packet(syn: bool, ack: bool, fin: bool, rst: bool, is_outgoing: bool) -> ParsedPacket {
         use crate::network::protocol::tcp::{TcpFlags, TcpHeaderInfo};
-        use crate::network::types::{ProtocolState, TcpState};
+        use crate::network::types::{AddrKind, ProtocolState, TcpState};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         ParsedPacket {
             protocol: Protocol::Tcp,
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
             protocol_state: ProtocolState::Tcp(TcpState::Unknown),
             tcp_header: Some(TcpHeaderInfo {
                 seq: 1_000,
@@ -899,7 +901,7 @@ mod tests {
 
     fn quic_packet(packet_type: QuicPacketType, is_outgoing: bool) -> ParsedPacket {
         use crate::network::dpi::DpiResult;
-        use crate::network::types::{ProtocolState, QuicInfo};
+        use crate::network::types::{AddrKind, ProtocolState, QuicInfo};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         let mut quic = QuicInfo::new(1);
@@ -909,6 +911,8 @@ mod tests {
             protocol: Protocol::Udp,
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
             protocol_state: ProtocolState::Udp,
             tcp_header: None,
             is_outgoing,
@@ -923,13 +927,15 @@ mod tests {
 
     fn dns_packet(txid: u16, is_outgoing: bool, is_response: bool, rcode: u8) -> ParsedPacket {
         use crate::network::dpi::DpiResult;
-        use crate::network::types::{DnsInfo, DnsQueryType, ProtocolState};
+        use crate::network::types::{AddrKind, DnsInfo, DnsQueryType, ProtocolState};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         ParsedPacket {
             protocol: Protocol::Udp,
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 53),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
             protocol_state: ProtocolState::Udp,
             tcp_header: None,
             is_outgoing,

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -2524,12 +2524,41 @@ pub struct K8sInfo {
     pub cgroup_path: Option<String>,
 }
 
+/// Classification of a connection endpoint address. `Broadcast` covers both
+/// the limited broadcast (255.255.255.255) and subnet-directed broadcasts
+/// (e.g. 192.168.0.255 on a /24), which require interface prefix knowledge
+/// and are therefore computed by the packet parser, not derivable from the
+/// address alone. IPv6 has no broadcast, only multicast.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AddrKind {
+    #[default]
+    Unicast,
+    Broadcast,
+    Multicast,
+}
+
+impl AddrKind {
+    /// Stable lowercase token for JSON log output.
+    pub fn as_token(self) -> &'static str {
+        match self {
+            AddrKind::Unicast => "unicast",
+            AddrKind::Broadcast => "broadcast",
+            AddrKind::Multicast => "multicast",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Connection {
     // Core identification
     pub protocol: Protocol,
     pub local_addr: SocketAddr,
     pub remote_addr: SocketAddr,
+    /// Kind of the local endpoint address. Broadcast/multicast flows keep the
+    /// group/broadcast address on the local side when the sender is a peer;
+    /// this field lets the UI render that intentionally.
+    pub local_addr_kind: AddrKind,
+    pub remote_addr_kind: AddrKind,
 
     // Protocol state
     pub protocol_state: ProtocolState,
@@ -2639,6 +2668,8 @@ impl Connection {
             protocol,
             local_addr,
             remote_addr,
+            local_addr_kind: AddrKind::default(),
+            remote_addr_kind: AddrKind::default(),
             protocol_state: state,
             pid: None,
             process_ppid: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,8 +34,8 @@ use crate::network::{
     services::ServiceLookup,
     tracker::{ConnectionTracker, IngestOutcome},
     types::{
-        ApplicationProtocol, Connection, ConnectionKey, ConnectionLifecycleSample, DnsQueryType,
-        GraphScale, ProcessLineage, Protocol, TrafficHistory,
+        AddrKind, ApplicationProtocol, Connection, ConnectionKey, ConnectionLifecycleSample,
+        DnsQueryType, GraphScale, ProcessLineage, Protocol, TrafficHistory,
     },
 };
 
@@ -342,6 +342,15 @@ fn log_connection_event(
         "destination_port": conn.remote_addr.port(),
     });
 
+    // Only emitted for broadcast/multicast endpoints, keeping unicast events
+    // (and consumers of older logs) unchanged.
+    if conn.local_addr_kind != AddrKind::Unicast {
+        event["source_addr_kind"] = json!(conn.local_addr_kind.as_token());
+    }
+    if conn.remote_addr_kind != AddrKind::Unicast {
+        event["destination_addr_kind"] = json!(conn.remote_addr_kind.as_token());
+    }
+
     // Add hostname fields if DNS resolution is enabled and hostnames are resolved
     // Skip ARP connections to avoid feedback loop (DNS lookups generate ARP traffic)
     if let Some(resolver) = dns_resolver.filter(|_| conn.protocol != Protocol::Arp) {
@@ -508,6 +517,15 @@ fn log_pcap_connection(writer: &JsonLineWriter, conn: &Connection) {
         "bytes_received": conn.bytes_received,
         "state": conn.state(),
     });
+
+    // Only emitted for broadcast/multicast endpoints, keeping unicast records
+    // (and consumers of older sidecar files) unchanged.
+    if conn.local_addr_kind != AddrKind::Unicast {
+        event["local_addr_kind"] = json!(conn.local_addr_kind.as_token());
+    }
+    if conn.remote_addr_kind != AddrKind::Unicast {
+        event["remote_addr_kind"] = json!(conn.remote_addr_kind.as_token());
+    }
 
     // Per-connection record, so the full executable path is affordable here.
     if let Some(ppid) = conn.process_ppid {
@@ -3620,7 +3638,7 @@ mod connection_lifecycle_tests {
     use super::*;
     use crate::network::{
         protocol::tcp::{TcpFlags, TcpHeaderInfo},
-        types::{ProtocolState, TcpState},
+        types::{AddrKind, ProtocolState, TcpState},
     };
     use std::net::SocketAddr;
     use std::path::{Path, PathBuf};
@@ -3655,6 +3673,8 @@ mod connection_lifecycle_tests {
             protocol: Protocol::Tcp,
             local_addr: SocketAddr::from(([192, 0, 2, 1], 40_000)),
             remote_addr: SocketAddr::from(([198, 51, 100, 1], 443)),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
             tcp_header: Some(TcpHeaderInfo {
                 seq: 1_000,
                 ack: 0,
@@ -3929,6 +3949,8 @@ mod pcapng_export_tests {
             protocol: Protocol::Tcp,
             local_addr: SocketAddr::from(([192, 0, 2, 9], 41_000)),
             remote_addr: SocketAddr::from(([198, 51, 100, 9], 443)),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
             tcp_header: Some(TcpHeaderInfo {
                 seq: 1,
                 ack: 0,

--- a/src/ui/connection_table.rs
+++ b/src/ui/connection_table.rs
@@ -23,8 +23,10 @@ use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Cell, Row};
 
+use std::net::SocketAddr;
+
 use crate::network::dns::DnsResolver;
-use crate::network::types::{Connection, Protocol};
+use crate::network::types::{AddrKind, Connection, Protocol};
 use crate::ui::{
     NONE_PLACEHOLDER, SortColumn, UIState, dpi_color,
     format::{format_rate_compact, format_rtt_compact},
@@ -238,10 +240,22 @@ fn service_text<'a>(conn: &'a Connection, ui_state: &UIState) -> Cow<'a, str> {
     }
 }
 
+/// Table cell for an endpoint: broadcast/multicast endpoints render as an
+/// intentional label ("bcast:138", "mcast:5353") instead of an address that
+/// reads like a unicast host; the full address stays visible in Details.
+fn endpoint_display(addr: SocketAddr, kind: AddrKind, max_width: usize) -> String {
+    match kind {
+        AddrKind::Broadcast => format!("bcast:{}", addr.port()),
+        AddrKind::Multicast => format!("mcast:{}", addr.port()),
+        AddrKind::Unicast => truncate_with_ellipsis(&addr.to_string(), max_width),
+    }
+}
+
 /// Remote address (or resolved hostname) with port, fitted to
 /// `max_width` cells. Hostnames keep their port visible when cut
 /// ("host…:443"); raw addresses only ellipsize as a last resort at
-/// very narrow widths.
+/// very narrow widths. Broadcast/multicast endpoints render as labels
+/// and skip hostname resolution.
 fn remote_display(
     conn: &Connection,
     ui_state: &UIState,
@@ -250,6 +264,7 @@ fn remote_display(
 ) -> String {
     if ui_state.show_hostnames
         && conn.protocol != Protocol::Arp
+        && conn.remote_addr_kind == AddrKind::Unicast
         && let Some(resolver) = dns_resolver
         && let Some(hostname) = resolver.get_hostname(&conn.remote_addr.ip())
     {
@@ -263,7 +278,7 @@ fn remote_display(
             full
         }
     } else {
-        truncate_with_ellipsis(&conn.remote_addr.to_string(), max_width)
+        endpoint_display(conn.remote_addr, conn.remote_addr_kind, max_width)
     }
 }
 
@@ -409,8 +424,9 @@ pub(in crate::ui) fn connection_row<'a>(
                 col.width as usize,
             ))
             .style(style_if_colored(theme::field_remote_addr())),
-            ColumnId::Local => Cell::from(truncate_with_ellipsis(
-                &conn.local_addr.to_string(),
+            ColumnId::Local => Cell::from(endpoint_display(
+                conn.local_addr,
+                conn.local_addr_kind,
                 col.width as usize,
             ))
             .style(style_if_colored(theme::field_local_addr())),
@@ -739,6 +755,42 @@ mod tests {
         let narrow = remote_display(&conn, &ui_state, None, REMOTE_MIN_WIDTH as usize);
         assert_eq!(narrow.chars().count(), REMOTE_MIN_WIDTH as usize);
         assert!(narrow.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn endpoint_display_labels_broadcast_and_multicast() {
+        let bcast: SocketAddr = "192.168.0.255:138".parse().unwrap();
+        assert_eq!(
+            endpoint_display(bcast, AddrKind::Broadcast, 18),
+            "bcast:138"
+        );
+
+        let mcast: SocketAddr = "224.0.0.251:5353".parse().unwrap();
+        assert_eq!(
+            endpoint_display(mcast, AddrKind::Multicast, 18),
+            "mcast:5353"
+        );
+
+        let unicast: SocketAddr = "192.168.0.52:60236".parse().unwrap();
+        assert_eq!(
+            endpoint_display(unicast, AddrKind::Unicast, 18),
+            "192.168.0.52:60236"
+        );
+        assert!(endpoint_display(unicast, AddrKind::Unicast, 10).ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn remote_display_labels_multicast_instead_of_resolving_hostnames() {
+        let mut conn = Connection::new(
+            Protocol::Udp,
+            "192.168.0.132:5353".parse().unwrap(),
+            "224.0.0.251:5353".parse().unwrap(),
+            ProtocolState::Udp,
+        );
+        conn.remote_addr_kind = AddrKind::Multicast;
+        let ui_state = UIState::default();
+
+        assert_eq!(remote_display(&conn, &ui_state, None, 24), "mcast:5353");
     }
 
     #[test]

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -24,7 +24,9 @@ use std::{
 };
 
 use crate::network::dns::DnsResolver;
-use crate::network::types::{Connection, MatchQuality, ProcessLineage, Protocol, ProtocolState};
+use crate::network::types::{
+    AddrKind, Connection, MatchQuality, ProcessLineage, Protocol, ProtocolState,
+};
 use crate::ui::{
     ClickAction, ClickableRegions, Component, ComponentContext, Effect, GroupedRow, HandlerContext,
     NONE_PLACEHOLDER,
@@ -467,6 +469,27 @@ fn format_quic_close(close: &crate::network::types::QuicCloseInfo) -> String {
     format!("{} 0x{:x}", origin, close.error_code)
 }
 
+/// Endpoint address with a broadcast/multicast annotation when the address
+/// is a group or broadcast destination rather than an actual host.
+fn annotated_addr(addr: std::net::SocketAddr, kind: AddrKind) -> String {
+    match kind {
+        AddrKind::Broadcast => format!("{addr} (broadcast)"),
+        AddrKind::Multicast => format!("{addr} (multicast)"),
+        AddrKind::Unicast => addr.to_string(),
+    }
+}
+
+/// Scope of the remote endpoint. `bogon::classify` is stateless and cannot
+/// recognize subnet-directed broadcasts (it would report the private range),
+/// so the connection's parser-derived kind overrides it.
+fn remote_scope(conn: &Connection) -> crate::network::bogon::Scope {
+    if conn.remote_addr_kind == AddrKind::Broadcast {
+        crate::network::bogon::Scope::Broadcast
+    } else {
+        crate::network::bogon::classify(conn.remote_addr.ip())
+    }
+}
+
 /// Push a muted explanatory line into a card. Unlike a field row this carries
 /// no label/value pair, so it registers no click-to-copy target.
 fn push_detail_note<'a>(
@@ -845,7 +868,7 @@ pub(in crate::ui) fn draw_connection_details(
         &mut details_text,
         &mut detail_fields,
         "Local Address",
-        conn.local_addr.to_string(),
+        annotated_addr(conn.local_addr, conn.local_addr_kind),
         label_style,
         theme::fg(theme::field_local_addr()),
     );
@@ -853,7 +876,7 @@ pub(in crate::ui) fn draw_connection_details(
         &mut details_text,
         &mut detail_fields,
         "Remote Address",
-        conn.remote_addr.to_string(),
+        annotated_addr(conn.remote_addr, conn.remote_addr_kind),
         label_style,
         theme::fg(theme::field_remote_addr()),
     );
@@ -861,9 +884,7 @@ pub(in crate::ui) fn draw_connection_details(
         &mut details_text,
         &mut detail_fields,
         "Scope",
-        crate::network::bogon::classify(conn.remote_addr.ip())
-            .label()
-            .to_string(),
+        remote_scope(conn).label().to_string(),
         label_style,
         theme::fg(theme::field_remote_addr()),
     );
@@ -2608,5 +2629,45 @@ mod path_shortening_tests {
             super::account_name_from_buffer(unterminated.as_ptr(), &unterminated),
             None
         );
+    }
+}
+
+#[cfg(test)]
+mod endpoint_annotation_tests {
+    use super::{annotated_addr, remote_scope};
+    use crate::network::bogon::Scope;
+    use crate::network::types::{AddrKind, Connection, Protocol, ProtocolState};
+
+    #[test]
+    fn addresses_are_annotated_by_kind() {
+        let addr = "192.168.0.255:51234".parse().unwrap();
+        assert_eq!(
+            annotated_addr(addr, AddrKind::Broadcast),
+            "192.168.0.255:51234 (broadcast)"
+        );
+        let addr = "224.0.0.251:5353".parse().unwrap();
+        assert_eq!(
+            annotated_addr(addr, AddrKind::Multicast),
+            "224.0.0.251:5353 (multicast)"
+        );
+        let addr = "192.168.0.52:60236".parse().unwrap();
+        assert_eq!(
+            annotated_addr(addr, AddrKind::Unicast),
+            "192.168.0.52:60236"
+        );
+    }
+
+    #[test]
+    fn scope_reports_broadcast_for_subnet_directed_remote() {
+        let mut conn = Connection::new(
+            Protocol::Udp,
+            "192.168.0.132:138".parse().unwrap(),
+            "192.168.0.255:138".parse().unwrap(),
+            ProtocolState::Udp,
+        );
+        // Stateless classification alone would report the private range.
+        assert_eq!(remote_scope(&conn), Scope::Private);
+        conn.remote_addr_kind = AddrKind::Broadcast;
+        assert_eq!(remote_scope(&conn), Scope::Broadcast);
     }
 }


### PR DESCRIPTION
- Incoming broadcasts (e.g. peer to 192.168.0.255) showed the broadcast address as a normal-looking Local host; endpoints now render as `bcast:PORT` / `mcast:PORT` in Overview and are annotated in Details
- Collect interface prefixes to recognize subnet-directed broadcasts; Scope reports BROADCAST instead of PRIVATE and such packets no longer trigger interface re-enumeration
- JSONL logs gain addr-kind keys, emitted only for non-unicast endpoints