### PR TITLE
Add Ubuntu 24.04 (noble) to PPA builds

### DIFF
--- a/.github/workflows/ppa-release.yml
+++ b/.github/workflows/ppa-release.yml
@@ -16,6 +16,7 @@ on:
         default: 'resolute'
         type: choice
         options:
+          - noble # 24.04 LTS (also Linux Mint 22.x)
           - questing # 25.10
           - resolute # 26.04 LTS
       tarball_suffix:
@@ -44,8 +45,8 @@ jobs:
             echo 'releases=["${{ inputs.ubuntu_release }}"]' >> $GITHUB_OUTPUT
             echo "Dispatch: building only ${{ inputs.ubuntu_release }}"
           else
-            echo 'releases=["questing","resolute"]' >> $GITHUB_OUTPUT
-            echo "Auto: building questing and resolute"
+            echo 'releases=["noble","questing","resolute"]' >> $GITHUB_OUTPUT
+            echo "Auto: building noble, questing and resolute"
           fi
 
   build-and-upload:
@@ -132,6 +133,7 @@ jobs:
           # packages. We pin to the lowest version available on the target
           # release that still satisfies our >= 1.88 floor (let-chains).
           case "${{ matrix.ubuntu_release }}" in
+            noble) RUST_VERSION=1.89 ;;
             questing) RUST_VERSION=1.88 ;;
             resolute) RUST_VERSION=1.91 ;;
             *) echo "::error::Unknown release ${{ matrix.ubuntu_release }} - add it to the case statement"; exit 1 ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for non-unicast endpoints
 
 ### Added
+- **Ubuntu 24.04 LTS (Noble) PPA**: The PPA now also builds for Ubuntu 24.04
+  LTS using its backported `rustc-1.89` toolchain, which makes the documented
+  `add-apt-repository` install work on Ubuntu 24.04 and Linux Mint 22.x.
+  Install docs updated accordingly (#533)
 - **DNS Query Name in Details**: The Details tab's DNS card now shows the
   queried domain as `DNS Query` alongside the query type and response IPs.
   The name was already parsed from query and response packets but only used

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,12 +93,15 @@ choco install rustnet
 
 ### Linux Package Installation
 
-#### Ubuntu PPA (Recommended for Ubuntu 25.10 Questing and 26.04 LTS Resolute)
+#### Ubuntu PPA (Recommended for Ubuntu 24.04 LTS, 25.10, 26.04 LTS and Linux Mint 22)
 
 The easiest way to install RustNet on Ubuntu is via the official PPA. The PPA publishes builds for the following Ubuntu series:
 
+- Ubuntu 24.04 LTS (Noble Numbat)
 - Ubuntu 25.10 (Questing Quokka)
 - Ubuntu 26.04 LTS (Resolute Raccoon)
+
+Linux Mint 22.x is based on Ubuntu 24.04, and Mint registers PPAs under the Ubuntu base series, so the same commands work there.
 
 ```bash
 # Add the RustNet PPA
@@ -118,7 +121,7 @@ sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet
 rustnet
 ```
 
-**Important:** The PPA supports only the two series listed above (Ubuntu 25.10 Questing and 26.04 LTS Resolute) because the build requires Rust 1.88+ (used for let-chains in the project). Earlier Ubuntu versions don't ship a recent enough `rustc` in their repositories. For older Ubuntu versions, use the [.deb packages](#debianubuntu-deb-packages) from GitHub releases or [build from source](#building-from-source).
+**Important:** The PPA supports only the three series listed above because the build requires Rust 1.88+ (used for let-chains in the project). Other Ubuntu series don't ship a recent enough `rustc` in their repositories. For those, use the [.deb packages](#debianubuntu-deb-packages) from GitHub releases or [build from source](#building-from-source).
 
 #### Debian/Ubuntu (.deb packages)
 

--- a/INSTALL.zh-CN.md
+++ b/INSTALL.zh-CN.md
@@ -93,12 +93,15 @@ choco install rustnet
 
 ### Linux 包安装<a id="linux-package-installation"></a>
 
-#### Ubuntu PPA（推荐用于 Ubuntu 25.10 Questing 和 26.04 LTS Resolute）
+#### Ubuntu PPA（推荐用于 Ubuntu 24.04 LTS、25.10、26.04 LTS 和 Linux Mint 22）
 
 在 Ubuntu 上安装 RustNet 最简单的方式是通过官方 PPA。该 PPA 为以下 Ubuntu 系列发布构建：
 
+- Ubuntu 24.04 LTS（Noble Numbat）
 - Ubuntu 25.10（Questing Quokka）
 - Ubuntu 26.04 LTS（Resolute Raccoon）
+
+Linux Mint 22.x 基于 Ubuntu 24.04，且 Mint 会将 PPA 注册到对应的 Ubuntu 基础系列，因此相同的命令在 Mint 上同样适用。
 
 ```bash
 # 添加 RustNet PPA
@@ -118,7 +121,7 @@ sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet
 rustnet
 ```
 
-**重要：** 该 PPA 仅支持上述两个系列（Ubuntu 25.10 Questing 和 26.04 LTS Resolute），因为构建需要 Rust 1.88+（项目中使用了 let-chains）。早期 Ubuntu 版本的仓库中没有足够新的 `rustc`。对于旧版 Ubuntu，请使用 GitHub releases 中的 [.deb 包](#debianubuntu-deb-packages)或[从源码构建](#building-from-source)。
+**重要：** 该 PPA 仅支持上述三个系列，因为构建需要 Rust 1.88+（项目中使用了 let-chains）。其他 Ubuntu 系列的仓库中没有足够新的 `rustc`。对于这些版本，请使用 GitHub releases 中的 [.deb 包](#debianubuntu-deb-packages)或[从源码构建](#building-from-source)。
 
 #### Debian/Ubuntu（.deb 包）<a id="debianubuntu-deb-packages"></a>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,7 +35,7 @@ macOS または Linux:
 brew install rustnet
 ```
 
-Ubuntu 25.10 以降:
+Ubuntu 24.04 LTS 以降 / Linux Mint 22:
 
 ```bash
 sudo add-apt-repository ppa:domcyrus/rustnet

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Stats are collected every 2 seconds in a background thread with minimal performa
 brew install rustnet
 ```
 
-**Ubuntu (25.10+):**
+**Ubuntu (24.04 LTS+) / Linux Mint 22:**
 ```bash
 sudo add-apt-repository ppa:domcyrus/rustnet
 sudo apt update && sudo apt install rustnet

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,7 +122,7 @@ RustNet 将进程级流量计量与实时网络接口统计整合在一起：
 brew install rustnet
 ```
 
-**Ubuntu(25.10+):**
+**Ubuntu(24.04 LTS+)/ Linux Mint 22:**
 ```bash
 sudo add-apt-repository ppa:domcyrus/rustnet
 sudo apt update && sudo apt install rustnet

--- a/debian/README.md
+++ b/debian/README.md
@@ -11,12 +11,13 @@ git tag v1.0.0
 git push origin v1.0.0
 ```
 
-This automatically builds and uploads source packages for both supported Ubuntu series:
+This automatically builds and uploads source packages for all supported Ubuntu series:
 
+- Ubuntu 24.04 LTS (Noble Numbat)
 - Ubuntu 25.10 (Questing Quokka)
 - Ubuntu 26.04 LTS (Resolute Raccoon)
 
-Both series ship `rustc-1.88` / `cargo-1.88`, which is the minimum required for the let-chains feature used by the project (see `rust-version` in `Cargo.toml`).
+Each series ships versioned `rustc`/`cargo` packages satisfying the Rust 1.88 minimum required for the let-chains feature used by the project (see `rust-version` in `Cargo.toml`). The workflow pins the toolchain per series (Noble: 1.89, Questing: 1.88, Resolute: 1.91).
 
 ## GitHub Secrets Setup
 
@@ -54,7 +55,7 @@ sudo apt install rustnet
 - **Binary**: rustnet
 - **Maintainer**: Marco Cadetg <cadetg@gmail.com>
 - **PPA**: https://launchpad.net/~domcyrus/+archive/ubuntu/rustnet
-- **Supported**: Ubuntu 25.10 (Questing) and 26.04 LTS (Resolute)
+- **Supported**: Ubuntu 24.04 LTS (Noble), 25.10 (Questing) and 26.04 LTS (Resolute)
 - **Architectures**: amd64, arm64, armhf
 
 ## Workflow


### PR DESCRIPTION
Noble ships backported rustc-1.89, so the PPA can build for 24.04 LTS and Linux Mint 22.x. Verified in a clean noble container. Docs updated.

After merge: dispatch the PPA workflow with ubuntu_release=noble to backfill 1.5.0.