### PR TITLE
Add Ubuntu 22.04 (jammy) to PPA builds

### DIFF
--- a/.github/workflows/ppa-release.yml
+++ b/.github/workflows/ppa-release.yml
@@ -16,6 +16,7 @@ on:
         default: 'resolute'
         type: choice
         options:
+          - jammy # 22.04 LTS (also Linux Mint 21.x, Pop!_OS 22.04)
           - noble # 24.04 LTS (also Linux Mint 22.x)
           - questing # 25.10
           - resolute # 26.04 LTS
@@ -45,8 +46,8 @@ jobs:
             echo 'releases=["${{ inputs.ubuntu_release }}"]' >> $GITHUB_OUTPUT
             echo "Dispatch: building only ${{ inputs.ubuntu_release }}"
           else
-            echo 'releases=["noble","questing","resolute"]' >> $GITHUB_OUTPUT
-            echo "Auto: building noble, questing and resolute"
+            echo 'releases=["jammy","noble","questing","resolute"]' >> $GITHUB_OUTPUT
+            echo "Auto: building jammy, noble, questing and resolute"
           fi
 
   build-and-upload:
@@ -133,6 +134,7 @@ jobs:
           # packages. We pin to the lowest version available on the target
           # release that still satisfies our >= 1.88 floor (let-chains).
           case "${{ matrix.ubuntu_release }}" in
+            jammy) RUST_VERSION=1.89 ;;
             noble) RUST_VERSION=1.89 ;;
             questing) RUST_VERSION=1.88 ;;
             resolute) RUST_VERSION=1.91 ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for non-unicast endpoints
 
 ### Added
+- **Ubuntu 22.04 LTS (Jammy) PPA**: The PPA now also builds for Ubuntu 22.04
+  LTS using its backported `rustc-1.89` toolchain, covering Linux Mint 21.x
+  and Pop!_OS 22.04. Install docs now list the supported derivatives and the
+  Pop!_OS `apt-manage` command (#534)
 - **Ubuntu 24.04 LTS (Noble) PPA**: The PPA now also builds for Ubuntu 24.04
   LTS using its backported `rustc-1.89` toolchain, which makes the documented
   `add-apt-repository` install work on Ubuntu 24.04 and Linux Mint 22.x.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,15 +93,19 @@ choco install rustnet
 
 ### Linux Package Installation
 
-#### Ubuntu PPA (Recommended for Ubuntu 24.04 LTS, 25.10, 26.04 LTS and Linux Mint 22)
+#### Ubuntu PPA (Recommended for Ubuntu 22.04+, Linux Mint and Pop!_OS)
 
-The easiest way to install RustNet on Ubuntu is via the official PPA. The PPA publishes builds for the following Ubuntu series:
+The easiest way to install RustNet on Ubuntu and its derivatives is via the official PPA. The PPA publishes builds for the following Ubuntu series:
 
+- Ubuntu 22.04 LTS (Jammy Jellyfish)
 - Ubuntu 24.04 LTS (Noble Numbat)
 - Ubuntu 25.10 (Questing Quokka)
 - Ubuntu 26.04 LTS (Resolute Raccoon)
 
-Linux Mint 22.x is based on Ubuntu 24.04, and Mint registers PPAs under the Ubuntu base series, so the same commands work there.
+Derivatives register PPAs under their Ubuntu base series, so the same commands work there:
+
+- Linux Mint 21.x (Jammy base) and 22.x (Noble base)
+- Pop!_OS 22.04 (Jammy base) and 24.04 (Noble base). Pop!_OS ships `apt-manage` instead of `add-apt-repository`: use `sudo apt-manage add ppa:domcyrus/rustnet`.
 
 ```bash
 # Add the RustNet PPA
@@ -121,7 +125,7 @@ sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet
 rustnet
 ```
 
-**Important:** The PPA supports only the three series listed above because the build requires Rust 1.88+ (used for let-chains in the project). Other Ubuntu series don't ship a recent enough `rustc` in their repositories. For those, use the [.deb packages](#debianubuntu-deb-packages) from GitHub releases or [build from source](#building-from-source).
+**Important:** The PPA supports only the four series listed above because the build requires Rust 1.88+ (used for let-chains in the project). Other Ubuntu series don't ship a recent enough `rustc` in their repositories. For those, use the [.deb packages](#debianubuntu-deb-packages) from GitHub releases or [build from source](#building-from-source).
 
 #### Debian/Ubuntu (.deb packages)
 

--- a/INSTALL.zh-CN.md
+++ b/INSTALL.zh-CN.md
@@ -93,15 +93,19 @@ choco install rustnet
 
 ### Linux 包安装<a id="linux-package-installation"></a>
 
-#### Ubuntu PPA（推荐用于 Ubuntu 24.04 LTS、25.10、26.04 LTS 和 Linux Mint 22）
+#### Ubuntu PPA（推荐用于 Ubuntu 22.04+、Linux Mint 和 Pop!_OS）
 
-在 Ubuntu 上安装 RustNet 最简单的方式是通过官方 PPA。该 PPA 为以下 Ubuntu 系列发布构建：
+在 Ubuntu 及其衍生发行版上安装 RustNet 最简单的方式是通过官方 PPA。该 PPA 为以下 Ubuntu 系列发布构建：
 
+- Ubuntu 22.04 LTS（Jammy Jellyfish）
 - Ubuntu 24.04 LTS（Noble Numbat）
 - Ubuntu 25.10（Questing Quokka）
 - Ubuntu 26.04 LTS（Resolute Raccoon）
 
-Linux Mint 22.x 基于 Ubuntu 24.04，且 Mint 会将 PPA 注册到对应的 Ubuntu 基础系列，因此相同的命令在 Mint 上同样适用。
+衍生发行版会将 PPA 注册到对应的 Ubuntu 基础系列，因此相同的命令同样适用：
+
+- Linux Mint 21.x（基于 Jammy）和 22.x（基于 Noble）
+- Pop!_OS 22.04（基于 Jammy）和 24.04（基于 Noble）。Pop!_OS 使用 `apt-manage` 而非 `add-apt-repository`：请运行 `sudo apt-manage add ppa:domcyrus/rustnet`。
 
 ```bash
 # 添加 RustNet PPA
@@ -121,7 +125,7 @@ sudo setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' /usr/bin/rustnet
 rustnet
 ```
 
-**重要：** 该 PPA 仅支持上述三个系列，因为构建需要 Rust 1.88+（项目中使用了 let-chains）。其他 Ubuntu 系列的仓库中没有足够新的 `rustc`。对于这些版本，请使用 GitHub releases 中的 [.deb 包](#debianubuntu-deb-packages)或[从源码构建](#building-from-source)。
+**重要：** 该 PPA 仅支持上述四个系列，因为构建需要 Rust 1.88+（项目中使用了 let-chains）。其他 Ubuntu 系列的仓库中没有足够新的 `rustc`。对于这些版本，请使用 GitHub releases 中的 [.deb 包](#debianubuntu-deb-packages)或[从源码构建](#building-from-source)。
 
 #### Debian/Ubuntu（.deb 包）<a id="debianubuntu-deb-packages"></a>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,10 +35,11 @@ macOS または Linux:
 brew install rustnet
 ```
 
-Ubuntu 24.04 LTS 以降 / Linux Mint 22:
+Ubuntu 22.04 LTS 以降 / Linux Mint 21 以降 / Pop!_OS 22.04 以降:
 
 ```bash
 sudo add-apt-repository ppa:domcyrus/rustnet
+# Pop!_OS の場合: sudo apt-manage add ppa:domcyrus/rustnet
 sudo apt update && sudo apt install rustnet
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ Stats are collected every 2 seconds in a background thread with minimal performa
 brew install rustnet
 ```
 
-**Ubuntu (24.04 LTS+) / Linux Mint 22:**
+**Ubuntu (22.04 LTS+) / Linux Mint 21+ / Pop!_OS 22.04+:**
 ```bash
 sudo add-apt-repository ppa:domcyrus/rustnet
+# on Pop!_OS: sudo apt-manage add ppa:domcyrus/rustnet
 sudo apt update && sudo apt install rustnet
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,9 +122,10 @@ RustNet 将进程级流量计量与实时网络接口统计整合在一起：
 brew install rustnet
 ```
 
-**Ubuntu(24.04 LTS+)/ Linux Mint 22:**
+**Ubuntu(22.04 LTS+)/ Linux Mint 21+ / Pop!_OS 22.04+:**
 ```bash
 sudo add-apt-repository ppa:domcyrus/rustnet
+# Pop!_OS 上使用：sudo apt-manage add ppa:domcyrus/rustnet
 sudo apt update && sudo apt install rustnet
 ```
 

--- a/debian/README.md
+++ b/debian/README.md
@@ -13,11 +13,12 @@ git push origin v1.0.0
 
 This automatically builds and uploads source packages for all supported Ubuntu series:
 
+- Ubuntu 22.04 LTS (Jammy Jellyfish)
 - Ubuntu 24.04 LTS (Noble Numbat)
 - Ubuntu 25.10 (Questing Quokka)
 - Ubuntu 26.04 LTS (Resolute Raccoon)
 
-Each series ships versioned `rustc`/`cargo` packages satisfying the Rust 1.88 minimum required for the let-chains feature used by the project (see `rust-version` in `Cargo.toml`). The workflow pins the toolchain per series (Noble: 1.89, Questing: 1.88, Resolute: 1.91).
+Each series ships versioned `rustc`/`cargo` packages satisfying the Rust 1.88 minimum required for the let-chains feature used by the project (see `rust-version` in `Cargo.toml`). The workflow pins the toolchain per series (Jammy: 1.89, Noble: 1.89, Questing: 1.88, Resolute: 1.91).
 
 ## GitHub Secrets Setup
 
@@ -55,7 +56,7 @@ sudo apt install rustnet
 - **Binary**: rustnet
 - **Maintainer**: Marco Cadetg <cadetg@gmail.com>
 - **PPA**: https://launchpad.net/~domcyrus/+archive/ubuntu/rustnet
-- **Supported**: Ubuntu 24.04 LTS (Noble), 25.10 (Questing) and 26.04 LTS (Resolute)
+- **Supported**: Ubuntu 22.04 LTS (Jammy), 24.04 LTS (Noble), 25.10 (Questing) and 26.04 LTS (Resolute)
 - **Architectures**: amd64, arm64, armhf
 
 ## Workflow


### PR DESCRIPTION
Jammy ships backported rustc-1.89, extending the PPA to 22.04 LTS, Linux Mint 21.x and Pop!_OS 22.04. Verified in a clean jammy container. Docs list the derivatives and the Pop!_OS apt-manage command.

After merge: dispatch the PPA workflow with ubuntu_release=jammy and tarball_suffix=ds2 to backfill 1.5.0.