### PR TITLE
Mark connections to the default gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for non-unicast endpoints
 
 ### Added
+- **Default Gateway Marker**: Connections whose remote endpoint is the host's
+  default gateway (the local router) are now marked. The Overview Remote
+  column appends `(gw)` when it fits, the Details tab annotates the remote
+  address with `(gateway)`, and JSONL logs gain `remote_is_gateway` (sidecar)
+  and `destination_is_gateway` (event log) keys, emitted only when true.
+  Gateways are read from the OS routing table (`/proc/net/route` and
+  `/proc/net/ipv6_route` on Linux, a `PF_ROUTE` sysctl dump on macOS/FreeBSD,
+  `GetIpForwardTable2` on Windows) and refreshed with the local-address
+  snapshot, so VPN or network changes are picked up
 - **NTP RTT**: NTP client connections now show the latest request→response
   round trip in the Details Transport Health card, along with the server
   stratum. Polls pair with responses through the originate timestamp echo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,6 +2657,7 @@ dependencies = [
  "dashmap",
  "dns-lookup",
  "flate2",
+ "libc",
  "log",
  "maxminddb",
  "pnet_datalink",

--- a/benches/connection_merge.rs
+++ b/benches/connection_merge.rs
@@ -36,6 +36,7 @@ fn make_parsed_packet() -> rustnet_monitor::network::parser::ParsedPacket {
         remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
         local_addr_kind: AddrKind::Unicast,
         remote_addr_kind: AddrKind::Unicast,
+        remote_is_gateway: false,
         tcp_header: Some(TcpHeaderInfo {
             seq: 1000,
             ack: 2000,

--- a/benches/tracker_ingest.rs
+++ b/benches/tracker_ingest.rs
@@ -18,6 +18,7 @@ fn make_packet(flow: u16, seq: u32) -> ParsedPacket {
         remote_addr,
         local_addr_kind: AddrKind::Unicast,
         remote_addr_kind: AddrKind::Unicast,
+        remote_is_gateway: false,
         tcp_header: Some(TcpHeaderInfo {
             seq,
             ack: seq.wrapping_add(1),

--- a/crates/rustnet-core/Cargo.toml
+++ b/crates/rustnet-core/Cargo.toml
@@ -30,6 +30,9 @@ flate2 = "1"
 ring = "0.17"
 aes = "0.9"
 
+[target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = [
     "Win32_Foundation",

--- a/crates/rustnet-core/src/network/gateway.rs
+++ b/crates/rustnet-core/src/network/gateway.rs
@@ -1,0 +1,598 @@
+//! Default-gateway discovery from the operating system's routing table.
+//!
+//! Supplies the next-hop addresses of the host's default routes so the parser
+//! can mark connections whose remote endpoint is the local router. Platform
+//! sources: `/proc/net/route` and `/proc/net/ipv6_route` on Linux, a
+//! `PF_ROUTE` sysctl dump on macOS/FreeBSD, and `GetIpForwardTable2` on
+//! Windows. Failures degrade to an empty set, so the gateway marker simply
+//! disappears rather than affecting capture.
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    windows,
+    test
+))]
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Log a route-table read failure at warn level once and at debug level on
+/// repeats, so a persistent failure is visible without repeating every
+/// refresh interval.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    windows
+))]
+fn log_failure(logged: &std::sync::atomic::AtomicBool, message: &str) {
+    if logged.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        log::debug!("{message}");
+    } else {
+        log::warn!("{message}");
+    }
+}
+
+/// `RTF_UP | RTF_GATEWAY` in the `/proc/net/route` flag encoding.
+#[cfg(any(target_os = "linux", test))]
+const PROC_RTF_UP_GATEWAY: u32 = 0x3;
+
+#[cfg(target_os = "linux")]
+pub(crate) fn default_gateways() -> HashSet<IpAddr> {
+    static FAILURE_LOGGED: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    let mut gateways = HashSet::new();
+    match std::fs::read_to_string("/proc/net/route") {
+        Ok(contents) => gateways.extend(parse_proc_route(&contents).map(IpAddr::V4)),
+        Err(err) => log_failure(
+            &FAILURE_LOGGED,
+            &format!("reading /proc/net/route failed: {err}; gateway detection disabled"),
+        ),
+    }
+    // Absent when IPv6 is disabled; not a failure worth warning about.
+    if let Ok(contents) = std::fs::read_to_string("/proc/net/ipv6_route") {
+        gateways.extend(parse_proc_ipv6_route(&contents).map(IpAddr::V6));
+    }
+    gateways
+}
+
+/// Gateways of default routes in `/proc/net/route` contents. Columns are
+/// Iface, Destination, Gateway, Flags, RefCnt, Use, Metric, Mask, ...; the
+/// address fields are little-endian hex.
+#[cfg(any(target_os = "linux", test))]
+fn parse_proc_route(contents: &str) -> impl Iterator<Item = Ipv4Addr> + '_ {
+    contents.lines().skip(1).filter_map(|line| {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        let (dest, gateway, flags, mask) = (
+            fields.get(1)?,
+            fields.get(2)?,
+            fields.get(3)?,
+            fields.get(7)?,
+        );
+        if *dest != "00000000" || *mask != "00000000" {
+            return None;
+        }
+        let flags = u32::from_str_radix(flags, 16).ok()?;
+        if flags & PROC_RTF_UP_GATEWAY != PROC_RTF_UP_GATEWAY {
+            return None;
+        }
+        // Little-endian: "0100A8C0" is 192.168.0.1.
+        let gateway = Ipv4Addr::from(u32::from_str_radix(gateway, 16).ok()?.to_le_bytes());
+        (!gateway.is_unspecified()).then_some(gateway)
+    })
+}
+
+/// Next hops of default routes in `/proc/net/ipv6_route` contents. Columns
+/// are dest, dest prefix length, source, source prefix length, next hop,
+/// metric, refcnt, use, flags, device; addresses are 32 big-endian hex chars.
+#[cfg(any(target_os = "linux", test))]
+fn parse_proc_ipv6_route(contents: &str) -> impl Iterator<Item = Ipv6Addr> + '_ {
+    contents.lines().filter_map(|line| {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        let (dest, dest_plen, next_hop, flags) = (
+            fields.first()?,
+            fields.get(1)?,
+            fields.get(4)?,
+            fields.get(8)?,
+        );
+        if *dest_plen != "00" || dest.bytes().any(|b| b != b'0') {
+            return None;
+        }
+        let flags = u32::from_str_radix(flags, 16).ok()?;
+        if flags & PROC_RTF_UP_GATEWAY != PROC_RTF_UP_GATEWAY {
+            return None;
+        }
+        let next_hop = parse_hex_ipv6(next_hop)?;
+        (!next_hop.is_unspecified()).then_some(next_hop)
+    })
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_hex_ipv6(hex: &str) -> Option<Ipv6Addr> {
+    if hex.len() != 32 {
+        return None;
+    }
+    let mut octets = [0u8; 16];
+    for (octet, pair) in octets.iter_mut().zip(hex.as_bytes().chunks(2)) {
+        *octet = u8::from_str_radix(std::str::from_utf8(pair).ok()?, 16).ok()?;
+    }
+    Some(Ipv6Addr::from(octets))
+}
+
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+pub(crate) fn default_gateways() -> HashSet<IpAddr> {
+    static FAILURE_LOGGED: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    match route_flags_dump() {
+        Ok(buf) => parse_route_dump(&buf),
+        Err(errno) => {
+            log_failure(
+                &FAILURE_LOGGED,
+                &format!("PF_ROUTE sysctl dump failed (errno {errno}); gateway detection disabled"),
+            );
+            HashSet::new()
+        }
+    }
+}
+
+/// Dump every `RTF_GATEWAY` routing entry via sysctl. Retries with a fresh
+/// size probe when the table grows between the probe and the read.
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn route_flags_dump() -> Result<Vec<u8>, i32> {
+    const MAX_ATTEMPTS: usize = 3;
+    let mut mib = [
+        libc::CTL_NET,
+        libc::PF_ROUTE,
+        0,
+        0, // AF_UNSPEC: all address families
+        libc::NET_RT_FLAGS,
+        libc::RTF_GATEWAY,
+    ];
+
+    for _ in 0..MAX_ATTEMPTS {
+        let mut len: libc::size_t = 0;
+        let probe = unsafe {
+            libc::sysctl(
+                mib.as_mut_ptr(),
+                mib.len() as libc::c_uint,
+                std::ptr::null_mut(),
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if probe != 0 {
+            return Err(last_errno());
+        }
+        if len == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Slack for routes added between the probe and the read.
+        len += len / 2;
+        let mut buf = vec![0u8; len];
+        let read = unsafe {
+            libc::sysctl(
+                mib.as_mut_ptr(),
+                mib.len() as libc::c_uint,
+                buf.as_mut_ptr().cast(),
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if read == 0 {
+            buf.truncate(len);
+            return Ok(buf);
+        }
+        let errno = last_errno();
+        if errno != libc::ENOMEM {
+            return Err(errno);
+        }
+    }
+    Err(libc::ENOMEM)
+}
+
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn last_errno() -> i32 {
+    std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+
+/// Route-message sockaddrs are padded to this alignment; a zero `sa_len`
+/// still occupies one slot.
+#[cfg(target_os = "macos")]
+const SA_ALIGN: usize = 4;
+#[cfg(target_os = "freebsd")]
+const SA_ALIGN: usize = std::mem::size_of::<libc::c_long>();
+
+#[cfg(target_os = "macos")]
+type RtMsgHdr = libc::rt_msghdr;
+#[cfg(target_os = "freebsd")]
+type RtMsgHdr = FreebsdRtMsgHdr;
+
+/// FreeBSD's `struct rt_msghdr` (net/route.h), which the libc crate does not
+/// provide for FreeBSD. Underscore fields exist only to give the struct the
+/// kernel's exact size and offsets.
+#[cfg(target_os = "freebsd")]
+#[repr(C)]
+struct FreebsdRtMsgHdr {
+    rtm_msglen: u16,
+    rtm_version: u8,
+    _rtm_type: u8,
+    _rtm_index: u16,
+    _rtm_spare1: u16,
+    rtm_flags: libc::c_int,
+    rtm_addrs: libc::c_int,
+    _rtm_pid: libc::pid_t,
+    _rtm_seq: libc::c_int,
+    _rtm_errno: libc::c_int,
+    _rtm_fmask: libc::c_int,
+    _rtm_inits: libc::c_ulong,
+    /// `struct rt_metrics`: 14 `u_long` fields on every supported release.
+    _rtm_rmx: [libc::c_ulong; 14],
+}
+
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn sa_advance(sa_len: usize) -> usize {
+    if sa_len == 0 {
+        SA_ALIGN
+    } else {
+        sa_len.div_ceil(SA_ALIGN) * SA_ALIGN
+    }
+}
+
+/// Next-hop addresses of default routes in a `NET_RT_FLAGS` sysctl dump.
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn parse_route_dump(buf: &[u8]) -> HashSet<IpAddr> {
+    let mut gateways = HashSet::new();
+    let header_len = std::mem::size_of::<RtMsgHdr>();
+    let mut offset = 0;
+    while offset + header_len <= buf.len() {
+        let header: RtMsgHdr = unsafe { std::ptr::read_unaligned(buf[offset..].as_ptr().cast()) };
+        let msg_len = header.rtm_msglen as usize;
+        if msg_len < header_len || offset + msg_len > buf.len() {
+            // Malformed or truncated dump; stop rather than misparse.
+            break;
+        }
+        let record = &buf[offset..offset + msg_len];
+        offset += msg_len;
+
+        if header.rtm_version != libc::RTM_VERSION as u8 {
+            continue;
+        }
+        let required_flags = libc::RTF_UP | libc::RTF_GATEWAY;
+        if header.rtm_flags & required_flags != required_flags {
+            continue;
+        }
+        let required_addrs = libc::RTA_DST | libc::RTA_GATEWAY;
+        if header.rtm_addrs & required_addrs != required_addrs {
+            continue;
+        }
+
+        // RTA_DST and RTA_GATEWAY are the two lowest bits, so their sockaddrs
+        // are always the first two in the array following the header.
+        let mut cursor = header_len;
+        let Some((dst, dst_len)) = sockaddr_ip(&record[cursor..]) else {
+            continue;
+        };
+        cursor += sa_advance(dst_len);
+        if cursor >= record.len() {
+            continue;
+        }
+        let Some((gateway, _)) = sockaddr_ip(&record[cursor..]) else {
+            continue;
+        };
+        if dst.is_unspecified() && !gateway.is_unspecified() {
+            gateways.insert(gateway);
+        }
+    }
+    gateways
+}
+
+/// Decode a routing-message sockaddr into its IP address and `sa_len`.
+/// The kernel truncates trailing zero bytes, so short sockaddrs are
+/// zero-padded (a bare `AF_INET` header means 0.0.0.0). Returns `None` for
+/// non-IP families such as `AF_LINK` interface routes.
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn sockaddr_ip(sa: &[u8]) -> Option<(IpAddr, usize)> {
+    let sa_len = *sa.first()? as usize;
+    let family = *sa.get(1)?;
+    let data = &sa[..sa_len.min(sa.len())];
+    if family == libc::AF_INET as u8 {
+        // sockaddr_in: len, family, port (2 bytes), address (4 bytes)
+        let mut octets = [0u8; 4];
+        copy_from(&mut octets, data, 4);
+        Some((IpAddr::V4(Ipv4Addr::from(octets)), sa_len))
+    } else if family == libc::AF_INET6 as u8 {
+        // sockaddr_in6: len, family, port (2), flowinfo (4), address (16)
+        let mut octets = [0u8; 16];
+        copy_from(&mut octets, data, 8);
+        // KAME kernels embed the scope id in bytes 2-3 of link-local
+        // addresses; zero it so the address matches packet addresses.
+        if octets[0] == 0xfe && octets[1] & 0xc0 == 0x80 {
+            octets[2] = 0;
+            octets[3] = 0;
+        }
+        Some((IpAddr::V6(Ipv6Addr::from(octets)), sa_len))
+    } else {
+        None
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn copy_from(dest: &mut [u8], src: &[u8], start: usize) {
+    for (index, byte) in dest.iter_mut().enumerate() {
+        if let Some(value) = src.get(start + index) {
+            *byte = *value;
+        }
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn default_gateways() -> HashSet<IpAddr> {
+    use windows::Win32::Foundation::NO_ERROR;
+    use windows::Win32::NetworkManagement::IpHelper::{
+        FreeMibTable, GetIpForwardTable2, MIB_IPFORWARD_TABLE2,
+    };
+    use windows::Win32::Networking::WinSock::{AF_INET, AF_INET6, AF_UNSPEC};
+
+    static FAILURE_LOGGED: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    let mut gateways = HashSet::new();
+    let mut table: *mut MIB_IPFORWARD_TABLE2 = std::ptr::null_mut();
+    let result = unsafe { GetIpForwardTable2(AF_UNSPEC, &mut table) };
+    if result != NO_ERROR {
+        log_failure(
+            &FAILURE_LOGGED,
+            &format!(
+                "GetIpForwardTable2 failed while collecting default gateways: {}",
+                result.0
+            ),
+        );
+        return gateways;
+    }
+
+    let rows = unsafe {
+        let table = &*table;
+        std::slice::from_raw_parts(table.Table.as_ptr(), table.NumEntries as usize)
+    };
+    for row in rows {
+        if row.DestinationPrefix.PrefixLength != 0 {
+            continue;
+        }
+        let family = unsafe { row.NextHop.si_family };
+        if family == AF_INET {
+            let bytes = unsafe { row.NextHop.Ipv4.sin_addr.S_un.S_un_b };
+            let ip = Ipv4Addr::new(bytes.s_b1, bytes.s_b2, bytes.s_b3, bytes.s_b4);
+            // An unspecified next hop marks an on-link route, not a gateway.
+            if !ip.is_unspecified() {
+                gateways.insert(IpAddr::V4(ip));
+            }
+        } else if family == AF_INET6 {
+            let ip = Ipv6Addr::from(unsafe { row.NextHop.Ipv6.sin6_addr.u.Byte });
+            if !ip.is_unspecified() {
+                gateways.insert(IpAddr::V6(ip));
+            }
+        }
+    }
+    unsafe { FreeMibTable(table.cast()) };
+    gateways
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    windows
+)))]
+pub(crate) fn default_gateways() -> HashSet<IpAddr> {
+    HashSet::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proc_route_default_gateway_is_decoded() {
+        let contents = "Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT\n\
+            eth0\t00000000\t0100A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n\
+            eth0\t0000A8C0\t00000000\t0001\t0\t0\t100\t00FFFFFF\t0\t0\t0\n";
+        assert_eq!(
+            parse_proc_route(contents).collect::<Vec<_>>(),
+            vec![Ipv4Addr::new(192, 168, 0, 1)]
+        );
+    }
+
+    #[test]
+    fn proc_route_skips_down_and_unspecified_gateways() {
+        let contents = "Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT\n\
+            eth0\t00000000\t0100A8C0\t0002\t0\t0\t100\t00000000\t0\t0\t0\n\
+            eth0\t00000000\t00000000\t0003\t0\t0\t100\t00000000\t0\t0\t0\n";
+        assert_eq!(parse_proc_route(contents).count(), 0);
+    }
+
+    #[test]
+    fn proc_ipv6_route_default_next_hop_is_decoded() {
+        let contents = "\
+            00000000000000000000000000000000 00 00000000000000000000000000000000 00 fe800000000000000000000000000001 00000400 00000001 00000000 00000003 eth0\n\
+            20010db8000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000001 00000000 00000001 eth0\n";
+        assert_eq!(
+            parse_proc_ipv6_route(contents).collect::<Vec<_>>(),
+            vec!["fe80::1".parse::<Ipv6Addr>().unwrap()]
+        );
+    }
+
+    #[test]
+    fn proc_ipv6_route_skips_gatewayless_default() {
+        let contents = "00000000000000000000000000000000 00 00000000000000000000000000000000 00 00000000000000000000000000000000 00000400 00000001 00000000 00000001 lo\n";
+        assert_eq!(parse_proc_ipv6_route(contents).count(), 0);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    mod route_dump {
+        use super::super::*;
+
+        fn record(flags: i32, addrs: i32, sockaddrs: &[Vec<u8>]) -> Vec<u8> {
+            let mut body = Vec::new();
+            for sa in sockaddrs {
+                let mut padded = sa.clone();
+                padded.resize(sa_advance(sa[0] as usize), 0);
+                body.extend_from_slice(&padded);
+            }
+
+            let mut header: RtMsgHdr = unsafe { std::mem::zeroed() };
+            header.rtm_msglen = (std::mem::size_of::<RtMsgHdr>() + body.len()) as u16;
+            header.rtm_version = libc::RTM_VERSION as u8;
+            header.rtm_flags = flags;
+            header.rtm_addrs = addrs;
+
+            let mut record = vec![0u8; std::mem::size_of::<RtMsgHdr>()];
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    (&header as *const RtMsgHdr).cast::<u8>(),
+                    record.as_mut_ptr(),
+                    record.len(),
+                );
+            }
+            record.extend_from_slice(&body);
+            record
+        }
+
+        fn sockaddr_v4(addr: Ipv4Addr) -> Vec<u8> {
+            let mut sa = vec![0u8; 16];
+            sa[0] = 16;
+            sa[1] = libc::AF_INET as u8;
+            sa[4..8].copy_from_slice(&addr.octets());
+            sa
+        }
+
+        fn sockaddr_v6(addr: Ipv6Addr) -> Vec<u8> {
+            let mut sa = vec![0u8; 28];
+            sa[0] = 28;
+            sa[1] = libc::AF_INET6 as u8;
+            sa[8..24].copy_from_slice(&addr.octets());
+            sa
+        }
+
+        const UP_GATEWAY: i32 = libc::RTF_UP | libc::RTF_GATEWAY;
+        const DST_GATEWAY: i32 = libc::RTA_DST | libc::RTA_GATEWAY;
+
+        #[test]
+        fn v4_default_route_gateway_is_extracted() {
+            let buf = record(
+                UP_GATEWAY,
+                DST_GATEWAY,
+                &[
+                    sockaddr_v4(Ipv4Addr::UNSPECIFIED),
+                    sockaddr_v4(Ipv4Addr::new(192, 168, 0, 1)),
+                ],
+            );
+            assert_eq!(
+                parse_route_dump(&buf),
+                [IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))].into()
+            );
+        }
+
+        #[test]
+        fn truncated_dst_sockaddr_reads_as_default_route() {
+            // The kernel truncates trailing zero bytes: a bare len+family
+            // sockaddr is how the 0.0.0.0 destination usually arrives.
+            let buf = record(
+                UP_GATEWAY,
+                DST_GATEWAY,
+                &[
+                    vec![2, libc::AF_INET as u8],
+                    sockaddr_v4(Ipv4Addr::new(10, 0, 0, 1)),
+                ],
+            );
+            assert_eq!(
+                parse_route_dump(&buf),
+                [IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))].into()
+            );
+        }
+
+        #[test]
+        fn non_default_destinations_are_skipped() {
+            let buf = record(
+                UP_GATEWAY,
+                DST_GATEWAY,
+                &[
+                    sockaddr_v4(Ipv4Addr::new(10, 0, 0, 0)),
+                    sockaddr_v4(Ipv4Addr::new(192, 168, 0, 1)),
+                ],
+            );
+            assert!(parse_route_dump(&buf).is_empty());
+        }
+
+        #[test]
+        fn link_layer_gateways_are_skipped() {
+            let mut link_sa = vec![0u8; 20];
+            link_sa[0] = 20;
+            link_sa[1] = libc::AF_LINK as u8;
+            let buf = record(
+                UP_GATEWAY,
+                DST_GATEWAY,
+                &[sockaddr_v4(Ipv4Addr::UNSPECIFIED), link_sa],
+            );
+            assert!(parse_route_dump(&buf).is_empty());
+        }
+
+        #[test]
+        fn down_routes_are_skipped() {
+            let buf = record(
+                libc::RTF_GATEWAY,
+                DST_GATEWAY,
+                &[
+                    sockaddr_v4(Ipv4Addr::UNSPECIFIED),
+                    sockaddr_v4(Ipv4Addr::new(192, 168, 0, 1)),
+                ],
+            );
+            assert!(parse_route_dump(&buf).is_empty());
+        }
+
+        #[test]
+        fn v6_link_local_gateway_scope_id_is_zeroed() {
+            let mut scoped = "fe80::1".parse::<Ipv6Addr>().unwrap().octets();
+            scoped[2] = 0x00;
+            scoped[3] = 0x05;
+            let buf = record(
+                UP_GATEWAY,
+                DST_GATEWAY,
+                &[
+                    sockaddr_v6(Ipv6Addr::UNSPECIFIED),
+                    sockaddr_v6(Ipv6Addr::from(scoped)),
+                ],
+            );
+            assert_eq!(
+                parse_route_dump(&buf),
+                ["fe80::1".parse::<IpAddr>().unwrap()].into()
+            );
+        }
+
+        #[test]
+        fn truncated_buffer_does_not_panic() {
+            let buf = record(
+                UP_GATEWAY,
+                DST_GATEWAY,
+                &[
+                    sockaddr_v4(Ipv4Addr::UNSPECIFIED),
+                    sockaddr_v4(Ipv4Addr::new(192, 168, 0, 1)),
+                ],
+            );
+            assert!(parse_route_dump(&buf[..buf.len() - 5]).is_empty());
+        }
+
+        #[test]
+        fn live_dump_parses_without_panicking() {
+            // Smoke test against the real routing table; asserts only that
+            // collection succeeds, since CI hosts may have no default route.
+            let _ = default_gateways();
+        }
+    }
+}

--- a/crates/rustnet-core/src/network/local_addresses.rs
+++ b/crates/rustnet-core/src/network/local_addresses.rs
@@ -1,3 +1,4 @@
+use crate::network::gateway;
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -9,16 +10,27 @@ pub(crate) struct LocalAddresses {
     /// Subnet-directed broadcasts only; the limited broadcast
     /// (255.255.255.255) needs no prefix knowledge and is handled statelessly.
     pub v4_broadcasts: HashSet<Ipv4Addr>,
+    /// Next-hop addresses of the host's default routes, refreshed together
+    /// with the interface addresses.
+    pub gateways: HashSet<IpAddr>,
 }
 
 #[cfg(test)]
 impl LocalAddresses {
-    /// Test helper: a snapshot with the given addresses and no broadcast set.
+    /// Test helper: a snapshot with the given addresses and no broadcast or
+    /// gateway sets.
     pub(crate) fn from_ips(ips: impl IntoIterator<Item = IpAddr>) -> Self {
         Self {
             ips: ips.into_iter().collect(),
             v4_broadcasts: HashSet::new(),
+            gateways: HashSet::new(),
         }
+    }
+
+    /// Test helper: the snapshot with the given default-gateway addresses.
+    pub(crate) fn with_gateways(mut self, gateways: impl IntoIterator<Item = IpAddr>) -> Self {
+        self.gateways = gateways.into_iter().collect();
+        self
     }
 }
 
@@ -80,6 +92,7 @@ pub(crate) fn collect_local_addresses() -> LocalAddresses {
 
     local.ips.insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
     local.ips.insert(IpAddr::V6(Ipv6Addr::LOCALHOST));
+    local.gateways = gateway::default_gateways();
     local
 }
 

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -260,6 +260,7 @@ pub fn merge_packet_into_connection(
     // connections whose first packet raced interface enumeration.
     conn.local_addr_kind = parsed.local_addr_kind;
     conn.remote_addr_kind = parsed.remote_addr_kind;
+    conn.remote_is_gateway = parsed.remote_is_gateway;
 
     // Update packet counts and bytes
     if parsed.is_outgoing {
@@ -455,6 +456,7 @@ pub fn create_connection_from_packet(parsed: &ParsedPacket, now: SystemTime) -> 
     );
     conn.local_addr_kind = parsed.local_addr_kind;
     conn.remote_addr_kind = parsed.remote_addr_kind;
+    conn.remote_is_gateway = parsed.remote_is_gateway;
 
     // Set initial TCP state based on flags if TCP
     if let Some(tcp_header) = parsed.tcp_header {
@@ -1086,6 +1088,7 @@ mod tests {
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
             local_addr_kind: AddrKind::Unicast,
             remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             protocol_state: ProtocolState::Tcp(TcpState::Unknown),
             tcp_header: Some(TcpHeaderInfo {
                 seq: 1000,
@@ -1214,6 +1217,19 @@ mod tests {
         assert_eq!(conn.local_addr_kind, AddrKind::Unicast);
         merge_packet_into_connection(&mut conn, &packet, SystemTime::now());
         assert_eq!(conn.local_addr_kind, AddrKind::Broadcast);
+    }
+
+    #[test]
+    fn gateway_flag_is_copied_and_refreshed_on_merge() {
+        let mut packet = create_test_packet(false, false);
+        packet.remote_is_gateway = true;
+        let mut conn = create_connection_from_packet(&packet, SystemTime::now());
+        assert!(conn.remote_is_gateway);
+
+        // A route change is reflected by the next packet after the refresh.
+        packet.remote_is_gateway = false;
+        merge_packet_into_connection(&mut conn, &packet, SystemTime::now());
+        assert!(!conn.remote_is_gateway);
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/mod.rs
+++ b/crates/rustnet-core/src/network/mod.rs
@@ -10,6 +10,7 @@
 pub mod bogon;
 pub mod dns;
 pub mod dpi;
+mod gateway;
 pub mod geoip;
 pub mod interface_stats;
 pub mod link_layer;

--- a/crates/rustnet-core/src/network/parser.rs
+++ b/crates/rustnet-core/src/network/parser.rs
@@ -29,6 +29,9 @@ pub struct ParsedPacket {
     /// (subnet-broadcast detection needs the parser's interface snapshot).
     pub local_addr_kind: AddrKind,
     pub remote_addr_kind: AddrKind,
+    /// Whether the remote endpoint is a default-gateway address, stamped
+    /// centrally alongside the address kinds from the parser's route snapshot.
+    pub remote_is_gateway: bool,
     pub tcp_header: Option<TcpHeaderInfo>, // TCP header info (seq, ack, window, flags)
     pub protocol_state: ProtocolState,
     pub is_outgoing: bool,
@@ -132,6 +135,9 @@ pub struct PacketParser {
     /// Subnet-directed broadcast addresses of the host's IPv4 networks,
     /// refreshed together with `local_ips`.
     v4_broadcasts: std::collections::HashSet<Ipv4Addr>,
+    /// Default-gateway addresses from the host's routing table, refreshed
+    /// together with `local_ips`.
+    gateways: std::collections::HashSet<IpAddr>,
     last_local_ip_refresh: Instant,
     last_ambiguous_endpoint_refresh: Option<Instant>,
     unchanged_ambiguous_refreshes: u32,
@@ -158,6 +164,7 @@ impl PacketParser {
         Self {
             local_ips: local.ips,
             v4_broadcasts: local.v4_broadcasts,
+            gateways: local.gateways,
             last_local_ip_refresh: Instant::now(),
             last_ambiguous_endpoint_refresh: None,
             unchanged_ambiguous_refreshes: 0,
@@ -258,6 +265,8 @@ impl PacketParser {
         let mut parsed = self.parse_packet_link_layer(data)?;
         parsed.local_addr_kind = self.classify_addr(parsed.local_addr.ip());
         parsed.remote_addr_kind = self.classify_addr(parsed.remote_addr.ip());
+        parsed.remote_is_gateway = parsed.remote_addr_kind == AddrKind::Unicast
+            && self.gateways.contains(&parsed.remote_addr.ip());
         Some(parsed)
     }
 
@@ -369,7 +378,10 @@ impl PacketParser {
     {
         let refreshed = collector();
         self.last_local_ip_refresh = Instant::now();
-        if refreshed.ips == self.local_ips && refreshed.v4_broadcasts == self.v4_broadcasts {
+        if refreshed.ips == self.local_ips
+            && refreshed.v4_broadcasts == self.v4_broadcasts
+            && refreshed.gateways == self.gateways
+        {
             return false;
         }
 
@@ -380,6 +392,7 @@ impl PacketParser {
         );
         self.local_ips = refreshed.ips;
         self.v4_broadcasts = refreshed.v4_broadcasts;
+        self.gateways = refreshed.gateways;
         self.unchanged_ambiguous_refreshes = 0;
         true
     }
@@ -675,6 +688,7 @@ impl PacketParser {
             // Overwritten centrally in PacketParser::parse_packet
             local_addr_kind: AddrKind::Unicast,
             remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             tcp_header: None,
             protocol_state: ProtocolState::Arp(arp_info),
             is_outgoing,
@@ -1229,6 +1243,60 @@ mod tests {
         assert!(parsed.is_outgoing);
         assert_eq!(parsed.local_addr_kind, AddrKind::Unicast);
         assert_eq!(parsed.remote_addr_kind, AddrKind::Broadcast);
+    }
+
+    #[test]
+    fn gateway_remote_endpoint_is_stamped() {
+        let mut parser = create_parser_with_linktype(1);
+        parser
+            .gateways
+            .insert(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+
+        // The local host (192.168.1.100) talks to the gateway
+        let packet = ethernet_ipv4_udp([192, 168, 1, 100], [192, 168, 1, 1]);
+        let parsed = parser.parse_packet(&packet).expect("packet should parse");
+        assert_eq!(parsed.remote_addr_kind, AddrKind::Unicast);
+        assert!(parsed.remote_is_gateway);
+
+        // An ordinary peer on the same subnet must not be marked
+        let packet = ethernet_ipv4_udp([192, 168, 1, 100], [192, 168, 1, 52]);
+        let parsed = parser.parse_packet(&packet).expect("packet should parse");
+        assert!(!parsed.remote_is_gateway);
+    }
+
+    #[test]
+    fn broadcast_remote_is_never_marked_as_gateway() {
+        let mut parser = create_parser_with_linktype(1);
+        parser.v4_broadcasts.insert(Ipv4Addr::new(192, 168, 1, 255));
+        parser
+            .gateways
+            .insert(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255)));
+
+        let packet = ethernet_ipv4_udp([192, 168, 1, 100], [192, 168, 1, 255]);
+        let parsed = parser.parse_packet(&packet).expect("packet should parse");
+        assert_eq!(parsed.remote_addr_kind, AddrKind::Broadcast);
+        assert!(!parsed.remote_is_gateway);
+    }
+
+    #[test]
+    fn refresh_picks_up_gateway_changes() {
+        let mut parser = create_parser_with_linktype(1);
+        parser.local_ips = [IpAddr::V4(Ipv4Addr::LOCALHOST)].into_iter().collect();
+        parser.v4_broadcasts.clear();
+        parser.gateways.clear();
+        let gateway = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        let collector =
+            || LocalAddresses::from_ips([IpAddr::V4(Ipv4Addr::LOCALHOST)]).with_gateways([gateway]);
+
+        assert!(
+            parser.refresh_local_ips_with(collector),
+            "a gateway-only change must count as a snapshot change"
+        );
+        assert!(parser.gateways.contains(&gateway));
+        assert!(
+            !parser.refresh_local_ips_with(collector),
+            "an unchanged snapshot must not report a change"
+        );
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/protocol/icmp.rs
+++ b/crates/rustnet-core/src/network/protocol/icmp.rs
@@ -52,6 +52,7 @@ pub fn parse(
         // Overwritten centrally in PacketParser::parse_packet
         local_addr_kind: AddrKind::Unicast,
         remote_addr_kind: AddrKind::Unicast,
+        remote_is_gateway: false,
         tcp_header: None,
         protocol_state: ProtocolState::Icmp {
             icmp_type,
@@ -111,6 +112,7 @@ pub fn parse_v6(
         // Overwritten centrally in PacketParser::parse_packet
         local_addr_kind: AddrKind::Unicast,
         remote_addr_kind: AddrKind::Unicast,
+        remote_is_gateway: false,
         tcp_header: None,
         protocol_state: ProtocolState::Icmp {
             icmp_type,

--- a/crates/rustnet-core/src/network/protocol/igmp.rs
+++ b/crates/rustnet-core/src/network/protocol/igmp.rs
@@ -65,6 +65,7 @@ pub fn parse(
         // Overwritten centrally in PacketParser::parse_packet
         local_addr_kind: AddrKind::Unicast,
         remote_addr_kind: AddrKind::Unicast,
+        remote_is_gateway: false,
         tcp_header: None,
         protocol_state: ProtocolState::Igmp {
             igmp_type,

--- a/crates/rustnet-core/src/network/protocol/tcp.rs
+++ b/crates/rustnet-core/src/network/protocol/tcp.rs
@@ -142,6 +142,7 @@ pub fn parse(
         // Overwritten centrally in PacketParser::parse_packet
         local_addr_kind: AddrKind::Unicast,
         remote_addr_kind: AddrKind::Unicast,
+        remote_is_gateway: false,
         tcp_header: Some(tcp_header),
         protocol_state: ProtocolState::Tcp(TcpState::Unknown),
         is_outgoing,

--- a/crates/rustnet-core/src/network/protocol/udp.rs
+++ b/crates/rustnet-core/src/network/protocol/udp.rs
@@ -50,6 +50,7 @@ pub fn parse(
         // Overwritten centrally in PacketParser::parse_packet
         local_addr_kind: AddrKind::Unicast,
         remote_addr_kind: AddrKind::Unicast,
+        remote_is_gateway: false,
         tcp_header: None,
         protocol_state: ProtocolState::Udp,
         is_outgoing,

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -986,6 +986,7 @@ mod tests {
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
             local_addr_kind: AddrKind::Unicast,
             remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             protocol_state: ProtocolState::Tcp(TcpState::Unknown),
             tcp_header: Some(TcpHeaderInfo {
                 seq: 1_000,
@@ -1023,6 +1024,7 @@ mod tests {
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
             local_addr_kind: AddrKind::Unicast,
             remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             protocol_state: ProtocolState::Udp,
             tcp_header: None,
             is_outgoing,
@@ -1046,6 +1048,7 @@ mod tests {
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 53),
             local_addr_kind: AddrKind::Unicast,
             remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             protocol_state: ProtocolState::Udp,
             tcp_header: None,
             is_outgoing,
@@ -1071,13 +1074,16 @@ mod tests {
         is_outgoing: bool,
         is_reply: bool,
     ) -> ParsedPacket {
-        use crate::network::types::ProtocolState;
+        use crate::network::types::{AddrKind, ProtocolState};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         ParsedPacket {
             protocol: Protocol::Icmp,
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 0),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 0),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             protocol_state: ProtocolState::Icmp {
                 icmp_type: if is_reply { 0 } else { 8 },
                 icmp_id: Some(identifier),
@@ -1419,13 +1425,16 @@ mod tests {
         class: crate::network::types::StunMessageClass,
     ) -> ParsedPacket {
         use crate::network::dpi::DpiResult;
-        use crate::network::types::{ProtocolState, StunInfo, StunMethod};
+        use crate::network::types::{AddrKind, ProtocolState, StunInfo, StunMethod};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         ParsedPacket {
             protocol: Protocol::Udp,
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 54_000),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), 3478),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             protocol_state: ProtocolState::Udp,
             tcp_header: None,
             is_outgoing,
@@ -1476,13 +1485,16 @@ mod tests {
         transmit_timestamp: u64,
     ) -> ParsedPacket {
         use crate::network::dpi::DpiResult;
-        use crate::network::types::{NtpInfo, ProtocolState};
+        use crate::network::types::{AddrKind, NtpInfo, ProtocolState};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         ParsedPacket {
             protocol: Protocol::Udp,
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 47_000),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)), 123),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             protocol_state: ProtocolState::Udp,
             tcp_header: None,
             is_outgoing,

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -2716,6 +2716,9 @@ pub struct Connection {
     /// this field lets the UI render that intentionally.
     pub local_addr_kind: AddrKind,
     pub remote_addr_kind: AddrKind,
+    /// Whether the remote endpoint is a default-gateway address from the
+    /// host's routing table at the time the last packet was observed.
+    pub remote_is_gateway: bool,
 
     // Protocol state
     pub protocol_state: ProtocolState,
@@ -2839,6 +2842,7 @@ impl Connection {
             remote_addr,
             local_addr_kind: AddrKind::default(),
             remote_addr_kind: AddrKind::default(),
+            remote_is_gateway: false,
             protocol_state: state,
             pid: None,
             process_ppid: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -350,6 +350,9 @@ fn log_connection_event(
     if conn.remote_addr_kind != AddrKind::Unicast {
         event["destination_addr_kind"] = json!(conn.remote_addr_kind.as_token());
     }
+    if conn.remote_is_gateway {
+        event["destination_is_gateway"] = json!(true);
+    }
 
     // Add hostname fields if DNS resolution is enabled and hostnames are resolved
     // Skip ARP connections to avoid feedback loop (DNS lookups generate ARP traffic)
@@ -525,6 +528,9 @@ fn log_pcap_connection(writer: &JsonLineWriter, conn: &Connection) {
     }
     if conn.remote_addr_kind != AddrKind::Unicast {
         event["remote_addr_kind"] = json!(conn.remote_addr_kind.as_token());
+    }
+    if conn.remote_is_gateway {
+        event["remote_is_gateway"] = json!(true);
     }
 
     // Per-connection record, so the full executable path is affordable here.
@@ -3675,6 +3681,7 @@ mod connection_lifecycle_tests {
             remote_addr: SocketAddr::from(([198, 51, 100, 1], 443)),
             local_addr_kind: AddrKind::Unicast,
             remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             tcp_header: Some(TcpHeaderInfo {
                 seq: 1_000,
                 ack: 0,
@@ -3951,6 +3958,7 @@ mod pcapng_export_tests {
             remote_addr: SocketAddr::from(([198, 51, 100, 9], 443)),
             local_addr_kind: AddrKind::Unicast,
             remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
             tcp_header: Some(TcpHeaderInfo {
                 seq: 1,
                 ack: 0,

--- a/src/ui/connection_table.rs
+++ b/src/ui/connection_table.rs
@@ -243,11 +243,26 @@ fn service_text<'a>(conn: &'a Connection, ui_state: &UIState) -> Cow<'a, str> {
 /// Table cell for an endpoint: broadcast/multicast endpoints render as an
 /// intentional label ("bcast:138", "mcast:5353") instead of an address that
 /// reads like a unicast host; the full address stays visible in Details.
-fn endpoint_display(addr: SocketAddr, kind: AddrKind, max_width: usize) -> String {
+/// Default-gateway endpoints keep the address visible and gain a "(gw)"
+/// suffix when it fits.
+fn endpoint_display(
+    addr: SocketAddr,
+    kind: AddrKind,
+    is_gateway: bool,
+    max_width: usize,
+) -> String {
     match kind {
         AddrKind::Broadcast => format!("bcast:{}", addr.port()),
         AddrKind::Multicast => format!("mcast:{}", addr.port()),
-        AddrKind::Unicast => truncate_with_ellipsis(&addr.to_string(), max_width),
+        AddrKind::Unicast => {
+            if is_gateway {
+                let with_marker = format!("{addr} (gw)");
+                if with_marker.chars().count() <= max_width {
+                    return with_marker;
+                }
+            }
+            truncate_with_ellipsis(&addr.to_string(), max_width)
+        }
     }
 }
 
@@ -278,7 +293,12 @@ fn remote_display(
             full
         }
     } else {
-        endpoint_display(conn.remote_addr, conn.remote_addr_kind, max_width)
+        endpoint_display(
+            conn.remote_addr,
+            conn.remote_addr_kind,
+            conn.remote_is_gateway,
+            max_width,
+        )
     }
 }
 
@@ -427,6 +447,7 @@ pub(in crate::ui) fn connection_row<'a>(
             ColumnId::Local => Cell::from(endpoint_display(
                 conn.local_addr,
                 conn.local_addr_kind,
+                false,
                 col.width as usize,
             ))
             .style(style_if_colored(theme::field_local_addr())),
@@ -762,22 +783,41 @@ mod tests {
     fn endpoint_display_labels_broadcast_and_multicast() {
         let bcast: SocketAddr = "192.168.0.255:138".parse().unwrap();
         assert_eq!(
-            endpoint_display(bcast, AddrKind::Broadcast, 18),
+            endpoint_display(bcast, AddrKind::Broadcast, false, 18),
             "bcast:138"
         );
 
         let mcast: SocketAddr = "224.0.0.251:5353".parse().unwrap();
         assert_eq!(
-            endpoint_display(mcast, AddrKind::Multicast, 18),
+            endpoint_display(mcast, AddrKind::Multicast, false, 18),
             "mcast:5353"
         );
 
         let unicast: SocketAddr = "192.168.0.52:60236".parse().unwrap();
         assert_eq!(
-            endpoint_display(unicast, AddrKind::Unicast, 18),
+            endpoint_display(unicast, AddrKind::Unicast, false, 18),
             "192.168.0.52:60236"
         );
-        assert!(endpoint_display(unicast, AddrKind::Unicast, 10).ends_with('\u{2026}'));
+        assert!(endpoint_display(unicast, AddrKind::Unicast, false, 10).ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn endpoint_display_marks_gateways_when_width_allows() {
+        let gateway: SocketAddr = "192.168.0.1:34824".parse().unwrap();
+        assert_eq!(
+            endpoint_display(gateway, AddrKind::Unicast, true, 24),
+            "192.168.0.1:34824 (gw)"
+        );
+        // Falls back to the plain address when the marker does not fit.
+        assert_eq!(
+            endpoint_display(gateway, AddrKind::Unicast, true, 18),
+            "192.168.0.1:34824"
+        );
+        // The kind label wins over the gateway marker for non-unicast kinds.
+        assert_eq!(
+            endpoint_display(gateway, AddrKind::Broadcast, true, 24),
+            "bcast:34824"
+        );
     }
 
     #[test]

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -479,6 +479,15 @@ fn annotated_addr(addr: std::net::SocketAddr, kind: AddrKind) -> String {
     }
 }
 
+/// Remote address annotated like `annotated_addr`, plus a gateway marker when
+/// the endpoint is the host's default gateway (router).
+fn annotated_remote_addr(addr: std::net::SocketAddr, kind: AddrKind, is_gateway: bool) -> String {
+    if is_gateway && kind == AddrKind::Unicast {
+        return format!("{addr} (gateway)");
+    }
+    annotated_addr(addr, kind)
+}
+
 /// Scope of the remote endpoint. `bogon::classify` is stateless and cannot
 /// recognize subnet-directed broadcasts (it would report the private range),
 /// so the connection's parser-derived kind overrides it.
@@ -876,7 +885,11 @@ pub(in crate::ui) fn draw_connection_details(
         &mut details_text,
         &mut detail_fields,
         "Remote Address",
-        annotated_addr(conn.remote_addr, conn.remote_addr_kind),
+        annotated_remote_addr(
+            conn.remote_addr,
+            conn.remote_addr_kind,
+            conn.remote_is_gateway,
+        ),
         label_style,
         theme::fg(theme::field_remote_addr()),
     );
@@ -2794,7 +2807,7 @@ mod path_shortening_tests {
 
 #[cfg(test)]
 mod endpoint_annotation_tests {
-    use super::{annotated_addr, remote_scope};
+    use super::{annotated_addr, annotated_remote_addr, remote_scope};
     use crate::network::bogon::Scope;
     use crate::network::types::{AddrKind, Connection, Protocol, ProtocolState};
 
@@ -2814,6 +2827,24 @@ mod endpoint_annotation_tests {
         assert_eq!(
             annotated_addr(addr, AddrKind::Unicast),
             "192.168.0.52:60236"
+        );
+    }
+
+    #[test]
+    fn remote_addresses_are_annotated_as_gateway() {
+        let addr = "192.168.0.1:34824".parse().unwrap();
+        assert_eq!(
+            annotated_remote_addr(addr, AddrKind::Unicast, true),
+            "192.168.0.1:34824 (gateway)"
+        );
+        assert_eq!(
+            annotated_remote_addr(addr, AddrKind::Unicast, false),
+            "192.168.0.1:34824"
+        );
+        // The kind annotation wins over the gateway marker.
+        assert_eq!(
+            annotated_remote_addr(addr, AddrKind::Broadcast, true),
+            "192.168.0.1:34824 (broadcast)"
         );
     }
 


### PR DESCRIPTION
- Detects default gateway IPs from the OS routing table (Linux /proc/net/route, macOS/FreeBSD PF_ROUTE sysctl, Windows GetIpForwardTable2), refreshed with the local address snapshot
- Overview Remote column appends `(gw)` when it fits, Details annotates the remote address with `(gateway)`, JSONL logs gain `remote_is_gateway` / `destination_is_gateway` keys
- Also fixes tracker test helpers missing the addr kind fields (#525 and #528 merged independently, which broke `cargo test` on main)