### PR TITLE
refactor: deduplicate icmp parsing, timing guards, and test fixtures in rustnet-core

### DIFF
--- a/crates/rustnet-core/src/network/dpi/dns.rs
+++ b/crates/rustnet-core/src/network/dpi/dns.rs
@@ -435,6 +435,37 @@ fn skip_records(payload: &[u8], start: usize, count: u16) -> Option<usize> {
     Some(offset)
 }
 
+/// DNS wire-format builders shared by the DNS-family DPI tests: mDNS and
+/// LLMNR reuse the DNS packet layout, so their tests encode packets here.
+#[cfg(test)]
+pub(super) mod test_fixtures {
+    /// Append `name` as uncompressed DNS labels (split on '.') plus the null
+    /// terminator.
+    pub(crate) fn encode_name(packet: &mut Vec<u8>, name: &str) {
+        for label in name.split('.') {
+            packet.push(label.len() as u8);
+            packet.extend_from_slice(label.as_bytes());
+        }
+        packet.push(0x00);
+    }
+
+    /// A DNS packet with the given header `txid` and `flags`, one question
+    /// for `name` with `qtype` (class IN), and empty remaining sections.
+    pub(crate) fn build_dns_packet(txid: u16, flags: u16, name: &str, qtype: u16) -> Vec<u8> {
+        let mut packet = Vec::new();
+        packet.extend_from_slice(&txid.to_be_bytes());
+        packet.extend_from_slice(&flags.to_be_bytes());
+        packet.extend_from_slice(&[0x00, 0x01]); // Questions: 1
+        packet.extend_from_slice(&[0x00, 0x00]); // Answer RRs: 0
+        packet.extend_from_slice(&[0x00, 0x00]); // Authority RRs: 0
+        packet.extend_from_slice(&[0x00, 0x00]); // Additional RRs: 0
+        encode_name(&mut packet, name);
+        packet.extend_from_slice(&qtype.to_be_bytes());
+        packet.extend_from_slice(&[0x00, 0x01]); // Class: IN
+        packet
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rustnet-core/src/network/dpi/llmnr.rs
+++ b/crates/rustnet-core/src/network/dpi/llmnr.rs
@@ -13,63 +13,22 @@ use super::dns;
 /// Returns `None` if the packet cannot be parsed as DNS.
 pub fn analyze_llmnr(payload: &[u8]) -> Option<LlmnrInfo> {
     // Reuse DNS parser - LLMNR has the same wire format
-    let dns_info = dns::analyze_dns(payload)?;
-
-    Some(LlmnrInfo {
-        query_name: dns_info.query_name,
-        query_type: dns_info.query_type,
-        is_response: dns_info.is_response,
-        response_ips: dns_info.response_ips,
-    })
+    dns::analyze_dns(payload).map(LlmnrInfo::from)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::dns::test_fixtures::{build_dns_packet, encode_name};
     use super::*;
     use crate::network::types::DnsQueryType;
 
     fn build_llmnr_query(name: &str, qtype: u16) -> Vec<u8> {
-        let mut packet = Vec::new();
-
-        // DNS header (12 bytes)
-        packet.extend_from_slice(&[0x00, 0x01]); // Transaction ID
-        packet.extend_from_slice(&[0x00, 0x00]); // Flags (query)
-        packet.extend_from_slice(&[0x00, 0x01]); // Questions: 1
-        packet.extend_from_slice(&[0x00, 0x00]); // Answer RRs: 0
-        packet.extend_from_slice(&[0x00, 0x00]); // Authority RRs: 0
-        packet.extend_from_slice(&[0x00, 0x00]); // Additional RRs: 0
-
-        // Question section - encode name (single label for LLMNR)
-        packet.push(name.len() as u8);
-        packet.extend_from_slice(name.as_bytes());
-        packet.push(0x00); // Null terminator
-
-        // Query type and class
-        packet.extend_from_slice(&qtype.to_be_bytes());
-        packet.extend_from_slice(&[0x00, 0x01]); // Class: IN
-
-        packet
+        build_dns_packet(0x0001, 0x0000, name, qtype)
     }
 
     fn build_llmnr_response(name: &str, qtype: u16) -> Vec<u8> {
-        let mut packet = Vec::new();
-
-        // DNS header (12 bytes)
-        packet.extend_from_slice(&[0x00, 0x01]); // Transaction ID
-        packet.extend_from_slice(&[0x80, 0x00]); // Flags (response)
-        packet.extend_from_slice(&[0x00, 0x01]); // Questions: 1
-        packet.extend_from_slice(&[0x00, 0x00]); // Answer RRs: 0
-        packet.extend_from_slice(&[0x00, 0x00]); // Authority RRs: 0
-        packet.extend_from_slice(&[0x00, 0x00]); // Additional RRs: 0
-
-        // Question section
-        packet.push(name.len() as u8);
-        packet.extend_from_slice(name.as_bytes());
-        packet.push(0x00);
-        packet.extend_from_slice(&qtype.to_be_bytes());
-        packet.extend_from_slice(&[0x00, 0x01]);
-
-        packet
+        // Flags: response
+        build_dns_packet(0x0001, 0x8000, name, qtype)
     }
 
     #[test]
@@ -110,9 +69,7 @@ mod tests {
         packet.extend_from_slice(&[0x00, 0x01, 0x80, 0x00, 0x00, 0x01, 0x00, 0x01]);
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
         // Question (single label).
-        packet.push(name.len() as u8);
-        packet.extend_from_slice(name.as_bytes());
-        packet.push(0x00);
+        encode_name(&mut packet, name);
         packet.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]); // QTYPE A, QCLASS IN
         // Answer: NAME pointer back to offset 12, TYPE A, CLASS IN, TTL, RDLENGTH 4, RDATA.
         packet.extend_from_slice(&[

--- a/crates/rustnet-core/src/network/dpi/mdns.rs
+++ b/crates/rustnet-core/src/network/dpi/mdns.rs
@@ -16,67 +16,22 @@ use super::dns;
 ///
 /// Returns `None` if the packet cannot be parsed as DNS.
 pub fn analyze_mdns(payload: &[u8]) -> Option<MdnsInfo> {
-    let dns_info = dns::analyze_dns_for_mdns(payload)?;
-
-    Some(MdnsInfo {
-        query_name: dns_info.query_name,
-        query_type: dns_info.query_type,
-        is_response: dns_info.is_response,
-        response_ips: dns_info.response_ips,
-    })
+    dns::analyze_dns_for_mdns(payload).map(MdnsInfo::from)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::dns::test_fixtures::{build_dns_packet, encode_name};
     use super::*;
     use crate::network::types::DnsQueryType;
 
     fn build_mdns_query(name: &str, qtype: u16) -> Vec<u8> {
-        let mut packet = Vec::new();
-
-        // DNS header (12 bytes)
-        packet.extend_from_slice(&[0x00, 0x00]); // Transaction ID
-        packet.extend_from_slice(&[0x00, 0x00]); // Flags (query)
-        packet.extend_from_slice(&[0x00, 0x01]); // Questions: 1
-        packet.extend_from_slice(&[0x00, 0x00]); // Answer RRs: 0
-        packet.extend_from_slice(&[0x00, 0x00]); // Authority RRs: 0
-        packet.extend_from_slice(&[0x00, 0x00]); // Additional RRs: 0
-
-        // Question section - encode domain name
-        for label in name.split('.') {
-            packet.push(label.len() as u8);
-            packet.extend_from_slice(label.as_bytes());
-        }
-        packet.push(0x00); // Null terminator
-
-        // Query type and class
-        packet.extend_from_slice(&qtype.to_be_bytes());
-        packet.extend_from_slice(&[0x00, 0x01]); // Class: IN
-
-        packet
+        build_dns_packet(0x0000, 0x0000, name, qtype)
     }
 
     fn build_mdns_response(name: &str, qtype: u16) -> Vec<u8> {
-        let mut packet = Vec::new();
-
-        // DNS header (12 bytes)
-        packet.extend_from_slice(&[0x00, 0x00]); // Transaction ID
-        packet.extend_from_slice(&[0x84, 0x00]); // Flags (response, authoritative)
-        packet.extend_from_slice(&[0x00, 0x01]); // Questions: 1
-        packet.extend_from_slice(&[0x00, 0x00]); // Answer RRs: 0
-        packet.extend_from_slice(&[0x00, 0x00]); // Authority RRs: 0
-        packet.extend_from_slice(&[0x00, 0x00]); // Additional RRs: 0
-
-        // Question section
-        for label in name.split('.') {
-            packet.push(label.len() as u8);
-            packet.extend_from_slice(label.as_bytes());
-        }
-        packet.push(0x00);
-        packet.extend_from_slice(&qtype.to_be_bytes());
-        packet.extend_from_slice(&[0x00, 0x01]);
-
-        packet
+        // Flags: response, authoritative
+        build_dns_packet(0x0000, 0x8400, name, qtype)
     }
 
     #[test]
@@ -119,11 +74,7 @@ mod tests {
         packet.extend_from_slice(&[0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x01]);
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
         // Answer: NAME uncompressed.
-        for label in name.split('.') {
-            packet.push(label.len() as u8);
-            packet.extend_from_slice(label.as_bytes());
-        }
-        packet.push(0x00);
+        encode_name(&mut packet, name);
         // TYPE A, CLASS IN (cache-flush bit cleared), TTL 120, RDLENGTH 4, RDATA.
         packet.extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x78, 0x00, 0x04]);
         packet.extend_from_slice(&ip);
@@ -157,22 +108,12 @@ mod tests {
         packet.extend_from_slice(&[0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x01]);
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
         // ANSWER: PTR "_http._tcp.local" → "mybox._http._tcp.local"
-        let ptr_name = "_http._tcp.local";
-        for label in ptr_name.split('.') {
-            packet.push(label.len() as u8);
-            packet.extend_from_slice(label.as_bytes());
-        }
-        packet.push(0x00);
+        encode_name(&mut packet, "_http._tcp.local");
         // TYPE PTR (12), CLASS IN, TTL, RDLENGTH 2 (compressed pointer back).
         packet.extend_from_slice(&[0x00, 0x0C, 0x00, 0x01, 0x00, 0x00, 0x00, 0x78, 0x00, 0x02]);
         packet.extend_from_slice(&[0xC0, 0x0C]);
         // ADDITIONAL: A record for "host.local" → 10.0.0.5.
-        let a_name = "host.local";
-        for label in a_name.split('.') {
-            packet.push(label.len() as u8);
-            packet.extend_from_slice(label.as_bytes());
-        }
-        packet.push(0x00);
+        encode_name(&mut packet, "host.local");
         packet.extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x78, 0x00, 0x04]);
         packet.extend_from_slice(&[10, 0, 0, 5]);
 

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -1013,15 +1013,10 @@ mod tests {
     fn create_test_packet(is_outgoing: bool, fin: bool) -> ParsedPacket {
         use crate::network::protocol::tcp::{TcpFlags, TcpHeaderInfo};
 
-        ParsedPacket {
-            protocol: Protocol::Tcp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 12345),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Tcp(TcpState::Unknown),
-            tcp_header: Some(TcpHeaderInfo {
+        let mut packet = ParsedPacket::test_tcp(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 12345),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
+            TcpHeaderInfo {
                 seq: 1000,
                 ack: 2000,
                 window: 65535,
@@ -1034,13 +1029,11 @@ mod tests {
                     urg: false,
                 },
                 payload_len: 60, // Simulated payload length
-            }),
-            is_outgoing,
-            packet_len: 100,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
-        }
+            },
+        );
+        packet.is_outgoing = is_outgoing;
+        packet.packet_len = 100;
+        packet
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/parser.rs
+++ b/crates/rustnet-core/src/network/parser.rs
@@ -51,6 +51,64 @@ impl ParsedPacket {
     }
 }
 
+/// Shared test constructors so each test module builds only the fields its
+/// scenario exercises instead of repeating the full struct literal.
+#[cfg(test)]
+impl ParsedPacket {
+    /// Baseline test packet: unicast endpoints, no TCP header, no DPI result,
+    /// no process attribution. Callers override the fields they care about.
+    pub(crate) fn test_base(
+        protocol: Protocol,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        protocol_state: ProtocolState,
+    ) -> Self {
+        Self {
+            protocol,
+            local_addr,
+            remote_addr,
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
+            tcp_header: None,
+            protocol_state,
+            is_outgoing: false,
+            packet_len: 0,
+            dpi_result: None,
+            process_name: None,
+            process_id: None,
+        }
+    }
+
+    /// TCP test packet carrying the given header.
+    pub(crate) fn test_tcp(
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        tcp_header: TcpHeaderInfo,
+    ) -> Self {
+        let mut packet = Self::test_base(
+            Protocol::Tcp,
+            local_addr,
+            remote_addr,
+            ProtocolState::Tcp(TcpState::Unknown),
+        );
+        packet.tcp_header = Some(tcp_header);
+        packet
+    }
+
+    /// UDP test packet classified by DPI as `application`.
+    pub(crate) fn test_udp(
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        application: ApplicationProtocol,
+    ) -> Self {
+        let mut packet =
+            Self::test_base(Protocol::Udp, local_addr, remote_addr, ProtocolState::Udp);
+        packet.dpi_result = Some(DpiResult { application });
+        packet
+    }
+}
+
 /// Configuration for packet parsing
 ///
 /// # Example

--- a/crates/rustnet-core/src/network/protocol/icmp.rs
+++ b/crates/rustnet-core/src/network/protocol/icmp.rs
@@ -12,60 +12,7 @@ pub fn parse(
     params: TransportParams,
     local_ips: &std::collections::HashSet<std::net::IpAddr>,
 ) -> Option<ParsedPacket> {
-    if transport_data.is_empty() {
-        return None;
-    }
-
-    let icmp_type = transport_data[0];
-
-    // Echo requests and replies carry an identifier plus a sequence number.
-    // Both are needed to pair several concurrent requests from one ping flow.
-    let (icmp_id, icmp_sequence) =
-        if transport_data.len() >= 8 && (icmp_type == 8 || icmp_type == 0) {
-            (
-                Some(u16::from_be_bytes([transport_data[4], transport_data[5]])),
-                Some(u16::from_be_bytes([transport_data[6], transport_data[7]])),
-            )
-        } else {
-            (None, None)
-        };
-
-    // Determine direction based on local IPs
-    let is_outgoing = local_ips.contains(&params.src_ip);
-
-    let (local_addr, remote_addr) = if is_outgoing {
-        (
-            SocketAddr::new(params.src_ip, 0),
-            SocketAddr::new(params.dst_ip, 0),
-        )
-    } else {
-        (
-            SocketAddr::new(params.dst_ip, 0),
-            SocketAddr::new(params.src_ip, 0),
-        )
-    };
-
-    Some(ParsedPacket {
-        protocol: Protocol::Icmp,
-        local_addr,
-        remote_addr,
-        // Overwritten centrally in PacketParser::parse_packet
-        local_addr_kind: AddrKind::Unicast,
-        remote_addr_kind: AddrKind::Unicast,
-        remote_is_gateway: false,
-        tcp_header: None,
-        protocol_state: ProtocolState::Icmp {
-            icmp_type,
-            icmp_id,
-            icmp_sequence,
-            ndp_neighbor: None,
-        },
-        is_outgoing,
-        packet_len: params.packet_len,
-        dpi_result: None,
-        process_name: params.process_name,
-        process_id: params.process_id,
-    })
+    parse_icmp(transport_data, params, local_ips, (8, 0))
 }
 
 /// Parse an ICMPv6 packet
@@ -74,15 +21,28 @@ pub fn parse_v6(
     params: TransportParams,
     local_ips: &std::collections::HashSet<std::net::IpAddr>,
 ) -> Option<ParsedPacket> {
+    parse_icmp(transport_data, params, local_ips, (128, 129))
+}
+
+/// Shared ICMPv4/ICMPv6 parse; `echo_types` carries the version's echo
+/// request and reply type values, the only place the two formats differ.
+fn parse_icmp(
+    transport_data: &[u8],
+    params: TransportParams,
+    local_ips: &std::collections::HashSet<std::net::IpAddr>,
+    echo_types: (u8, u8),
+) -> Option<ParsedPacket> {
     if transport_data.is_empty() {
         return None;
     }
 
     let icmp_type = transport_data[0];
+    let (echo_request, echo_reply) = echo_types;
 
-    // ICMPv6 echo uses the same identifier and sequence layout as ICMPv4.
+    // Echo requests and replies carry an identifier plus a sequence number.
+    // Both are needed to pair several concurrent requests from one ping flow.
     let (icmp_id, icmp_sequence) =
-        if transport_data.len() >= 8 && (icmp_type == 128 || icmp_type == 129) {
+        if transport_data.len() >= 8 && (icmp_type == echo_request || icmp_type == echo_reply) {
             (
                 Some(u16::from_be_bytes([transport_data[4], transport_data[5]])),
                 Some(u16::from_be_bytes([transport_data[6], transport_data[7]])),
@@ -119,13 +79,13 @@ pub fn parse_v6(
             icmp_type,
             icmp_id,
             icmp_sequence,
-            // Filled by the parser for NDP messages that pass the
-            // hop-limit and fragmentation gates.
+            // Filled by the parser for ICMPv6 NDP messages that pass
+            // the hop-limit and fragmentation gates.
             ndp_neighbor: None,
         },
         is_outgoing,
         packet_len: params.packet_len,
-        dpi_result: None, // No DPI for ICMPv6
+        dpi_result: None,
         process_name: params.process_name,
         process_id: params.process_id,
     })

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -84,6 +84,20 @@ fn is_quic_handshake_packet(packet_type: QuicPacketType) -> bool {
     )
 }
 
+/// Whether a UDP packet's DPI classification is one the RTT tracker times.
+/// Gates the rtt lock in `measure_timings` so untimed UDP traffic (QUIC 1-RTT
+/// bulk data, SSDP, mDNS, ...) never touches the mutex on the packet path.
+fn udp_application_is_timed(application: &ApplicationProtocol) -> bool {
+    match application {
+        ApplicationProtocol::Quic(quic) => is_quic_handshake_packet(quic.packet_type),
+        ApplicationProtocol::Dns(_)
+        | ApplicationProtocol::NetBios(_)
+        | ApplicationProtocol::Stun(_)
+        | ApplicationProtocol::Ntp(_) => true,
+        _ => false,
+    }
+}
+
 /// The active connection table: flow key -> connection.
 ///
 /// Keys are compact `Copy` structs, and the map uses FxHash — with a small
@@ -370,6 +384,10 @@ impl ConnectionTracker {
         // the handshake is behind header protection, so this initial flight is
         // the only round trip an on-path observer can time.
         let mut measured_rtt: Option<Duration> = None;
+        let mut dns_response_time: Option<Duration> = None;
+        let mut netbios_response_time: Option<Duration> = None;
+        let mut stun_rtt: Option<Duration> = None;
+        let mut ntp_rtt: Option<Duration> = None;
         let base_key = parsed.connection_key();
         if parsed.protocol == Protocol::Tcp
             && let Some(tcp_header) = &parsed.tcp_header
@@ -386,56 +404,66 @@ impl ConnectionTracker {
             }
         } else if parsed.protocol == Protocol::Udp
             && let Some(dpi) = &parsed.dpi_result
-            && let ApplicationProtocol::Quic(quic) = &dpi.application
-            && is_quic_handshake_packet(quic.packet_type)
+            && udp_application_is_timed(&dpi.application)
             && let Ok(mut tracker) = self.rtt.lock()
         {
-            measured_rtt = tracker.record_quic_handshake(base_key, parsed.is_outgoing, now);
-        }
-
-        // Time DNS query→response pairs by transaction ID. Port-53 gating
-        // already happened in DPI dispatch, so any Dns result here is unicast
-        // DNS (mDNS/LLMNR map to their own variants).
-        let mut dns_response_time: Option<Duration> = None;
-        if parsed.protocol == Protocol::Udp
-            && let Some(dpi) = &parsed.dpi_result
-            && let ApplicationProtocol::Dns(dns) = &dpi.application
-            && let Ok(mut tracker) = self.rtt.lock()
-        {
-            dns_response_time = tracker.record_dns_packet(
-                base_key,
-                dns.txid,
-                parsed.is_outgoing,
-                dns.is_response,
-                now,
-            );
-        }
-
-        // NetBIOS Name Service broadcasts are answered from a host's unicast
-        // address, so the RTT tracker pairs on local socket, service, and
-        // transaction ID rather than the full connection key.
-        let mut netbios_response_time: Option<Duration> = None;
-        if parsed.protocol == Protocol::Udp
-            && let Some(dpi) = &parsed.dpi_result
-            && let ApplicationProtocol::NetBios(netbios) = &dpi.application
-        {
-            let completed = match self.rtt.lock() {
-                Ok(mut tracker) => {
-                    tracker.record_netbios_packet(base_key, netbios, parsed.is_outgoing, now)
+            // One lock acquisition covers every timed UDP application; a
+            // packet carries one DPI result, so at most one arm runs.
+            match &dpi.application {
+                ApplicationProtocol::Quic(_) => {
+                    measured_rtt = tracker.record_quic_handshake(base_key, parsed.is_outgoing, now);
                 }
-                Err(_) => None,
-            };
-            if let Some((rtt, request_key)) = completed {
-                netbios_response_time = Some(rtt);
-                // A broadcast request and its unicast reply live under
-                // different keys. Stamp the requesting connection too, so the
-                // row showing the query also shows its round trip; this
-                // packet's own connection is updated in the ingest path below.
-                if request_key != base_key
-                    && let Some(mut conn) = self.connections.get_mut(&request_key)
-                {
-                    conn.netbios_response_time = Some(rtt);
+                // Time DNS query→response pairs by transaction ID. Port-53
+                // gating already happened in DPI dispatch, so any Dns result
+                // here is unicast DNS (mDNS/LLMNR map to their own variants).
+                ApplicationProtocol::Dns(dns) => {
+                    dns_response_time = tracker.record_dns_packet(
+                        base_key,
+                        dns.txid,
+                        parsed.is_outgoing,
+                        dns.is_response,
+                        now,
+                    );
                 }
+                // NetBIOS Name Service broadcasts are answered from a host's
+                // unicast address, so the RTT tracker pairs on local socket,
+                // service, and transaction ID rather than the full connection
+                // key.
+                ApplicationProtocol::NetBios(netbios) => {
+                    let completed =
+                        tracker.record_netbios_packet(base_key, netbios, parsed.is_outgoing, now);
+                    if let Some((rtt, request_key)) = completed {
+                        netbios_response_time = Some(rtt);
+                        // A broadcast request and its unicast reply live under
+                        // different keys. Stamp the requesting connection too,
+                        // so the row showing the query also shows its round
+                        // trip; this packet's own connection is updated in the
+                        // ingest path below.
+                        if request_key != base_key
+                            && let Some(mut conn) = self.connections.get_mut(&request_key)
+                        {
+                            conn.netbios_response_time = Some(rtt);
+                        }
+                    }
+                }
+                // STUN requests and responses share a 96-bit transaction ID
+                // that retransmits reuse, so request→response pairing is
+                // exact.
+                ApplicationProtocol::Stun(stun) => {
+                    stun_rtt = tracker.record_stun(
+                        base_key,
+                        stun.transaction_id,
+                        parsed.is_outgoing,
+                        stun.message_class,
+                        now,
+                    );
+                }
+                // NTP servers echo the client's transmit timestamp as the
+                // originate timestamp, pairing each poll with its response.
+                ApplicationProtocol::Ntp(ntp) => {
+                    ntp_rtt = tracker.record_ntp(base_key, ntp, parsed.is_outgoing, now);
+                }
+                _ => {}
             }
         }
 
@@ -472,34 +500,6 @@ impl ConnectionTracker {
                 is_reply,
                 now,
             );
-        }
-
-        // STUN requests and responses share a 96-bit transaction ID that
-        // retransmits reuse, so request→response pairing is exact.
-        let mut stun_rtt: Option<Duration> = None;
-        if parsed.protocol == Protocol::Udp
-            && let Some(dpi) = &parsed.dpi_result
-            && let ApplicationProtocol::Stun(stun) = &dpi.application
-            && let Ok(mut tracker) = self.rtt.lock()
-        {
-            stun_rtt = tracker.record_stun(
-                base_key,
-                stun.transaction_id,
-                parsed.is_outgoing,
-                stun.message_class,
-                now,
-            );
-        }
-
-        // NTP servers echo the client's transmit timestamp as the originate
-        // timestamp, pairing each poll with its response.
-        let mut ntp_rtt: Option<Duration> = None;
-        if parsed.protocol == Protocol::Udp
-            && let Some(dpi) = &parsed.dpi_result
-            && let ApplicationProtocol::Ntp(ntp) = &dpi.application
-            && let Ok(mut tracker) = self.rtt.lock()
-        {
-            ntp_rtt = tracker.record_ntp(base_key, ntp, parsed.is_outgoing, now);
         }
 
         PacketTimings {
@@ -1030,18 +1030,12 @@ mod tests {
 
     fn tcp_packet(syn: bool, ack: bool, fin: bool, rst: bool, is_outgoing: bool) -> ParsedPacket {
         use crate::network::protocol::tcp::{TcpFlags, TcpHeaderInfo};
-        use crate::network::types::{AddrKind, ProtocolState, TcpState};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-        ParsedPacket {
-            protocol: Protocol::Tcp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Tcp(TcpState::Unknown),
-            tcp_header: Some(TcpHeaderInfo {
+        let mut packet = ParsedPacket::test_tcp(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
+            TcpHeaderInfo {
                 seq: 1_000,
                 ack: 2_000,
                 window: 65_535,
@@ -1054,72 +1048,50 @@ mod tests {
                     urg: false,
                 },
                 payload_len: 0,
-            }),
-            is_outgoing,
-            packet_len: 60,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
-        }
+            },
+        );
+        packet.is_outgoing = is_outgoing;
+        packet.packet_len = 60;
+        packet
     }
 
     fn quic_packet(packet_type: QuicPacketType, is_outgoing: bool) -> ParsedPacket {
-        use crate::network::dpi::DpiResult;
-        use crate::network::types::{AddrKind, ProtocolState, QuicInfo};
+        use crate::network::types::QuicInfo;
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         let mut quic = QuicInfo::new(1);
         quic.packet_type = packet_type;
 
-        ParsedPacket {
-            protocol: Protocol::Udp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Udp,
-            tcp_header: None,
-            is_outgoing,
-            packet_len: 1_200,
-            dpi_result: Some(DpiResult {
-                application: ApplicationProtocol::Quic(Box::new(quic)),
-            }),
-            process_name: None,
-            process_id: None,
-        }
+        let mut packet = ParsedPacket::test_udp(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 443),
+            ApplicationProtocol::Quic(Box::new(quic)),
+        );
+        packet.is_outgoing = is_outgoing;
+        packet.packet_len = 1_200;
+        packet
     }
 
     fn dns_packet(txid: u16, is_outgoing: bool, is_response: bool, rcode: u8) -> ParsedPacket {
-        use crate::network::dpi::DpiResult;
-        use crate::network::types::{AddrKind, DnsInfo, DnsQueryType, ProtocolState};
+        use crate::network::types::{DnsInfo, DnsQueryType};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-        ParsedPacket {
-            protocol: Protocol::Udp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 53),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Udp,
-            tcp_header: None,
-            is_outgoing,
-            packet_len: 80,
-            dpi_result: Some(DpiResult {
-                application: ApplicationProtocol::Dns(DnsInfo {
-                    query_name: Some("example.com".to_string()),
-                    query_type: Some(DnsQueryType::A),
-                    response_ips: Vec::new(),
-                    is_response,
-                    txid,
-                    rcode: is_response.then_some(rcode),
-                    nodata: None,
-                }),
+        let mut packet = ParsedPacket::test_udp(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 40_000),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2)), 53),
+            ApplicationProtocol::Dns(DnsInfo {
+                query_name: Some("example.com".to_string()),
+                query_type: Some(DnsQueryType::A),
+                response_ips: Vec::new(),
+                is_response,
+                txid,
+                rcode: is_response.then_some(rcode),
+                nodata: None,
             }),
-            process_name: None,
-            process_id: None,
-        }
+        );
+        packet.is_outgoing = is_outgoing;
+        packet.packet_len = 80;
+        packet
     }
 
     fn netbios_packet(
@@ -1129,40 +1101,27 @@ mod tests {
         is_response: bool,
         remote_ip: [u8; 4],
     ) -> ParsedPacket {
-        use crate::network::dpi::DpiResult;
-        use crate::network::types::{
-            AddrKind, NetBiosInfo, NetBiosResponseStatus, NetBiosService, ProtocolState,
-        };
+        use crate::network::types::{AddrKind, NetBiosInfo, NetBiosResponseStatus, NetBiosService};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-        ParsedPacket {
-            protocol: Protocol::Udp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 137),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::from(remote_ip)), 137),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: if remote_ip == [255, 255, 255, 255] {
-                AddrKind::Broadcast
-            } else {
-                AddrKind::Unicast
-            },
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Udp,
-            tcp_header: None,
-            is_outgoing,
-            packet_len: 80,
-            dpi_result: Some(DpiResult {
-                application: ApplicationProtocol::NetBios(NetBiosInfo {
-                    service: NetBiosService::NameService,
-                    opcode,
-                    name: Some("FILESERVER".to_string()),
-                    transaction_id,
-                    is_response,
-                    response_status: is_response.then_some(NetBiosResponseStatus::NameService(0)),
-                }),
+        let mut packet = ParsedPacket::test_udp(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 137),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::from(remote_ip)), 137),
+            ApplicationProtocol::NetBios(NetBiosInfo {
+                service: NetBiosService::NameService,
+                opcode,
+                name: Some("FILESERVER".to_string()),
+                transaction_id,
+                is_response,
+                response_status: is_response.then_some(NetBiosResponseStatus::NameService(0)),
             }),
-            process_name: None,
-            process_id: None,
+        );
+        if remote_ip == [255, 255, 255, 255] {
+            packet.remote_addr_kind = AddrKind::Broadcast;
         }
+        packet.is_outgoing = is_outgoing;
+        packet.packet_len = 80;
+        packet
     }
 
     fn icmp_echo_packet(
@@ -1171,29 +1130,23 @@ mod tests {
         is_outgoing: bool,
         is_reply: bool,
     ) -> ParsedPacket {
-        use crate::network::types::{AddrKind, ProtocolState};
+        use crate::network::types::ProtocolState;
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-        ParsedPacket {
-            protocol: Protocol::Icmp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 0),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 0),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Icmp {
+        let mut packet = ParsedPacket::test_base(
+            Protocol::Icmp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 0),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 0),
+            ProtocolState::Icmp {
                 icmp_type: if is_reply { 0 } else { 8 },
                 icmp_id: Some(identifier),
                 icmp_sequence: Some(sequence),
                 ndp_neighbor: None,
             },
-            tcp_header: None,
-            is_outgoing,
-            packet_len: 84,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
-        }
+        );
+        packet.is_outgoing = is_outgoing;
+        packet.packet_len = 84;
+        packet
     }
 
     /// Capture time for a packet `millis` into a synthetic trace. Tests drive
@@ -1204,17 +1157,14 @@ mod tests {
     }
 
     fn arp_packet(operation: crate::network::types::ArpOperation) -> ParsedPacket {
-        use crate::network::types::{AddrKind, ArpInfo, ProtocolState};
+        use crate::network::types::{ArpInfo, ProtocolState};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-        ParsedPacket {
-            protocol: Protocol::Arp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 132)), 0),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 0),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Arp(ArpInfo {
+        let mut packet = ParsedPacket::test_base(
+            Protocol::Arp,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 132)), 0),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 0),
+            ProtocolState::Arp(ArpInfo {
                 operation,
                 sender_mac: "04:d9:f5:c5:ed:e8".to_string(),
                 sender_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
@@ -1223,13 +1173,9 @@ mod tests {
                 sender_vendor: Some("ASUSTek COMPUTER INC.".to_string()),
                 target_vendor: Some("Apple, Inc.".to_string()),
             }),
-            tcp_header: None,
-            is_outgoing: false,
-            packet_len: 42,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
-        }
+        );
+        packet.packet_len = 42;
+        packet
     }
 
     /// Ingesting an ARP reply must populate the neighbor cache for both the
@@ -1733,32 +1679,22 @@ mod tests {
         is_outgoing: bool,
         class: crate::network::types::StunMessageClass,
     ) -> ParsedPacket {
-        use crate::network::dpi::DpiResult;
-        use crate::network::types::{AddrKind, ProtocolState, StunInfo, StunMethod};
+        use crate::network::types::{StunInfo, StunMethod};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-        ParsedPacket {
-            protocol: Protocol::Udp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 54_000),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), 3478),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Udp,
-            tcp_header: None,
-            is_outgoing,
-            packet_len: 48,
-            dpi_result: Some(DpiResult {
-                application: ApplicationProtocol::Stun(StunInfo {
-                    message_class: class,
-                    method: StunMethod::Binding,
-                    transaction_id,
-                    software: None,
-                }),
+        let mut packet = ParsedPacket::test_udp(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 54_000),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)), 3478),
+            ApplicationProtocol::Stun(StunInfo {
+                message_class: class,
+                method: StunMethod::Binding,
+                transaction_id,
+                software: None,
             }),
-            process_name: None,
-            process_id: None,
-        }
+        );
+        packet.is_outgoing = is_outgoing;
+        packet.packet_len = 48;
+        packet
     }
 
     /// STUN binding requests and responses pair by transaction ID, giving a
@@ -1793,33 +1729,23 @@ mod tests {
         origin_timestamp: u64,
         transmit_timestamp: u64,
     ) -> ParsedPacket {
-        use crate::network::dpi::DpiResult;
-        use crate::network::types::{AddrKind, NtpInfo, ProtocolState};
+        use crate::network::types::NtpInfo;
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-        ParsedPacket {
-            protocol: Protocol::Udp,
-            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 47_000),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)), 123),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            protocol_state: ProtocolState::Udp,
-            tcp_header: None,
-            is_outgoing,
-            packet_len: 90,
-            dpi_result: Some(DpiResult {
-                application: ApplicationProtocol::Ntp(NtpInfo {
-                    version: 4,
-                    mode,
-                    stratum: 2,
-                    origin_timestamp,
-                    transmit_timestamp,
-                }),
+        let mut packet = ParsedPacket::test_udp(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 47_000),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)), 123),
+            ApplicationProtocol::Ntp(NtpInfo {
+                version: 4,
+                mode,
+                stratum: 2,
+                origin_timestamp,
+                transmit_timestamp,
             }),
-            process_name: None,
-            process_id: None,
-        }
+        );
+        packet.is_outgoing = is_outgoing;
+        packet.packet_len = 90;
+        packet
     }
 
     /// An NTP poll pairs with its response through the originate timestamp

--- a/crates/rustnet-core/src/network/types/protocol_info.rs
+++ b/crates/rustnet-core/src/network/types/protocol_info.rs
@@ -679,6 +679,18 @@ pub struct MdnsInfo {
     pub response_ips: Vec<std::net::IpAddr>,
 }
 
+/// mDNS shares the DNS wire format; keep only the fields the mDNS view uses.
+impl From<DnsInfo> for MdnsInfo {
+    fn from(dns: DnsInfo) -> Self {
+        Self {
+            query_name: dns.query_name,
+            query_type: dns.query_type,
+            is_response: dns.is_response,
+            response_ips: dns.response_ips,
+        }
+    }
+}
+
 // LLMNR-specific types
 #[derive(Debug, Clone)]
 pub struct LlmnrInfo {
@@ -686,6 +698,18 @@ pub struct LlmnrInfo {
     pub query_type: Option<DnsQueryType>,
     pub is_response: bool,
     pub response_ips: Vec<std::net::IpAddr>,
+}
+
+/// LLMNR shares the DNS wire format; keep only the fields the LLMNR view uses.
+impl From<DnsInfo> for LlmnrInfo {
+    fn from(dns: DnsInfo) -> Self {
+        Self {
+            query_name: dns.query_name,
+            query_type: dns.query_type,
+            is_response: dns.is_response,
+            response_ips: dns.response_ips,
+        }
+    }
 }
 
 // DHCP-specific types


### PR DESCRIPTION
Follow-up dedup pass in rustnet-core (net -110 lines):

- icmp.rs: parse/parse_v6 merged into one parse_icmp with the echo type constants as a parameter
- tracker.rs measure_timings: the five UDP timing guards become one match under a single rtt lock acquisition, gated so untimed UDP traffic still never locks
- shared ParsedPacket test constructors replace nine copy-pasted builders in tracker/merge tests
- shared DNS wire-format test fixtures for the mDNS/LLMNR tests, plus From<DnsInfo> impls

No behavior change; no changelog entry (internal refactor, same as #541).