### PR TITLE
Track NetBIOS request response times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **NetBIOS Response Time**: UDP Name Service and Datagram Service requests now
+  show response time and the latest response status in Details. Pairing uses the
+  16-bit transaction ID plus the local socket and service, so broadcast requests
+  match replies from individual hosts. WACK packets keep the request pending
+  until its final response, and pending requests have a 10s expiry and hard cap
 - **DNS Response Time**: Unicast UDP DNS connections now show a transport
   metric in the Details Transport Health card instead of "No transport metrics
   for this protocol". Queries and responses are paired by their 16-bit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **NetBIOS Response Time**: UDP Name Service and Datagram Service requests now
   show response time and the latest response status in Details. Pairing uses the
   16-bit transaction ID plus the local socket and service, so broadcast requests
-  match replies from individual hosts. WACK packets keep the request pending
-  until its final response, and pending requests have a 10s expiry and hard cap
+  match replies from individual hosts, and the round trip is shown on both the
+  broadcast request row and the responder's connection. WACK packets keep the
+  request pending until its final response, and pending requests have a 10s
+  expiry and hard cap
 - **Ubuntu 22.04 LTS (Jammy) PPA**: The PPA now also builds for Ubuntu 22.04
   LTS using its backported `rustc-1.89` toolchain, covering Linux Mint 21.x
   and Pop!_OS 22.04. Install docs now list the supported derivatives and the

--- a/crates/rustnet-core/src/network/dpi/netbios.rs
+++ b/crates/rustnet-core/src/network/dpi/netbios.rs
@@ -2,7 +2,7 @@
 //!
 //! Parses NetBIOS Name Service (UDP 137) and Datagram Service (UDP 138) packets.
 
-use crate::network::types::{NetBiosInfo, NetBiosOpcode, NetBiosService};
+use crate::network::types::{NetBiosInfo, NetBiosOpcode, NetBiosResponseStatus, NetBiosService};
 
 /// Minimum NetBIOS Name Service packet size
 const MIN_NBNS_SIZE: usize = 12;
@@ -29,13 +29,15 @@ pub fn analyze_netbios_ns(payload: &[u8]) -> Option<NetBiosInfo> {
 
     // Extract opcode from flags (bits 11-14)
     let opcode_value = ((flags >> 11) & 0x0F) as u8;
-    let is_response = (flags & 0x8000) != 0;
+    let has_response_flag = (flags & 0x8000) != 0;
 
-    let opcode = if is_response {
-        NetBiosOpcode::Response
-    } else {
-        parse_opcode(opcode_value)
+    let opcode = match (has_response_flag, opcode_value) {
+        // A WACK is an interim response asking the client to keep waiting.
+        (true, 7) => NetBiosOpcode::Wack,
+        (true, _) => NetBiosOpcode::Response,
+        (false, _) => parse_opcode(opcode_value),
     };
+    let is_response = has_response_flag && opcode != NetBiosOpcode::Wack;
 
     // Try to decode NetBIOS name if present
     let name = if payload.len() > 12 {
@@ -48,6 +50,10 @@ pub fn analyze_netbios_ns(payload: &[u8]) -> Option<NetBiosInfo> {
         service: NetBiosService::NameService,
         opcode,
         name,
+        transaction_id: u16::from_be_bytes([payload[0], payload[1]]),
+        is_response,
+        response_status: is_response
+            .then_some(NetBiosResponseStatus::NameService((flags & 0x000F) as u8)),
     })
 }
 
@@ -60,30 +66,44 @@ pub fn analyze_netbios_dgm(payload: &[u8]) -> Option<NetBiosInfo> {
 
     // RFC 1002 §4.4: header size — and therefore where the encoded name
     // starts — depends on the message type.
-    let (opcode, min_size, name_offset) = match msg_type {
+    let (opcode, min_size, name_offset, response_status) = match msg_type {
         // §4.4.1 DIRECT_UNIQUE / DIRECT_GROUP / BROADCAST: message
         // delivery, SOURCE_NAME follows the 14-byte header
         0x10..=0x12 => (
             NetBiosOpcode::Datagram,
             NBDGM_DIRECT_HEADER,
             Some(NBDGM_DIRECT_HEADER),
+            None,
         ),
         // §4.4.2 DATAGRAM ERROR: header + error code, no name
-        0x13 => (NetBiosOpcode::Error, NBDGM_ERROR_SIZE, None),
+        0x13 => (NetBiosOpcode::Error, NBDGM_ERROR_SIZE, None, None),
         // §4.4.3 DATAGRAM QUERY REQUEST: DESTINATION_NAME follows the
         // 10-byte header
         0x14 => (
             NetBiosOpcode::Query,
             NBDGM_QUERY_HEADER,
             Some(NBDGM_QUERY_HEADER),
+            None,
         ),
         // §4.4.3 POSITIVE / NEGATIVE QUERY RESPONSE
-        0x15 | 0x16 => (
+        0x15 => (
             NetBiosOpcode::Response,
             NBDGM_QUERY_HEADER,
             Some(NBDGM_QUERY_HEADER),
+            Some(NetBiosResponseStatus::DatagramPositive),
         ),
-        other => (NetBiosOpcode::Unknown(other), NBDGM_QUERY_HEADER, None),
+        0x16 => (
+            NetBiosOpcode::Response,
+            NBDGM_QUERY_HEADER,
+            Some(NBDGM_QUERY_HEADER),
+            Some(NetBiosResponseStatus::DatagramNegative),
+        ),
+        other => (
+            NetBiosOpcode::Unknown(other),
+            NBDGM_QUERY_HEADER,
+            None,
+            None,
+        ),
     };
 
     if payload.len() < min_size {
@@ -98,6 +118,9 @@ pub fn analyze_netbios_dgm(payload: &[u8]) -> Option<NetBiosInfo> {
         service: NetBiosService::DatagramService,
         opcode,
         name,
+        transaction_id: u16::from_be_bytes([payload[2], payload[3]]),
+        is_response: response_status.is_some(),
+        response_status,
     })
 }
 
@@ -230,6 +253,9 @@ mod tests {
         assert_eq!(info.service, NetBiosService::NameService);
         assert_eq!(info.opcode, NetBiosOpcode::Query);
         assert_eq!(info.name, Some("WORKSTATION".to_string()));
+        assert_eq!(info.transaction_id, 1);
+        assert!(!info.is_response);
+        assert_eq!(info.response_status, None);
     }
 
     #[test]
@@ -239,6 +265,36 @@ mod tests {
         assert_eq!(info.service, NetBiosService::NameService);
         assert_eq!(info.opcode, NetBiosOpcode::Response);
         assert_eq!(info.name, Some("FILESERVER".to_string()));
+        assert_eq!(info.transaction_id, 1);
+        assert!(info.is_response);
+        assert_eq!(
+            info.response_status,
+            Some(NetBiosResponseStatus::NameService(0))
+        );
+    }
+
+    #[test]
+    fn test_nbns_negative_response_status() {
+        let mut packet = build_nbns_response("MISSING");
+        packet[3] = 0x03; // NAM_ERR
+        let info = analyze_netbios_ns(&packet).expect("should parse");
+        assert_eq!(
+            info.response_status,
+            Some(NetBiosResponseStatus::NameService(3))
+        );
+        assert_eq!(info.response_status.unwrap().to_string(), "NAM_ERR");
+        assert!(!info.response_status.unwrap().is_success());
+    }
+
+    #[test]
+    fn test_nbns_wack_is_not_final_response() {
+        let mut packet = [0u8; MIN_NBNS_SIZE];
+        packet[0..2].copy_from_slice(&0x1234u16.to_be_bytes());
+        packet[2..4].copy_from_slice(&0xB800u16.to_be_bytes());
+        let info = analyze_netbios_ns(&packet).expect("should parse");
+        assert_eq!(info.opcode, NetBiosOpcode::Wack);
+        assert!(!info.is_response);
+        assert_eq!(info.response_status, None);
     }
 
     #[test]
@@ -278,6 +334,25 @@ mod tests {
         let info = analyze_netbios_dgm(&packet).expect("should parse");
         assert_eq!(info.opcode, NetBiosOpcode::Query);
         assert_eq!(info.name, Some("FILESERVER".to_string()));
+        assert_eq!(info.transaction_id, 0);
+        assert!(!info.is_response);
+    }
+
+    #[test]
+    fn test_nbdgm_negative_query_response() {
+        let mut packet = vec![0u8; 10];
+        packet[0] = 0x16;
+        packet[2..4].copy_from_slice(&0x4567u16.to_be_bytes());
+        packet.extend_from_slice(&encode_netbios_name("FILESERVER"));
+        let info = analyze_netbios_dgm(&packet).expect("should parse");
+        assert_eq!(info.opcode, NetBiosOpcode::Response);
+        assert_eq!(info.transaction_id, 0x4567);
+        assert!(info.is_response);
+        assert_eq!(
+            info.response_status,
+            Some(NetBiosResponseStatus::DatagramNegative)
+        );
+        assert!(!info.response_status.unwrap().is_success());
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -7,7 +7,7 @@ use crate::network::dpi::{DpiResult, is_partial_sni, try_extract_tls_from_reasse
 use crate::network::parser::{ParsedPacket, TcpFlags};
 use crate::network::types::{
     ApplicationProtocol, Connection, DnsInfo, DpiInfo, FtpInfo, HttpInfo, HttpsInfo, MqttInfo,
-    ProtocolState, QuicConnectionState, QuicInfo, SshInfo, TcpState,
+    NetBiosInfo, ProtocolState, QuicConnectionState, QuicInfo, SshInfo, TcpState,
 };
 
 /// Get the priority of a QUIC connection state for proper state progression
@@ -565,6 +565,14 @@ fn merge_dpi_info(conn: &mut Connection, dpi_result: &DpiResult) {
                     merge_dns_info(old_info, new_info);
                 }
 
+                // NetBIOS request/response merging
+                (
+                    ApplicationProtocol::NetBios(old_info),
+                    ApplicationProtocol::NetBios(new_info),
+                ) => {
+                    merge_netbios_info(old_info, new_info);
+                }
+
                 // SSH - merge SSH info
                 (ApplicationProtocol::Ssh(old_info), ApplicationProtocol::Ssh(new_info)) => {
                     merge_ssh_info(old_info, new_info);
@@ -908,6 +916,26 @@ fn merge_dns_info(old_info: &mut DnsInfo, new_info: &DnsInfo) {
     }
 }
 
+/// Merge NetBIOS request and response information.
+fn merge_netbios_info(old_info: &mut NetBiosInfo, new_info: &NetBiosInfo) {
+    if old_info.name.is_none() && new_info.name.is_some() {
+        old_info.name.clone_from(&new_info.name);
+    }
+
+    old_info.opcode = new_info.opcode;
+    old_info.transaction_id = new_info.transaction_id;
+
+    if new_info.is_response {
+        old_info.is_response = true;
+    }
+
+    // Keep the last completed response status. A later request on the same
+    // socket must not erase it before its response arrives.
+    if new_info.response_status.is_some() {
+        old_info.response_status = new_info.response_status;
+    }
+}
+
 /// Merge SSH information
 fn merge_ssh_info(old_info: &mut SshInfo, new_info: &SshInfo) {
     // Update version if not set
@@ -1144,6 +1172,52 @@ mod tests {
         };
         merge_dns_info(&mut old, &new_response);
         assert_eq!(old.rcode, Some(0), "the latest response code wins");
+    }
+
+    #[test]
+    fn test_merge_netbios_keeps_status_and_tracks_latest_transaction() {
+        use crate::network::types::{NetBiosOpcode, NetBiosResponseStatus, NetBiosService};
+
+        let mut old = NetBiosInfo {
+            service: NetBiosService::NameService,
+            opcode: NetBiosOpcode::Response,
+            name: Some("FILESERVER".to_string()),
+            transaction_id: 0x1111,
+            is_response: true,
+            response_status: Some(NetBiosResponseStatus::NameService(3)),
+        };
+        let new_query = NetBiosInfo {
+            service: NetBiosService::NameService,
+            opcode: NetBiosOpcode::Query,
+            name: None,
+            transaction_id: 0x2222,
+            is_response: false,
+            response_status: None,
+        };
+
+        merge_netbios_info(&mut old, &new_query);
+        assert_eq!(old.opcode, NetBiosOpcode::Query);
+        assert_eq!(old.transaction_id, 0x2222);
+        assert_eq!(
+            old.response_status,
+            Some(NetBiosResponseStatus::NameService(3)),
+            "a request must not erase the last response status"
+        );
+
+        let new_response = NetBiosInfo {
+            service: NetBiosService::NameService,
+            opcode: NetBiosOpcode::Response,
+            name: None,
+            transaction_id: 0x2222,
+            is_response: true,
+            response_status: Some(NetBiosResponseStatus::NameService(0)),
+        };
+        merge_netbios_info(&mut old, &new_response);
+        assert_eq!(old.opcode, NetBiosOpcode::Response);
+        assert_eq!(
+            old.response_status,
+            Some(NetBiosResponseStatus::NameService(0))
+        );
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -175,6 +175,9 @@ pub struct IngestOutcome {
     /// The latest completed DNS query→response round trip, if this packet was
     /// a response matching a pending query by transaction ID.
     pub dns_response_time: Option<Duration>,
+    /// The latest completed NetBIOS request-to-response round trip, if this
+    /// packet matched a pending request by transaction ID.
+    pub netbios_response_time: Option<Duration>,
 }
 
 /// A live, lifecycle-managed table of network connections built from parsed
@@ -287,6 +290,23 @@ impl ConnectionTracker {
             );
         }
 
+        // NetBIOS Name Service broadcasts are answered from a host's unicast
+        // address, so the RTT tracker pairs on local socket, service, and
+        // transaction ID rather than the full connection key.
+        let mut netbios_response_time: Option<Duration> = None;
+        if parsed.protocol == Protocol::Udp
+            && let Some(dpi) = &parsed.dpi_result
+            && let ApplicationProtocol::NetBios(netbios) = &dpi.application
+            && let Ok(mut tracker) = self.rtt.lock()
+        {
+            netbios_response_time = tracker.record_netbios_packet(
+                base_key.local_addr,
+                netbios,
+                parsed.is_outgoing,
+                now,
+            );
+        }
+
         // A read guard makes ordinary packet updates atomic with cleanup. The
         // uncommon generation-split path drops it and reacquires a write guard
         // so retained-source readers also see one consistent move.
@@ -308,6 +328,7 @@ impl ConnectionTracker {
                 fast_retransmits: 0,
                 measured_rtt,
                 dns_response_time,
+                netbios_response_time,
             };
         }
 
@@ -317,10 +338,24 @@ impl ConnectionTracker {
             .is_some_and(|conn| Self::packet_starts_new_generation(&conn, parsed));
         if starts_new_generation {
             drop(lifecycle);
-            return self.ingest_new_generation(parsed, now, key, measured_rtt, dns_response_time);
+            return self.ingest_new_generation(
+                parsed,
+                now,
+                key,
+                measured_rtt,
+                dns_response_time,
+                netbios_response_time,
+            );
         }
 
-        self.ingest_into_active(parsed, now, key, measured_rtt, dns_response_time)
+        self.ingest_into_active(
+            parsed,
+            now,
+            key,
+            measured_rtt,
+            dns_response_time,
+            netbios_response_time,
+        )
     }
 
     fn ingest_into_active(
@@ -330,6 +365,7 @@ impl ConnectionTracker {
         key: ConnectionKey,
         measured_rtt: Option<Duration>,
         dns_response_time: Option<Duration>,
+        netbios_response_time: Option<Duration>,
     ) -> IngestOutcome {
         // Prevent unbounded growth from port scans or connection floods. Only
         // limit new connections; existing ones always get updated. The fast
@@ -351,6 +387,7 @@ impl ConnectionTracker {
                 fast_retransmits: 0,
                 measured_rtt,
                 dns_response_time,
+                netbios_response_time,
             };
         }
 
@@ -370,6 +407,9 @@ impl ConnectionTracker {
                 if let Some(rtt) = dns_response_time {
                     conn.dns_response_time = Some(rtt);
                 }
+                if let Some(rtt) = netbios_response_time {
+                    conn.netbios_response_time = Some(rtt);
+                }
             })
             .or_insert_with(|| {
                 created = true;
@@ -379,6 +419,9 @@ impl ConnectionTracker {
                 }
                 if let Some(rtt) = dns_response_time {
                     conn.dns_response_time = Some(rtt);
+                }
+                if let Some(rtt) = netbios_response_time {
+                    conn.netbios_response_time = Some(rtt);
                 }
                 conn
             });
@@ -406,6 +449,7 @@ impl ConnectionTracker {
             fast_retransmits: deltas.fast_retransmits,
             measured_rtt,
             dns_response_time,
+            netbios_response_time,
         }
     }
 
@@ -416,6 +460,7 @@ impl ConnectionTracker {
         key: ConnectionKey,
         measured_rtt: Option<Duration>,
         dns_response_time: Option<Duration>,
+        netbios_response_time: Option<Duration>,
     ) -> IngestOutcome {
         let _lifecycle = self
             .lifecycle
@@ -458,6 +503,7 @@ impl ConnectionTracker {
             key,
             measured_rtt,
             dns_response_time,
+            netbios_response_time,
         );
         outcome.archived = archived;
         self.enforce_historic_limit();
@@ -832,6 +878,7 @@ impl Default for ConnectionTracker {
 mod tests {
     use super::*;
     use crate::network::parser::PacketParser;
+    use crate::network::types::NetBiosOpcode;
 
     /// A minimal Ethernet+IPv4+UDP frame, parsed into a `ParsedPacket` so we can
     /// exercise the tracker with a realistic input.
@@ -942,6 +989,42 @@ mod tests {
                     is_response,
                     txid,
                     rcode: is_response.then_some(rcode),
+                }),
+            }),
+            process_name: None,
+            process_id: None,
+        }
+    }
+
+    fn netbios_packet(
+        transaction_id: u16,
+        is_outgoing: bool,
+        opcode: NetBiosOpcode,
+        is_response: bool,
+        remote_ip: [u8; 4],
+    ) -> ParsedPacket {
+        use crate::network::dpi::DpiResult;
+        use crate::network::types::{
+            NetBiosInfo, NetBiosResponseStatus, NetBiosService, ProtocolState,
+        };
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        ParsedPacket {
+            protocol: Protocol::Udp,
+            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 137),
+            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::from(remote_ip)), 137),
+            protocol_state: ProtocolState::Udp,
+            tcp_header: None,
+            is_outgoing,
+            packet_len: 80,
+            dpi_result: Some(DpiResult {
+                application: ApplicationProtocol::NetBios(NetBiosInfo {
+                    service: NetBiosService::NameService,
+                    opcode,
+                    name: Some("FILESERVER".to_string()),
+                    transaction_id,
+                    is_response,
+                    response_status: is_response.then_some(NetBiosResponseStatus::NameService(0)),
                 }),
             }),
             process_name: None,
@@ -1170,6 +1253,107 @@ mod tests {
         tracker.ingest_at(&dns_packet(0x1234, true, false, 0), capture_time(0));
         let response = tracker.ingest_at(&dns_packet(0x1234, false, true, 2), capture_time(40));
         assert_eq!(response.dns_response_time, Some(Duration::from_millis(40)));
+    }
+
+    /// Name Service requests are normally broadcast, then answered from a
+    /// host's unicast address. The transaction still pairs even though the
+    /// request and response belong to different connection-table keys.
+    #[test]
+    fn netbios_broadcast_request_measures_unicast_response_time() {
+        let tracker = ConnectionTracker::new();
+        let query = tracker.ingest_at(
+            &netbios_packet(
+                0x1234,
+                true,
+                NetBiosOpcode::Query,
+                false,
+                [255, 255, 255, 255],
+            ),
+            capture_time(0),
+        );
+        assert!(query.netbios_response_time.is_none());
+
+        let response = tracker.ingest_at(
+            &netbios_packet(
+                0x1234,
+                false,
+                NetBiosOpcode::Response,
+                true,
+                [192, 168, 0, 20],
+            ),
+            capture_time(27),
+        );
+        assert_ne!(query.key, response.key);
+        assert_eq!(
+            response.netbios_response_time,
+            Some(Duration::from_millis(27))
+        );
+        let conn = tracker.connections().get(&response.key).unwrap().clone();
+        assert_eq!(conn.netbios_response_time, Some(Duration::from_millis(27)));
+        assert!(conn.initial_rtt.is_none());
+    }
+
+    #[test]
+    fn netbios_response_with_unknown_transaction_id_measures_nothing() {
+        let tracker = ConnectionTracker::new();
+        tracker.ingest_at(
+            &netbios_packet(
+                0x1234,
+                true,
+                NetBiosOpcode::Query,
+                false,
+                [255, 255, 255, 255],
+            ),
+            capture_time(0),
+        );
+        let response = tracker.ingest_at(
+            &netbios_packet(
+                0x9999,
+                false,
+                NetBiosOpcode::Response,
+                true,
+                [192, 168, 0, 20],
+            ),
+            capture_time(27),
+        );
+        assert!(response.netbios_response_time.is_none());
+    }
+
+    /// A WACK extends an NBNS transaction and must not consume its pending
+    /// request. The eventual final response completes the original timing.
+    #[test]
+    fn netbios_wack_keeps_request_pending() {
+        let tracker = ConnectionTracker::new();
+        tracker.ingest_at(
+            &netbios_packet(
+                0x1234,
+                true,
+                NetBiosOpcode::Registration,
+                false,
+                [192, 168, 0, 2],
+            ),
+            capture_time(0),
+        );
+        let wack = tracker.ingest_at(
+            &netbios_packet(0x1234, false, NetBiosOpcode::Wack, false, [192, 168, 0, 2]),
+            capture_time(10),
+        );
+        assert!(wack.netbios_response_time.is_none());
+
+        let response = tracker.ingest_at(
+            &netbios_packet(
+                0x1234,
+                false,
+                NetBiosOpcode::Response,
+                true,
+                [192, 168, 0, 2],
+            ),
+            capture_time(40),
+        );
+        assert_eq!(
+            response.netbios_response_time,
+            Some(Duration::from_millis(40))
+        );
     }
 
     /// 1-RTT packets carry a short header with nothing timeable in the clear.

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -336,14 +336,25 @@ impl ConnectionTracker {
         if parsed.protocol == Protocol::Udp
             && let Some(dpi) = &parsed.dpi_result
             && let ApplicationProtocol::NetBios(netbios) = &dpi.application
-            && let Ok(mut tracker) = self.rtt.lock()
         {
-            netbios_response_time = tracker.record_netbios_packet(
-                base_key.local_addr,
-                netbios,
-                parsed.is_outgoing,
-                now,
-            );
+            let completed = match self.rtt.lock() {
+                Ok(mut tracker) => {
+                    tracker.record_netbios_packet(base_key, netbios, parsed.is_outgoing, now)
+                }
+                Err(_) => None,
+            };
+            if let Some((rtt, request_key)) = completed {
+                netbios_response_time = Some(rtt);
+                // A broadcast request and its unicast reply live under
+                // different keys. Stamp the requesting connection too, so the
+                // row showing the query also shows its round trip; this
+                // packet's own connection is updated in the ingest path below.
+                if request_key != base_key
+                    && let Some(mut conn) = self.connections.get_mut(&request_key)
+                {
+                    conn.netbios_response_time = Some(rtt);
+                }
+            }
         }
 
         // ICMP echo requests reuse one identifier for the life of a ping
@@ -1562,6 +1573,14 @@ mod tests {
         let conn = tracker.connections().get(&response.key).unwrap().clone();
         assert_eq!(conn.netbios_response_time, Some(Duration::from_millis(27)));
         assert!(conn.initial_rtt.is_none());
+
+        // The broadcast row is the one a user naturally inspects, so the
+        // round trip must land there as well, not only on the responder.
+        let query_conn = tracker.connections().get(&query.key).unwrap().clone();
+        assert_eq!(
+            query_conn.netbios_response_time,
+            Some(Duration::from_millis(27))
+        );
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -921,12 +921,69 @@ pub struct NetBiosInfo {
     pub service: NetBiosService,
     pub opcode: NetBiosOpcode,
     pub name: Option<String>,
+    /// Name Service transaction ID or Datagram Service datagram ID.
+    pub transaction_id: u16,
+    /// Whether this packet is a final response to a request.
+    ///
+    /// Name Service WACK packets are deliberately excluded because a later
+    /// response completes the transaction.
+    pub is_response: bool,
+    /// Result carried by a final Name or Datagram Service response.
+    pub response_status: Option<NetBiosResponseStatus>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+impl NetBiosInfo {
+    pub fn is_request(&self) -> bool {
+        !self.is_response
+            && matches!(
+                self.opcode,
+                NetBiosOpcode::Query
+                    | NetBiosOpcode::Registration
+                    | NetBiosOpcode::Release
+                    | NetBiosOpcode::Refresh
+            )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NetBiosService {
     NameService,
     DatagramService,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetBiosResponseStatus {
+    /// Four-bit RCODE from a NetBIOS Name Service response.
+    NameService(u8),
+    DatagramPositive,
+    DatagramNegative,
+}
+
+impl NetBiosResponseStatus {
+    pub fn is_success(self) -> bool {
+        matches!(
+            self,
+            NetBiosResponseStatus::NameService(0) | NetBiosResponseStatus::DatagramPositive
+        )
+    }
+}
+
+impl std::fmt::Display for NetBiosResponseStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NetBiosResponseStatus::NameService(0) => write!(f, "SUCCESS"),
+            NetBiosResponseStatus::NameService(1) => write!(f, "FMT_ERR"),
+            NetBiosResponseStatus::NameService(2) => write!(f, "SRV_ERR"),
+            NetBiosResponseStatus::NameService(3) => write!(f, "NAM_ERR"),
+            NetBiosResponseStatus::NameService(4) => write!(f, "IMP_ERR"),
+            NetBiosResponseStatus::NameService(5) => write!(f, "RFS_ERR"),
+            NetBiosResponseStatus::NameService(6) => write!(f, "ACT_ERR"),
+            NetBiosResponseStatus::NameService(7) => write!(f, "CFT_ERR"),
+            NetBiosResponseStatus::NameService(code) => write!(f, "RCODE {}", code),
+            NetBiosResponseStatus::DatagramPositive => write!(f, "POSITIVE"),
+            NetBiosResponseStatus::DatagramNegative => write!(f, "NEGATIVE"),
+        }
+    }
 }
 
 impl std::fmt::Display for NetBiosService {
@@ -1887,12 +1944,18 @@ pub struct RttTracker {
     /// Outbound DNS queries awaiting their response, keyed by connection and
     /// transaction ID (stub resolvers reuse one socket for many queries).
     pending_dns: HashMap<(ConnectionKey, u16), SystemTime>,
+    /// Outbound NetBIOS requests awaiting a response. The remote endpoint is
+    /// intentionally absent because Name Service requests are commonly sent
+    /// to a broadcast address and answered by an individual host.
+    pending_netbios: HashMap<(SocketAddr, NetBiosService, u16), SystemTime>,
     /// Recent RTT measurements for aggregation: (timestamp, rtt_duration)
     recent_rtts: VecDeque<(Instant, Duration)>,
     /// Maximum age for pending SYNs (cleanup stale entries)
     max_pending_age: Duration,
     /// Maximum age for pending DNS queries, well past any resolver timeout
     max_pending_dns_age: Duration,
+    /// Maximum age for pending NetBIOS requests.
+    max_pending_netbios_age: Duration,
     /// Maximum number of recent RTTs to keep
     max_recent_rtts: usize,
 }
@@ -1901,15 +1964,20 @@ pub struct RttTracker {
 /// query flood costs unmatched samples, never memory.
 const MAX_PENDING_DNS: usize = 4096;
 
+/// Hard cap on pending NetBIOS requests.
+const MAX_PENDING_NETBIOS: usize = 4096;
+
 impl RttTracker {
     pub fn new() -> Self {
         Self {
             pending_syns: HashMap::new(),
             pending_quic_handshakes: HashMap::new(),
             pending_dns: HashMap::new(),
+            pending_netbios: HashMap::new(),
             recent_rtts: VecDeque::new(),
             max_pending_age: Duration::from_secs(30),
             max_pending_dns_age: Duration::from_secs(10),
+            max_pending_netbios_age: Duration::from_secs(10),
             max_recent_rtts: 100,
         }
     }
@@ -2002,6 +2070,38 @@ impl RttTracker {
         }
     }
 
+    /// Record a NetBIOS packet and return the request-to-response time when an
+    /// incoming final response matches an outgoing request.
+    ///
+    /// NetBIOS Name Service usually sends requests to a broadcast address,
+    /// while the responding host replies from its unicast address. Pairing by
+    /// local socket, service, and transaction ID handles both broadcast and
+    /// unicast exchanges. Like DNS timing, the result includes remote service
+    /// processing and is not added to transport RTT aggregates.
+    pub fn record_netbios_packet(
+        &mut self,
+        local_addr: SocketAddr,
+        info: &NetBiosInfo,
+        is_outgoing: bool,
+        at: SystemTime,
+    ) -> Option<Duration> {
+        self.cleanup_stale(at);
+        let key = (local_addr, info.service, info.transaction_id);
+        if is_outgoing && info.is_request() {
+            if self.pending_netbios.len() < MAX_PENDING_NETBIOS
+                || self.pending_netbios.contains_key(&key)
+            {
+                self.pending_netbios.insert(key, at);
+            }
+            return None;
+        }
+        if !is_outgoing && info.is_response {
+            let sent_at = self.pending_netbios.remove(&key)?;
+            return Some(at.duration_since(sent_at).unwrap_or_default());
+        }
+        None
+    }
+
     /// Record a completed data round trip (segment to covering ACK) measured
     /// by the per-connection estimator, so the aggregate RTT view reflects
     /// established connections rather than only fresh handshakes.
@@ -2047,6 +2147,9 @@ impl RttTracker {
         if let Some(dns_cutoff) = now.checked_sub(self.max_pending_dns_age) {
             self.pending_dns.retain(|_, ts| *ts > dns_cutoff);
         }
+        if let Some(netbios_cutoff) = now.checked_sub(self.max_pending_netbios_age) {
+            self.pending_netbios.retain(|_, ts| *ts > netbios_cutoff);
+        }
     }
 
     /// Clear all RTT tracking data
@@ -2054,6 +2157,7 @@ impl RttTracker {
         self.pending_syns.clear();
         self.pending_quic_handshakes.clear();
         self.pending_dns.clear();
+        self.pending_netbios.clear();
         self.recent_rtts.clear();
     }
 }
@@ -2606,6 +2710,10 @@ pub struct Connection {
     // separate from the transport-level `initial_rtt`.
     pub dns_response_time: Option<std::time::Duration>,
 
+    // Latest NetBIOS request-to-response time, paired by transaction ID.
+    // Kept separate from transport RTT because it includes service processing.
+    pub netbios_response_time: Option<std::time::Duration>,
+
     // GeoIP information for remote address
     pub geoip_info: Option<crate::network::geoip::GeoIpInfo>,
 
@@ -2666,6 +2774,7 @@ impl Connection {
             tcp_analytics,
             initial_rtt: None,
             dns_response_time: None,
+            netbios_response_time: None,
             geoip_info: None,
             is_historic: false,
             closed_at: None,
@@ -4361,6 +4470,25 @@ mod tests {
         SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000) + Duration::from_millis(millis)
     }
 
+    fn netbios_test_info(
+        service: NetBiosService,
+        transaction_id: u16,
+        is_response: bool,
+    ) -> NetBiosInfo {
+        NetBiosInfo {
+            service,
+            opcode: if is_response {
+                NetBiosOpcode::Response
+            } else {
+                NetBiosOpcode::Query
+            },
+            name: Some("FILESERVER".to_string()),
+            transaction_id,
+            is_response,
+            response_status: is_response.then_some(NetBiosResponseStatus::NameService(0)),
+        }
+    }
+
     #[test]
     fn test_rtt_tracker_new() {
         let tracker = RttTracker::new();
@@ -4481,6 +4609,50 @@ mod tests {
         // ...but a retransmit of a tracked query still restarts its timer.
         tracker.record_dns_packet(key, 42, true, false, rtt_capture_time(1_000));
         let rtt = tracker.record_dns_packet(key, 42, false, true, rtt_capture_time(1_015));
+        assert_eq!(rtt, Some(Duration::from_millis(15)));
+    }
+
+    #[test]
+    fn test_rtt_tracker_pending_netbios_expires() {
+        let mut tracker = RttTracker::new();
+        let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 137);
+        let request = netbios_test_info(NetBiosService::NameService, 0x1234, false);
+        let response = netbios_test_info(NetBiosService::NameService, 0x1234, true);
+
+        tracker.record_netbios_packet(local, &request, true, rtt_capture_time(0));
+        let rtt = tracker.record_netbios_packet(local, &response, false, rtt_capture_time(11_000));
+        assert!(rtt.is_none(), "the pending request expired after 10s");
+        assert!(tracker.pending_netbios.is_empty());
+    }
+
+    #[test]
+    fn test_rtt_tracker_pending_netbios_capped() {
+        let mut tracker = RttTracker::new();
+        let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 137);
+
+        for transaction_id in 0..MAX_PENDING_NETBIOS as u16 {
+            let request = netbios_test_info(NetBiosService::NameService, transaction_id, false);
+            tracker.record_netbios_packet(local, &request, true, rtt_capture_time(0));
+        }
+        assert_eq!(tracker.pending_netbios.len(), MAX_PENDING_NETBIOS);
+
+        let overflow_local = SocketAddr::new(local.ip(), 138);
+        let overflow_request = netbios_test_info(NetBiosService::DatagramService, 7, false);
+        let overflow_response = netbios_test_info(NetBiosService::DatagramService, 7, true);
+        tracker.record_netbios_packet(overflow_local, &overflow_request, true, rtt_capture_time(1));
+        assert_eq!(tracker.pending_netbios.len(), MAX_PENDING_NETBIOS);
+        let rtt = tracker.record_netbios_packet(
+            overflow_local,
+            &overflow_response,
+            false,
+            rtt_capture_time(20),
+        );
+        assert!(rtt.is_none());
+
+        let request = netbios_test_info(NetBiosService::NameService, 42, false);
+        let response = netbios_test_info(NetBiosService::NameService, 42, true);
+        tracker.record_netbios_packet(local, &request, true, rtt_capture_time(1_000));
+        let rtt = tracker.record_netbios_packet(local, &response, false, rtt_capture_time(1_015));
         assert_eq!(rtt, Some(Duration::from_millis(15)));
     }
 

--- a/crates/rustnet-core/src/network/types.rs
+++ b/crates/rustnet-core/src/network/types.rs
@@ -2039,9 +2039,11 @@ pub struct RttTracker {
     /// transaction ID (stub resolvers reuse one socket for many queries).
     pending_dns: HashMap<(ConnectionKey, u16), SystemTime>,
     /// Outbound NetBIOS requests awaiting a response. The remote endpoint is
-    /// intentionally absent because Name Service requests are commonly sent
-    /// to a broadcast address and answered by an individual host.
-    pending_netbios: HashMap<(SocketAddr, NetBiosService, u16), SystemTime>,
+    /// intentionally absent from the map key because Name Service requests are
+    /// commonly sent to a broadcast address and answered by an individual
+    /// host. The requesting connection's key is stored so a reply arriving
+    /// under the responder's unicast key can stamp the request row too.
+    pending_netbios: HashMap<(SocketAddr, NetBiosService, u16), (SystemTime, ConnectionKey)>,
     /// Outbound ICMP echo requests awaiting replies, keyed by connection,
     /// identifier, and sequence number. The sequence keeps fast pings distinct.
     pending_icmp_echoes: HashMap<(ConnectionKey, u16, u16), SystemTime>,
@@ -2196,34 +2198,37 @@ impl RttTracker {
         }
     }
 
-    /// Record a NetBIOS packet and return the request-to-response time when an
-    /// incoming final response matches an outgoing request.
+    /// Record a NetBIOS packet and, when an incoming final response matches an
+    /// outgoing request, return the request-to-response time together with the
+    /// requesting connection's key.
     ///
     /// NetBIOS Name Service usually sends requests to a broadcast address,
     /// while the responding host replies from its unicast address. Pairing by
     /// local socket, service, and transaction ID handles both broadcast and
-    /// unicast exchanges. Like DNS timing, the result includes remote service
+    /// unicast exchanges; the returned key lets the caller stamp the round
+    /// trip on the requesting connection when the reply arrives under a
+    /// different one. Like DNS timing, the result includes remote service
     /// processing and is not added to transport RTT aggregates.
     pub fn record_netbios_packet(
         &mut self,
-        local_addr: SocketAddr,
+        key: ConnectionKey,
         info: &NetBiosInfo,
         is_outgoing: bool,
         at: SystemTime,
-    ) -> Option<Duration> {
+    ) -> Option<(Duration, ConnectionKey)> {
         self.cleanup_stale(at);
-        let key = (local_addr, info.service, info.transaction_id);
+        let pending_key = (key.local_addr, info.service, info.transaction_id);
         if is_outgoing && info.is_request() {
             if self.pending_netbios.len() < MAX_PENDING_NETBIOS
-                || self.pending_netbios.contains_key(&key)
+                || self.pending_netbios.contains_key(&pending_key)
             {
-                self.pending_netbios.insert(key, at);
+                self.pending_netbios.insert(pending_key, (at, key));
             }
             return None;
         }
         if !is_outgoing && info.is_response {
-            let sent_at = self.pending_netbios.remove(&key)?;
-            return Some(at.duration_since(sent_at).unwrap_or_default());
+            let (sent_at, request_key) = self.pending_netbios.remove(&pending_key)?;
+            return Some((at.duration_since(sent_at).unwrap_or_default(), request_key));
         }
         None
     }
@@ -2380,7 +2385,8 @@ impl RttTracker {
             self.pending_dns.retain(|_, ts| *ts > dns_cutoff);
         }
         if let Some(netbios_cutoff) = now.checked_sub(self.max_pending_netbios_age) {
-            self.pending_netbios.retain(|_, ts| *ts > netbios_cutoff);
+            self.pending_netbios
+                .retain(|_, (ts, _)| *ts > netbios_cutoff);
         }
         if let Some(icmp_cutoff) = now.checked_sub(self.max_pending_icmp_age) {
             self.pending_icmp_echoes.retain(|_, ts| *ts > icmp_cutoff);
@@ -4924,12 +4930,16 @@ mod tests {
     #[test]
     fn test_rtt_tracker_pending_netbios_expires() {
         let mut tracker = RttTracker::new();
-        let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 137);
+        let key = ConnectionKey::new(
+            Protocol::Udp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 137),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255)), 137),
+        );
         let request = netbios_test_info(NetBiosService::NameService, 0x1234, false);
         let response = netbios_test_info(NetBiosService::NameService, 0x1234, true);
 
-        tracker.record_netbios_packet(local, &request, true, rtt_capture_time(0));
-        let rtt = tracker.record_netbios_packet(local, &response, false, rtt_capture_time(11_000));
+        tracker.record_netbios_packet(key, &request, true, rtt_capture_time(0));
+        let rtt = tracker.record_netbios_packet(key, &response, false, rtt_capture_time(11_000));
         assert!(rtt.is_none(), "the pending request expired after 10s");
         assert!(tracker.pending_netbios.is_empty());
     }
@@ -4938,20 +4948,26 @@ mod tests {
     fn test_rtt_tracker_pending_netbios_capped() {
         let mut tracker = RttTracker::new();
         let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 137);
+        let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255)), 137);
+        let key = ConnectionKey::new(Protocol::Udp, local, remote);
 
         for transaction_id in 0..MAX_PENDING_NETBIOS as u16 {
             let request = netbios_test_info(NetBiosService::NameService, transaction_id, false);
-            tracker.record_netbios_packet(local, &request, true, rtt_capture_time(0));
+            tracker.record_netbios_packet(key, &request, true, rtt_capture_time(0));
         }
         assert_eq!(tracker.pending_netbios.len(), MAX_PENDING_NETBIOS);
 
-        let overflow_local = SocketAddr::new(local.ip(), 138);
+        let overflow_key = ConnectionKey::new(
+            Protocol::Udp,
+            SocketAddr::new(local.ip(), 138),
+            SocketAddr::new(remote.ip(), 138),
+        );
         let overflow_request = netbios_test_info(NetBiosService::DatagramService, 7, false);
         let overflow_response = netbios_test_info(NetBiosService::DatagramService, 7, true);
-        tracker.record_netbios_packet(overflow_local, &overflow_request, true, rtt_capture_time(1));
+        tracker.record_netbios_packet(overflow_key, &overflow_request, true, rtt_capture_time(1));
         assert_eq!(tracker.pending_netbios.len(), MAX_PENDING_NETBIOS);
         let rtt = tracker.record_netbios_packet(
-            overflow_local,
+            overflow_key,
             &overflow_response,
             false,
             rtt_capture_time(20),
@@ -4960,9 +4976,13 @@ mod tests {
 
         let request = netbios_test_info(NetBiosService::NameService, 42, false);
         let response = netbios_test_info(NetBiosService::NameService, 42, true);
-        tracker.record_netbios_packet(local, &request, true, rtt_capture_time(1_000));
-        let rtt = tracker.record_netbios_packet(local, &response, false, rtt_capture_time(1_015));
-        assert_eq!(rtt, Some(Duration::from_millis(15)));
+        tracker.record_netbios_packet(key, &request, true, rtt_capture_time(1_000));
+        let rtt = tracker.record_netbios_packet(key, &response, false, rtt_capture_time(1_015));
+        assert_eq!(
+            rtt,
+            Some((Duration::from_millis(15), key)),
+            "a match returns the round trip and the requesting connection's key"
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1387,6 +1387,56 @@ mod snapshot_tests {
         );
     }
 
+    #[test]
+    fn details_tab_netbios_shows_response_time_in_transport_health() {
+        use crate::network::types::{
+            ApplicationProtocol, DpiInfo, NetBiosInfo, NetBiosOpcode, NetBiosResponseStatus,
+            NetBiosService,
+        };
+
+        let app = test_app();
+        let mut connections = sample_connections();
+        let netbios_conn = &mut connections[1];
+        netbios_conn.netbios_response_time = Some(Duration::from_micros(18_700));
+        netbios_conn.dpi_info = Some(DpiInfo {
+            application: ApplicationProtocol::NetBios(NetBiosInfo {
+                service: NetBiosService::NameService,
+                opcode: NetBiosOpcode::Response,
+                name: Some("FILESERVER".to_string()),
+                transaction_id: 0x1234,
+                is_response: true,
+                response_status: Some(NetBiosResponseStatus::NameService(3)),
+            }),
+            last_update_time: std::time::Instant::now(),
+        });
+
+        app.set_connections_snapshot_for_test(connections.clone());
+        let stats = app.get_stats();
+        let ui_state = UIState {
+            selected_tab: 1,
+            selected_connection_key: Some(connections[1].key()),
+            ..Default::default()
+        };
+        let mut click_regions = ClickableRegions::default();
+        let output = render(140, 40, |f| {
+            draw(
+                f,
+                &app,
+                &ui_state,
+                &connections,
+                None,
+                &stats,
+                &mut click_regions,
+            )
+            .expect("draw details");
+        });
+
+        assert!(output.contains("NetBIOS Response Time") && output.contains("18.7ms"));
+        assert!(output.contains("Last Response Status") && output.contains("NAM_ERR"));
+        assert!(output.contains("Timed by pairing request and response IDs"));
+        assert!(!output.contains("No transport metrics for this protocol"));
+    }
+
     /// The Attribution section repeats PID beside the richer process fields so
     /// the identity remains visible as one self-contained block.
     #[test]

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -1857,6 +1857,16 @@ pub(in crate::ui) fn draw_connection_details(
                 })
         })
         .flatten();
+    let netbios_info = (conn.protocol == Protocol::Udp)
+        .then(|| {
+            conn.dpi_info
+                .as_ref()
+                .and_then(|dpi| match &dpi.application {
+                    crate::network::types::ApplicationProtocol::NetBios(info) => Some(info),
+                    _ => None,
+                })
+        })
+        .flatten();
     let metrics_start = details_text.len();
     push_detail_section(&mut details_text, &mut detail_fields, "Transport Health");
     let show_rtt = conn.protocol == Protocol::Tcp || quic_info.is_some();
@@ -1917,6 +1927,63 @@ pub(in crate::ui) fn draw_connection_details(
             &mut details_text,
             &mut detail_fields,
             "Timed by pairing query and response IDs",
+        );
+    } else if let Some(netbios) = netbios_info {
+        if let Some(rtt) = conn.netbios_response_time {
+            let rtt_ms = rtt.as_secs_f64() * 1000.0;
+            let rtt_color = if rtt_ms < 50.0 {
+                theme::ok()
+            } else if rtt_ms < 150.0 {
+                theme::warn()
+            } else {
+                theme::err()
+            };
+            push_detail_field_styled(
+                &mut details_text,
+                &mut detail_fields,
+                "NetBIOS Response Time",
+                format!("{:.1}ms", rtt_ms),
+                label_style,
+                theme::fg(rtt_color),
+            );
+        } else {
+            push_detail_field(
+                &mut details_text,
+                &mut detail_fields,
+                "NetBIOS Response Time",
+                NONE_PLACEHOLDER.to_string(),
+                label_style,
+            );
+        }
+        if let Some(status) = netbios.response_status {
+            let status_color = if status.is_success() {
+                theme::ok()
+            } else {
+                theme::err()
+            };
+            push_detail_field_styled(
+                &mut details_text,
+                &mut detail_fields,
+                "Last Response Status",
+                status.to_string(),
+                label_style,
+                theme::fg(status_color),
+            );
+        } else {
+            push_detail_field(
+                &mut details_text,
+                &mut detail_fields,
+                "Last Response Status",
+                NONE_PLACEHOLDER.to_string(),
+                label_style,
+            );
+        }
+        details_text.push(Line::from(""));
+        detail_fields.push(None);
+        push_detail_note(
+            &mut details_text,
+            &mut detail_fields,
+            "Timed by pairing request and response IDs",
         );
     } else if !show_rtt {
         // Nothing on a bare UDP/ICMP flow is timeable or countable: no


### PR DESCRIPTION
## Summary

- Pair NetBIOS Name and Datagram Service requests with responses, including broadcast replies and WACK handling.
- Show response time and status in Details, with bounded pending request storage.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`