### PR TITLE
refactor: deduplicate TUI table, snapshot test, and help rendering

### DIFF
--- a/src/ui/connection_table.rs
+++ b/src/ui/connection_table.rs
@@ -18,19 +18,21 @@
 
 use std::borrow::Cow;
 
-use ratatui::layout::Constraint;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Cell, Row};
+use ratatui::widgets::{Cell, Row, Table};
 
 use std::net::SocketAddr;
 
 use crate::network::dns::DnsResolver;
 use crate::network::types::{AddrKind, Connection, Protocol};
 use crate::ui::{
-    NONE_PLACEHOLDER, SortColumn, UIState, dpi_color,
+    ClickAction, ClickableRegions, NONE_PLACEHOLDER, SortColumn, UIState, dpi_color,
     format::{format_rate_compact, format_rtt_compact, truncate_with_ellipsis},
     state_color, theme,
+    widgets::scrollbar::draw_scrollbar,
 };
 
 // --- Column floors (cells). Flexible columns grow beyond their floor
@@ -579,6 +581,85 @@ pub(in crate::ui) fn bandwidth_cell<'a>(rx_bps: f64, tx_bps: f64, color_cells: b
         ])
     };
     Cell::from(line.right_aligned())
+}
+
+/// Virtualization window over `items`: the rows at `scroll_offset`
+/// that fit `visible_rows`, plus one extra for a partial bottom row.
+pub(in crate::ui) fn visible_window<T>(
+    items: &[T],
+    scroll_offset: usize,
+    visible_rows: usize,
+) -> &[T] {
+    let window_end = (scroll_offset + visible_rows + 1).min(items.len());
+    &items[scroll_offset.min(items.len())..window_end]
+}
+
+/// How a windowed table maps onto its full row list: which rows are on
+/// screen and which one is selected. Indices are into the full list.
+pub(in crate::ui) struct RowWindow {
+    pub selected: Option<usize>,
+    pub scroll_offset: usize,
+    pub total_rows: usize,
+    pub visible_rows: usize,
+}
+
+/// Render a windowed connection table plus its scrollbar and click
+/// regions: the shared back half of the flat and grouped Overview
+/// lists. `rows` holds only the visible window described by `window`.
+pub(in crate::ui) fn render_row_table(
+    f: &mut Frame,
+    area: Rect,
+    header: Row<'_>,
+    rows: Vec<Row<'_>>,
+    widths: &[Constraint],
+    window: RowWindow,
+    click_regions: &mut ClickableRegions,
+) {
+    let RowWindow {
+        selected,
+        scroll_offset,
+        total_rows,
+        visible_rows,
+    } = window;
+
+    // Create table state with selection adjusted to windowed slice
+    let mut state = ratatui::widgets::TableState::default();
+    if let Some(selected_index) = selected {
+        state.select(Some(selected_index.saturating_sub(scroll_offset)));
+    }
+
+    let connections_table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(theme::row_highlight())
+        .highlight_symbol("> ");
+
+    let table_area = Rect::new(area.x, area.y, area.width.saturating_sub(2), area.height);
+    f.render_stateful_widget(connections_table, table_area, &mut state);
+
+    // Scrollbar tracks the row region (below header + margin).
+    let header_height = 2_u16; // header row (1) + bottom_margin (1)
+    let rows_area = Rect::new(
+        area.x,
+        area.y + header_height,
+        area.width,
+        area.height.saturating_sub(header_height),
+    );
+    draw_scrollbar(f, rows_area, total_rows, scroll_offset, visible_rows);
+
+    // Register click regions for visible rows
+    click_regions.scroll_area = Some(area);
+    let visible_start_y = area.y + header_height;
+    let max_visible_rows = area.height.saturating_sub(header_height) as usize;
+
+    for i in 0..max_visible_rows {
+        let row_idx = scroll_offset + i;
+        if row_idx >= total_rows {
+            break;
+        }
+        let row_y = visible_start_y + i as u16;
+        let row_rect = Rect::new(area.x, row_y, area.width, 1);
+        click_regions.register(row_rect, ClickAction::SelectConnection(row_idx));
+    }
 }
 
 #[cfg(test)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1181,6 +1181,51 @@ mod snapshot_tests {
         }
     }
 
+    /// Details render of `connections[selected]` through the full-page
+    /// `draw`, returning the text dump plus the click regions the frame
+    /// registered. `height` varies per test (40 covers the dashboard;
+    /// the attribution tests need 52 for the lineage rows).
+    fn render_details_frame(
+        app: &App,
+        connections: &[Connection],
+        selected: usize,
+        height: u16,
+    ) -> (String, ClickableRegions) {
+        let ui_state = UIState {
+            selected_tab: 1, // Details
+            selected_connection_key: Some(connections[selected].key()),
+            ..Default::default()
+        };
+        let stats = app.get_stats();
+        let mut click_regions = ClickableRegions::default();
+        let output = render(140, height, |f| {
+            draw(
+                f,
+                app,
+                &ui_state,
+                connections,
+                None,
+                &stats,
+                &mut click_regions,
+            )
+            .expect("draw details");
+        });
+        (output, click_regions)
+    }
+
+    /// Standard Details render at the 140x40 reference size.
+    fn render_details(app: &App, connections: &[Connection], selected: usize) -> String {
+        render_details_frame(app, connections, selected, 40).0
+    }
+
+    /// Row index of the first rendered line containing `heading`.
+    fn heading_row(render: &str, heading: &str) -> usize {
+        render
+            .lines()
+            .position(|line| line.contains(heading))
+            .unwrap_or_else(|| panic!("missing {heading}"))
+    }
+
     #[test]
     fn details_tab_tcp_https() {
         let app = test_app();
@@ -1188,26 +1233,7 @@ mod snapshot_tests {
         let connections = sample_connections();
         app.set_connections_snapshot_for_test(connections.clone());
 
-        let ui_state = UIState {
-            selected_tab: 1, // Details
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
+        let output = render_details(&app, &connections, 0);
 
         insta::with_settings!({
             filters => time_filters(),
@@ -1249,25 +1275,7 @@ mod snapshot_tests {
         });
 
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
-        let ui_state = UIState {
-            selected_tab: 1, // Details
-            selected_connection_key: Some(connections[1].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
+        let output = render_details(&app, &connections, 1);
 
         for tcp_only in [
             "TCP Retransmits",
@@ -1295,29 +1303,7 @@ mod snapshot_tests {
         // The card must not resize between protocols: Traffic Statistics is
         // anchored below Transport Health, so a shorter QUIC card would pull
         // the whole lower half of the dashboard upward.
-        let tcp_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let tcp_output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &tcp_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
-        let heading_row = |render: &str, heading: &str| {
-            render
-                .lines()
-                .position(|line| line.contains(heading))
-                .unwrap_or_else(|| panic!("missing {heading}"))
-        };
+        let tcp_output = render_details(&app, &connections, 0);
         assert_eq!(
             heading_row(&output, "Traffic Statistics"),
             heading_row(&tcp_output, "Traffic Statistics"),
@@ -1351,25 +1337,7 @@ mod snapshot_tests {
         });
 
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
-        let ui_state = UIState {
-            selected_tab: 1, // Details
-            selected_connection_key: Some(connections[1].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
+        let output = render_details(&app, &connections, 1);
 
         assert!(
             output.contains("DNS Response Time") && output.contains("12.3ms"),
@@ -1397,29 +1365,7 @@ mod snapshot_tests {
 
         // Same geometry invariant as the QUIC card: Traffic Statistics must
         // not move when flipping between a DNS and a TCP connection.
-        let tcp_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let tcp_output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &tcp_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
-        let heading_row = |render: &str, heading: &str| {
-            render
-                .lines()
-                .position(|line| line.contains(heading))
-                .unwrap_or_else(|| panic!("missing {heading}"))
-        };
+        let tcp_output = render_details(&app, &connections, 0);
         assert_eq!(
             heading_row(&output, "Traffic Statistics"),
             heading_row(&tcp_output, "Traffic Statistics"),
@@ -1451,25 +1397,7 @@ mod snapshot_tests {
         });
 
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
-        let ui_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[1].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
+        let output = render_details(&app, &connections, 1);
 
         assert!(output.contains("NetBIOS Response Time") && output.contains("18.7ms"));
         assert!(output.contains("Last Response Status") && output.contains("NAM_ERR"));
@@ -1500,25 +1428,7 @@ mod snapshot_tests {
         let connections = vec![ping];
 
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
-        let ui_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw ping details");
-        });
+        let output = render_details(&app, &connections, 0);
 
         assert!(output.contains("Ping RTT") && output.contains("8.7ms"));
         assert!(output.contains("Last Sequence") && output.contains("42"));
@@ -1549,25 +1459,7 @@ mod snapshot_tests {
         let connections = vec![ping];
 
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
-        let ui_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw inbound ping details");
-        });
+        let output = render_details(&app, &connections, 0);
 
         assert!(!output.contains("Ping RTT"));
         assert!(output.contains("Last Sequence") && output.contains("4242"));
@@ -1599,25 +1491,7 @@ mod snapshot_tests {
         let connections = vec![stun];
 
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
-        let ui_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw stun details");
-        });
+        let output = render_details(&app, &connections, 0);
 
         assert!(output.contains("STUN RTT") && output.contains("23.4ms"));
         assert!(output.contains("Last Message") && output.contains("Binding Success"));
@@ -1649,25 +1523,7 @@ mod snapshot_tests {
         let connections = vec![ntp];
 
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
-        let ui_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw ntp details");
-        });
+        let output = render_details(&app, &connections, 0);
 
         assert!(output.contains("NTP RTT") && output.contains("6.5ms"));
         assert!(output.contains("Stratum"));
@@ -1686,28 +1542,10 @@ mod snapshot_tests {
         let app = test_app();
         let mut connections = sample_connections();
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
 
-        let render_connections = |connections: &[Connection]| {
-            let ui_state = UIState {
-                selected_tab: 1,
-                selected_connection_key: Some(connections[0].key()),
-                ..Default::default()
-            };
-            let mut click_regions = ClickableRegions::default();
-            render(140, 52, |f| {
-                draw(
-                    f,
-                    &app,
-                    &ui_state,
-                    connections,
-                    None,
-                    &stats,
-                    &mut click_regions,
-                )
-                .expect("draw details");
-            })
-        };
+        // 52 rows so the lineage rows fit below the dashboard.
+        let render_connections =
+            |connections: &[Connection]| render_details_frame(&app, connections, 0, 52).0;
 
         connections[0].pid = None;
         let unattributed = render_connections(&connections);
@@ -1760,29 +1598,11 @@ mod snapshot_tests {
         let mut connections = sample_connections();
         connections[0].attribution_quality = Some(MatchQuality::ListenerSocket);
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
 
-        let ui_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
         // 40 rows: the Attribution card must stay visible on a 40-row
         // terminal — unresolved MAC rows are omitted, not rendered as
         // placeholders, precisely so the dashboard column does not grow.
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
+        let output = render_details(&app, &connections, 0);
 
         assert!(output.contains("Attribution"));
         assert!(output.contains("listener socket"));
@@ -1809,27 +1629,9 @@ mod snapshot_tests {
         connections[0].executable = Some(Arc::from(Path::new(full)));
         connections[0].attribution_quality = Some(MatchQuality::ExactTuple);
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
 
-        let ui_state = UIState {
-            selected_tab: 1,
-            selected_connection_key: Some(connections[0].key()),
-            ..Default::default()
-        };
-        let mut click_regions = ClickableRegions::default();
         // 40 rows for the same reason as the partial-attribution test above.
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
+        let (output, click_regions) = render_details_frame(&app, &connections, 0, 40);
 
         assert!(
             output.contains("/nix/store/"),
@@ -1867,28 +1669,8 @@ mod snapshot_tests {
             as_org: Some("Hetzner Online GmbH".to_string()),
         });
         app.set_connections_snapshot_for_test(connections.clone());
-        let stats = app.get_stats();
 
-        let render_selected = |selected: usize| {
-            let ui_state = UIState {
-                selected_tab: 1,
-                selected_connection_key: Some(connections[selected].key()),
-                ..Default::default()
-            };
-            let mut click_regions = ClickableRegions::default();
-            render(140, 40, |f| {
-                draw(
-                    f,
-                    &app,
-                    &ui_state,
-                    &connections,
-                    None,
-                    &stats,
-                    &mut click_regions,
-                )
-                .expect("draw details");
-            })
-        };
+        let render_selected = |selected: usize| render_details(&app, &connections, selected);
 
         let enriched_tcp = render_selected(0);
         let plain_udp = render_selected(1);

--- a/src/ui/tabs/activity.rs
+++ b/src/ui/tabs/activity.rs
@@ -155,6 +155,65 @@ fn title(text: impl Into<String>) -> Span<'static> {
     Span::styled(text.into(), Style::default().add_modifier(Modifier::BOLD))
 }
 
+/// The "now / 60s captured" summary line and the coverage bar for one
+/// direction. The TX and RX rows differ only in labels, colors, and
+/// which counters they read, so both come from here.
+fn pulse_lines(
+    snapshot: &ProcessActivitySnapshot,
+    basis: &InterfaceBasis,
+    direction: ActivityDirection,
+    bar_width: usize,
+) -> [Line<'static>; 2] {
+    let fraction = coverage_fraction(
+        snapshot_window_bytes(snapshot, direction),
+        interface_window_bytes(basis, direction),
+    );
+    let basis_marker = if basis.exact { "" } else { "~" };
+    let label = direction.rate_label();
+
+    let summary = Line::from(vec![
+        Span::styled(format!("{label} now "), theme::fg(theme::muted())),
+        Span::styled(
+            format_rate(snapshot_current_bps(snapshot, direction)),
+            theme::bold_fg(direction_ramp(direction)(1.0)),
+        ),
+        Span::styled("   60s captured ", theme::fg(theme::muted())),
+        Span::styled(
+            format_bytes(snapshot_window_bytes(snapshot, direction)),
+            theme::bold_fg(direction_color(direction)),
+        ),
+        Span::styled(" / ", theme::fg(theme::muted())),
+        Span::styled(
+            format!(
+                "{} {}",
+                basis.label,
+                format_bytes(interface_window_bytes(basis, direction))
+            ),
+            theme::fg(theme::accent()),
+        ),
+        Span::styled(
+            coverage_label(fraction, basis_marker),
+            theme::fg(if fraction.is_some_and(|fraction| fraction > 1.05) {
+                theme::warn()
+            } else {
+                theme::muted()
+            }),
+        ),
+    ]);
+
+    let mut spans = vec![Span::styled(
+        format!("{label} 60s coverage "),
+        theme::fg(theme::muted()),
+    )];
+    spans.extend(glow_bar::spans(
+        fraction.unwrap_or_default(),
+        bar_width,
+        direction_ramp(direction),
+    ));
+
+    [summary, Line::from(spans)]
+}
+
 fn draw_traffic_pulse(
     f: &mut Frame,
     snapshot: &ProcessActivitySnapshot,
@@ -166,9 +225,6 @@ fn draw_traffic_pulse(
         return;
     }
 
-    let tx_fraction = coverage_fraction(snapshot.window_tx_bytes, basis.tx_window_bytes);
-    let rx_fraction = coverage_fraction(snapshot.window_rx_bytes, basis.rx_window_bytes);
-    let basis_marker = if basis.exact { "" } else { "~" };
     let unknown_tx = snapshot
         .retained_tx_bytes
         .saturating_sub(snapshot.attributed_tx_bytes);
@@ -176,76 +232,23 @@ fn draw_traffic_pulse(
         .retained_rx_bytes
         .saturating_sub(snapshot.attributed_rx_bytes);
 
-    let tx_line = Line::from(vec![
-        Span::styled("TX now ", theme::fg(theme::muted())),
-        Span::styled(
-            format_rate(snapshot.current_tx_bps),
-            theme::bold_fg(theme::tx_wave(1.0)),
-        ),
-        Span::styled("   60s captured ", theme::fg(theme::muted())),
-        Span::styled(
-            format_bytes(snapshot.window_tx_bytes),
-            theme::bold_fg(theme::tx()),
-        ),
-        Span::styled(" / ", theme::fg(theme::muted())),
-        Span::styled(
-            format!("{} {}", basis.label, format_bytes(basis.tx_window_bytes)),
-            theme::fg(theme::accent()),
-        ),
-        Span::styled(
-            coverage_label(tx_fraction, basis_marker),
-            theme::fg(if tx_fraction.is_some_and(|fraction| fraction > 1.05) {
-                theme::warn()
-            } else {
-                theme::muted()
-            }),
-        ),
-    ]);
+    let bar_width = inner.width.saturating_sub(20) as usize;
+    let [tx_line, tx_bar] = pulse_lines(snapshot, basis, ActivityDirection::Egress, bar_width);
+    let [rx_line, rx_bar] = pulse_lines(snapshot, basis, ActivityDirection::Ingress, bar_width);
+
     f.render_widget(
         Paragraph::new(tx_line),
         Rect::new(inner.x, inner.y, inner.width, 1),
     );
 
     if inner.height > 1 {
-        let bar_width = inner.width.saturating_sub(20) as usize;
-        let mut spans = vec![Span::styled("TX 60s coverage ", theme::fg(theme::muted()))];
-        spans.extend(glow_bar::spans(
-            tx_fraction.unwrap_or_default(),
-            bar_width,
-            theme::tx_wave,
-        ));
         f.render_widget(
-            Paragraph::new(Line::from(spans)),
+            Paragraph::new(tx_bar),
             Rect::new(inner.x, inner.y + 1, inner.width, 1),
         );
     }
 
     if inner.height > 2 {
-        let rx_line = Line::from(vec![
-            Span::styled("RX now ", theme::fg(theme::muted())),
-            Span::styled(
-                format_rate(snapshot.current_rx_bps),
-                theme::bold_fg(theme::rx_wave(1.0)),
-            ),
-            Span::styled("   60s captured ", theme::fg(theme::muted())),
-            Span::styled(
-                format_bytes(snapshot.window_rx_bytes),
-                theme::bold_fg(theme::rx()),
-            ),
-            Span::styled(" / ", theme::fg(theme::muted())),
-            Span::styled(
-                format!("{} {}", basis.label, format_bytes(basis.rx_window_bytes)),
-                theme::fg(theme::accent()),
-            ),
-            Span::styled(
-                coverage_label(rx_fraction, basis_marker),
-                theme::fg(if rx_fraction.is_some_and(|fraction| fraction > 1.05) {
-                    theme::warn()
-                } else {
-                    theme::muted()
-                }),
-            ),
-        ]);
         f.render_widget(
             Paragraph::new(rx_line),
             Rect::new(inner.x, inner.y + 2, inner.width, 1),
@@ -253,15 +256,8 @@ fn draw_traffic_pulse(
     }
 
     if inner.height > 3 {
-        let bar_width = inner.width.saturating_sub(20) as usize;
-        let mut spans = vec![Span::styled("RX 60s coverage ", theme::fg(theme::muted()))];
-        spans.extend(glow_bar::spans(
-            rx_fraction.unwrap_or_default(),
-            bar_width,
-            theme::rx_wave,
-        ));
         f.render_widget(
-            Paragraph::new(Line::from(spans)),
+            Paragraph::new(rx_bar),
             Rect::new(inner.x, inner.y + 3, inner.width, 1),
         );
     }
@@ -415,6 +411,13 @@ fn snapshot_window_bytes(snapshot: &ProcessActivitySnapshot, direction: Activity
     match direction {
         ActivityDirection::Egress => snapshot.window_tx_bytes,
         ActivityDirection::Ingress => snapshot.window_rx_bytes,
+    }
+}
+
+fn snapshot_current_bps(snapshot: &ProcessActivitySnapshot, direction: ActivityDirection) -> f64 {
+    match direction {
+        ActivityDirection::Egress => snapshot.current_tx_bps,
+        ActivityDirection::Ingress => snapshot.current_rx_bps,
     }
 }
 

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -138,14 +138,7 @@ fn push_detail_field<'a>(
     value: String,
     label_style: Style,
 ) {
-    lines.push(Line::from(vec![
-        Span::styled(
-            format!("{:<width$}", label, width = DETAIL_LABEL_WIDTH),
-            label_style,
-        ),
-        Span::raw(value.clone()),
-    ]));
-    fields.push(Some((label.to_string(), value)));
+    push_detail_field_styled(lines, fields, label, value, label_style, Style::default());
 }
 
 /// Push a label-value line with a custom-styled value span.
@@ -157,14 +150,15 @@ fn push_detail_field_styled<'a>(
     label_style: Style,
     value_style: Style,
 ) {
-    lines.push(Line::from(vec![
-        Span::styled(
-            format!("{:<width$}", label, width = DETAIL_LABEL_WIDTH),
-            label_style,
-        ),
-        Span::styled(value.clone(), value_style),
-    ]));
-    fields.push(Some((label.to_string(), value)));
+    push_detail_field_with_copy(
+        lines,
+        fields,
+        label,
+        value.clone(),
+        value,
+        label_style,
+        value_style,
+    );
 }
 
 /// Push a label-value line whose rendered value differs from what

--- a/src/ui/tabs/help.rs
+++ b/src/ui/tabs/help.rs
@@ -59,251 +59,194 @@ impl Component for HelpTab {
     }
 }
 
+/// Key/description rows for the keybind list. The key half keeps its
+/// trailing space so the description starts one cell after it.
+const KEY_BINDINGS: &[(&str, &str)] = &[
+    ("q ", "Quit application (press twice to confirm)"),
+    ("Ctrl+C ", "Quit immediately"),
+    ("x ", "Clear all connections (press twice to confirm)"),
+    ("Tab, ] ", "Next tab"),
+    ("Shift+Tab, [ ", "Previous tab"),
+    (
+        "1-5 ",
+        "Jump directly to a tab (1=Overview, 2=Details, 3=Activity, 4=Graph, 5=Help)",
+    ),
+    ("↑/k, ↓/j ", "Navigate connections (wraps around)"),
+    ("g, G ", "Jump to first/last connection (vim-style)"),
+    ("Page Up/Down, Ctrl+B/F ", "Navigate connections by page"),
+    ("Ctrl+D/U ", "Scroll the Details info panes"),
+    ("c ", "Copy remote address to clipboard"),
+    ("p ", "Toggle between service names and port numbers"),
+    (
+        "d ",
+        "Toggle hostnames/IPs on Overview or Egress (TX)/Ingress (RX) on Activity",
+    ),
+    (
+        "s ",
+        "Cycle through sort columns (Bandwidth, Process, etc.)",
+    ),
+    ("S ", "Toggle sort direction (ascending/descending)"),
+    ("a ", "Toggle process grouping (aggregate by process)"),
+    ("Space ", "Expand/collapse group (when grouping enabled)"),
+    ("←/→ or h/l ", "Collapse/expand group"),
+    ("t ", "Toggle display of historic (closed) connections"),
+    (
+        "i ",
+        "Toggle System info on Overview or interface details on Activity",
+    ),
+    ("r ", "Reset view (grouping, sort, filter)"),
+    ("Enter ", "View connection details"),
+    ("Esc ", "Return to overview"),
+    ("h ", "Toggle this help screen"),
+    (
+        "/ ",
+        "Enter filter mode on Overview (use \u{2191}/\u{2193} to navigate while typing)",
+    ),
+];
+
+const TAB_SUMMARIES: &[(&str, &str)] = &[
+    ("  Overview ", "Connection list with mini traffic graph"),
+    ("  Details ", "Full details for selected connection"),
+    (
+        "  Activity ",
+        "Process egress/ingress, bandwidth shares, connections, and interface pulse",
+    ),
+    ("  Graph ", "Traffic charts and protocol distribution"),
+    ("  Help ", "This help screen"),
+];
+
+const ACTIVITY_CONCEPTS: &[(&str, &str)] = &[
+    (
+        "  Egress (TX) / Ingress (RX) ",
+        "Traffic sent from or received by the local process",
+    ),
+    (
+        "  60s coverage ",
+        "Captured connection traffic divided by interface traffic",
+    ),
+    (
+        "  Retained ",
+        "Active traffic plus up to 5,000 recently closed connections",
+    ),
+    (
+        "  Process attribution ",
+        "Traffic mapped to a PID or process name; unresolved bytes are Unknown",
+    ),
+    (
+        "  Top remote peer ",
+        "Highest-volume remote endpoint for the selected direction",
+    ),
+];
+
+const MOUSE_CONTROLS: &[(&str, &str)] = &[
+    ("  Click tab ", "Switch between tabs"),
+    ("  Click row ", "Select connection"),
+    (
+        "  Scroll wheel ",
+        "Navigate connection list / scroll Details, Activity interfaces, Help",
+    ),
+    ("  Double-click row ", "Open connection details"),
+    ("  Double-click group ", "Expand/collapse process group"),
+    ("  Click field (Details) ", "Copy field value to clipboard"),
+];
+
+const FILTER_EXAMPLES: &[(&str, &str)] = &[
+    ("  /google ", "Search for 'google' in all fields"),
+    (
+        "  /port:22 ",
+        "Exact port match (only port 22, not 2223 or 5522)",
+    ),
+    ("  /port:/22/ ", "Regex port match (22, 220, 5522, etc.)"),
+    ("  /src:192.168 ", "Filter by source IP prefix"),
+    ("  /dst:github.com ", "Filter by destination"),
+    (
+        "  /sni:/.*github.*/ ",
+        "Regex SNI match (wrap value in /…/ for regex)",
+    ),
+    ("  /process:firefox ", "Filter by process name"),
+];
+
+/// A key/description help row: the key span styled, the description raw.
+fn kv_line(key: &'static str, description: &'static str, key_style: Style) -> Line<'static> {
+    Line::from(vec![Span::styled(key, key_style), Span::raw(description)])
+}
+
+/// A bold accent section title ("Tabs:", "Mouse Controls:", ...).
+fn section_title(title: &'static str) -> Line<'static> {
+    Line::from(vec![Span::styled(title, theme::bold_fg(theme::accent()))])
+}
+
 pub(in crate::ui) fn draw_help(f: &mut Frame, ui_state: &UIState, area: Rect) -> Result<()> {
-    let help_text: Vec<Line> = vec![
+    let key_style = theme::fg(theme::key());
+    let example_style = theme::fg(theme::ok());
+
+    let mut help_text: Vec<Line> = vec![
         Line::from(vec![
             Span::styled("RustNet Monitor ", theme::bold_fg(theme::ok())),
             Span::raw("- Network Connection Monitor"),
         ]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("q ", theme::fg(theme::key())),
-            Span::raw("Quit application (press twice to confirm)"),
-        ]),
-        Line::from(vec![
-            Span::styled("Ctrl+C ", theme::fg(theme::key())),
-            Span::raw("Quit immediately"),
-        ]),
-        Line::from(vec![
-            Span::styled("x ", theme::fg(theme::key())),
-            Span::raw("Clear all connections (press twice to confirm)"),
-        ]),
-        Line::from(vec![
-            Span::styled("Tab, ] ", theme::fg(theme::key())),
-            Span::raw("Next tab"),
-        ]),
-        Line::from(vec![
-            Span::styled("Shift+Tab, [ ", theme::fg(theme::key())),
-            Span::raw("Previous tab"),
-        ]),
-        Line::from(vec![
-            Span::styled("1-5 ", theme::fg(theme::key())),
-            Span::raw(
-                "Jump directly to a tab (1=Overview, 2=Details, 3=Activity, 4=Graph, 5=Help)",
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("↑/k, ↓/j ", theme::fg(theme::key())),
-            Span::raw("Navigate connections (wraps around)"),
-        ]),
-        Line::from(vec![
-            Span::styled("g, G ", theme::fg(theme::key())),
-            Span::raw("Jump to first/last connection (vim-style)"),
-        ]),
-        Line::from(vec![
-            Span::styled("Page Up/Down, Ctrl+B/F ", theme::fg(theme::key())),
-            Span::raw("Navigate connections by page"),
-        ]),
-        Line::from(vec![
-            Span::styled("Ctrl+D/U ", theme::fg(theme::key())),
-            Span::raw("Scroll the Details info panes"),
-        ]),
-        Line::from(vec![
-            Span::styled("c ", theme::fg(theme::key())),
-            Span::raw("Copy remote address to clipboard"),
-        ]),
-        Line::from(vec![
-            Span::styled("p ", theme::fg(theme::key())),
-            Span::raw("Toggle between service names and port numbers"),
-        ]),
-        Line::from(vec![
-            Span::styled("d ", theme::fg(theme::key())),
-            Span::raw("Toggle hostnames/IPs on Overview or Egress (TX)/Ingress (RX) on Activity"),
-        ]),
-        Line::from(vec![
-            Span::styled("s ", theme::fg(theme::key())),
-            Span::raw("Cycle through sort columns (Bandwidth, Process, etc.)"),
-        ]),
-        Line::from(vec![
-            Span::styled("S ", theme::fg(theme::key())),
-            Span::raw("Toggle sort direction (ascending/descending)"),
-        ]),
-        Line::from(vec![
-            Span::styled("a ", theme::fg(theme::key())),
-            Span::raw("Toggle process grouping (aggregate by process)"),
-        ]),
-        Line::from(vec![
-            Span::styled("Space ", theme::fg(theme::key())),
-            Span::raw("Expand/collapse group (when grouping enabled)"),
-        ]),
-        Line::from(vec![
-            Span::styled("←/→ or h/l ", theme::fg(theme::key())),
-            Span::raw("Collapse/expand group"),
-        ]),
-        Line::from(vec![
-            Span::styled("t ", theme::fg(theme::key())),
-            Span::raw("Toggle display of historic (closed) connections"),
-        ]),
-        Line::from(vec![
-            Span::styled("i ", theme::fg(theme::key())),
-            Span::raw("Toggle System info on Overview or interface details on Activity"),
-        ]),
-        Line::from(vec![
-            Span::styled("r ", theme::fg(theme::key())),
-            Span::raw("Reset view (grouping, sort, filter)"),
-        ]),
-        Line::from(vec![
-            Span::styled("Enter ", theme::fg(theme::key())),
-            Span::raw("View connection details"),
-        ]),
-        Line::from(vec![
-            Span::styled("Esc ", theme::fg(theme::key())),
-            Span::raw("Return to overview"),
-        ]),
-        Line::from(vec![
-            Span::styled("h ", theme::fg(theme::key())),
-            Span::raw("Toggle this help screen"),
-        ]),
-        Line::from(vec![
-            Span::styled("/ ", theme::fg(theme::key())),
-            Span::raw(
-                "Enter filter mode on Overview (use \u{2191}/\u{2193} to navigate while typing)",
-            ),
-        ]),
-        Line::from(""),
-        Line::from(vec![Span::styled("Tabs:", theme::bold_fg(theme::accent()))]),
-        Line::from(vec![
-            Span::styled("  Overview ", theme::fg(theme::ok())),
-            Span::raw("Connection list with mini traffic graph"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Details ", theme::fg(theme::ok())),
-            Span::raw("Full details for selected connection"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Activity ", theme::fg(theme::ok())),
-            Span::raw("Process egress/ingress, bandwidth shares, connections, and interface pulse"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Graph ", theme::fg(theme::ok())),
-            Span::raw("Traffic charts and protocol distribution"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Help ", theme::fg(theme::ok())),
-            Span::raw("This help screen"),
-        ]),
-        Line::from(""),
-        Line::from(vec![Span::styled(
-            "Activity concepts:",
-            theme::bold_fg(theme::accent()),
-        )]),
-        Line::from(vec![
-            Span::styled("  Egress (TX) / Ingress (RX) ", theme::fg(theme::key())),
-            Span::raw("Traffic sent from or received by the local process"),
-        ]),
-        Line::from(vec![
-            Span::styled("  60s coverage ", theme::fg(theme::key())),
-            Span::raw("Captured connection traffic divided by interface traffic"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Retained ", theme::fg(theme::key())),
-            Span::raw("Active traffic plus up to 5,000 recently closed connections"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Process attribution ", theme::fg(theme::key())),
-            Span::raw("Traffic mapped to a PID or process name; unresolved bytes are Unknown"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Top remote peer ", theme::fg(theme::key())),
-            Span::raw("Highest-volume remote endpoint for the selected direction"),
-        ]),
-        Line::from(""),
-        Line::from(vec![Span::styled(
-            "Mouse Controls:",
-            theme::bold_fg(theme::accent()),
-        )]),
-        Line::from(vec![
-            Span::styled("  Click tab ", theme::fg(theme::key())),
-            Span::raw("Switch between tabs"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Click row ", theme::fg(theme::key())),
-            Span::raw("Select connection"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Scroll wheel ", theme::fg(theme::key())),
-            Span::raw("Navigate connection list / scroll Details, Activity interfaces, Help"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Double-click row ", theme::fg(theme::key())),
-            Span::raw("Open connection details"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Double-click group ", theme::fg(theme::key())),
-            Span::raw("Expand/collapse process group"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Click field (Details) ", theme::fg(theme::key())),
-            Span::raw("Copy field value to clipboard"),
-        ]),
-        Line::from(""),
-        Line::from(vec![Span::styled(
-            "Connection Colors:",
-            theme::bold_fg(theme::accent()),
-        )]),
-        Line::from(vec![
-            Span::styled("  White ", Style::default()),
-            Span::raw("Active connection (< 75% of timeout)"),
-        ]),
-        Line::from(vec![
-            Span::styled("  Yellow", theme::fg(theme::expiry_glow(0.0))),
-            Span::styled(" → ", theme::fg(theme::muted())),
-            Span::styled("Orange", theme::fg(theme::expiry_glow(0.5))),
-            Span::styled(" → ", theme::fg(theme::muted())),
-            Span::styled("Red ", theme::fg(theme::expiry_glow(1.0))),
-            Span::raw(
-                "Connection nearing timeout (75-100%; holds yellow to 90%, then intensifies)",
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("  Gray ", theme::historic_row()),
-            Span::raw("Historic (closed) connection"),
-        ]),
-        Line::from(""),
-        Line::from(vec![Span::styled(
-            "Filter Examples:",
-            theme::bold_fg(theme::accent()),
-        )]),
-        Line::from(vec![
-            Span::styled("  /google ", theme::fg(theme::ok())),
-            Span::raw("Search for 'google' in all fields"),
-        ]),
-        Line::from(vec![
-            Span::styled("  /port:22 ", theme::fg(theme::ok())),
-            Span::raw("Exact port match (only port 22, not 2223 or 5522)"),
-        ]),
-        Line::from(vec![
-            Span::styled("  /port:/22/ ", theme::fg(theme::ok())),
-            Span::raw("Regex port match (22, 220, 5522, etc.)"),
-        ]),
-        Line::from(vec![
-            Span::styled("  /src:192.168 ", theme::fg(theme::ok())),
-            Span::raw("Filter by source IP prefix"),
-        ]),
-        Line::from(vec![
-            Span::styled("  /dst:github.com ", theme::fg(theme::ok())),
-            Span::raw("Filter by destination"),
-        ]),
-        Line::from(vec![
-            Span::styled("  /sni:/.*github.*/ ", theme::fg(theme::ok())),
-            Span::raw("Regex SNI match (wrap value in /…/ for regex)"),
-        ]),
-        Line::from(vec![
-            Span::styled("  /process:firefox ", theme::fg(theme::ok())),
-            Span::raw("Filter by process name"),
-        ]),
-        Line::from(""),
     ];
+    help_text.extend(
+        KEY_BINDINGS
+            .iter()
+            .map(|&(key, desc)| kv_line(key, desc, key_style)),
+    );
+
+    help_text.push(Line::from(""));
+    help_text.push(section_title("Tabs:"));
+    help_text.extend(
+        TAB_SUMMARIES
+            .iter()
+            .map(|&(key, desc)| kv_line(key, desc, example_style)),
+    );
+
+    help_text.push(Line::from(""));
+    help_text.push(section_title("Activity concepts:"));
+    help_text.extend(
+        ACTIVITY_CONCEPTS
+            .iter()
+            .map(|&(key, desc)| kv_line(key, desc, key_style)),
+    );
+
+    help_text.push(Line::from(""));
+    help_text.push(section_title("Mouse Controls:"));
+    help_text.extend(
+        MOUSE_CONTROLS
+            .iter()
+            .map(|&(key, desc)| kv_line(key, desc, key_style)),
+    );
+
+    help_text.push(Line::from(""));
+    help_text.push(section_title("Connection Colors:"));
+    help_text.push(kv_line(
+        "  White ",
+        "Active connection (< 75% of timeout)",
+        Style::default(),
+    ));
+    // The expiry gradient names three ramp stops, so it stays a literal.
+    help_text.push(Line::from(vec![
+        Span::styled("  Yellow", theme::fg(theme::expiry_glow(0.0))),
+        Span::styled(" → ", theme::fg(theme::muted())),
+        Span::styled("Orange", theme::fg(theme::expiry_glow(0.5))),
+        Span::styled(" → ", theme::fg(theme::muted())),
+        Span::styled("Red ", theme::fg(theme::expiry_glow(1.0))),
+        Span::raw("Connection nearing timeout (75-100%; holds yellow to 90%, then intensifies)"),
+    ]));
+    help_text.push(kv_line(
+        "  Gray ",
+        "Historic (closed) connection",
+        theme::historic_row(),
+    ));
+
+    help_text.push(Line::from(""));
+    help_text.push(section_title("Filter Examples:"));
+    help_text.extend(
+        FILTER_EXAMPLES
+            .iter()
+            .map(|&(key, desc)| kv_line(key, desc, example_style)),
+    );
+    help_text.push(Line::from(""));
 
     // Scroll against the unwrapped line count. A handful of lines can
     // wrap on very narrow terminals, making the true maximum slightly

--- a/src/ui/tabs/overview.rs
+++ b/src/ui/tabs/overview.rs
@@ -9,7 +9,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Cell, Padding, Paragraph, Row, Table, Wrap},
+    widgets::{Block, Borders, Cell, Padding, Paragraph, Row, Wrap},
 };
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
@@ -19,18 +19,17 @@ use crate::app::{App, AppStats, ConnectionCounts};
 use crate::network::dns::DnsResolver;
 use crate::network::types::Connection;
 use crate::ui::{
-    ClickAction, ClickableRegions, Component, ComponentContext, Effect, GroupedRow, HandlerContext,
+    ClickableRegions, Component, ComponentContext, Effect, GroupedRow, HandlerContext,
     NONE_PLACEHOLDER, SortColumn, UIState, clear_all_with_confirmation,
     connection_table::{
-        Column, ColumnId, bandwidth_cell, build_header, column_constraints, connection_row,
-        select_columns,
+        Column, ColumnId, RowWindow, bandwidth_cell, build_header, column_constraints,
+        connection_row, render_row_table, select_columns, visible_window,
     },
     format::format_bytes,
     section_header,
     state::ProcessGroupStats,
     theme, try_handle_connection_nav,
     widgets::braille_graph,
-    widgets::scrollbar::draw_scrollbar,
 };
 
 /// Overview tab — connection list + stats sidebar. Reads every
@@ -458,8 +457,7 @@ fn draw_connections_list(
     // column set is chosen.
     let scroll_offset = ui_state.scroll_offset;
     let visible_rows = ui_state.visible_rows.max(1);
-    let window_end = (scroll_offset + visible_rows + 1).min(connections.len());
-    let visible_connections = &connections[scroll_offset.min(connections.len())..window_end];
+    let visible_connections = visible_window(connections, scroll_offset, visible_rows);
 
     // Reserve the two rightmost columns: a blank gap, then the scrollbar.
     let columns = select_columns(area.width.saturating_sub(2), show_location);
@@ -471,44 +469,20 @@ fn draw_connections_list(
         .map(|conn| connection_row(conn, &columns, ui_state, dns_resolver, None))
         .collect();
 
-    // Create table state with selection adjusted to windowed slice
-    let mut state = ratatui::widgets::TableState::default();
-    if let Some(selected_index) = ui_state.get_selected_index(connections) {
-        state.select(Some(selected_index.saturating_sub(scroll_offset)));
-    }
-
-    let connections_table = Table::new(rows, &widths)
-        .header(header)
-        .row_highlight_style(theme::row_highlight())
-        .highlight_symbol("> ");
-
-    let table_area = Rect::new(area.x, area.y, area.width.saturating_sub(2), area.height);
-    f.render_stateful_widget(connections_table, table_area, &mut state);
-
-    // Scrollbar tracks the row region (below header + margin).
-    let header_height = 2_u16; // header row (1) + bottom_margin (1)
-    let rows_area = Rect::new(
-        area.x,
-        area.y + header_height,
-        area.width,
-        area.height.saturating_sub(header_height),
+    render_row_table(
+        f,
+        area,
+        header,
+        rows,
+        &widths,
+        RowWindow {
+            selected: ui_state.get_selected_index(connections),
+            scroll_offset,
+            total_rows: connections.len(),
+            visible_rows,
+        },
+        click_regions,
     );
-    draw_scrollbar(f, rows_area, connections.len(), scroll_offset, visible_rows);
-
-    // Register click regions for visible connection rows
-    click_regions.scroll_area = Some(area);
-    let visible_start_y = area.y + header_height;
-    let max_visible_rows = area.height.saturating_sub(header_height) as usize;
-
-    for i in 0..max_visible_rows {
-        let conn_idx = scroll_offset + i;
-        if conn_idx >= connections.len() {
-            break;
-        }
-        let row_y = visible_start_y + i as u16;
-        let row_rect = Rect::new(area.x, row_y, area.width, 1);
-        click_regions.register(row_rect, ClickAction::SelectConnection(conn_idx));
-    }
 }
 
 /// Shared section title for the flat and grouped connection tables. The
@@ -579,8 +553,7 @@ fn draw_grouped_connections_list(
     // Virtualization: only build Row objects for the visible window
     let scroll_offset = ui_state.grouped_scroll_offset;
     let visible_rows = ui_state.visible_rows.max(1);
-    let window_end = (scroll_offset + visible_rows + 1).min(grouped_rows.len());
-    let visible_grouped = &grouped_rows[scroll_offset.min(grouped_rows.len())..window_end];
+    let visible_grouped = visible_window(grouped_rows, scroll_offset, visible_rows);
 
     // Reserve the two rightmost columns: a blank gap, then the scrollbar.
     let columns = select_columns(area.width.saturating_sub(2), show_location);
@@ -626,50 +599,20 @@ fn draw_grouped_connections_list(
         })
         .collect();
 
-    // Create table state with selection adjusted to windowed slice
-    let mut state = ratatui::widgets::TableState::default();
-    if let Some(selected_index) = ui_state.get_selected_grouped_index(grouped_rows) {
-        state.select(Some(selected_index.saturating_sub(scroll_offset)));
-    }
-
-    let connections_table = Table::new(rows, &widths)
-        .header(header)
-        .row_highlight_style(theme::row_highlight())
-        .highlight_symbol("> ");
-
-    let table_area = Rect::new(area.x, area.y, area.width.saturating_sub(2), area.height);
-    f.render_stateful_widget(connections_table, table_area, &mut state);
-
-    // Scrollbar tracks the row region (below header + margin).
-    let header_height = 2_u16;
-    let rows_area = Rect::new(
-        area.x,
-        area.y + header_height,
-        area.width,
-        area.height.saturating_sub(header_height),
-    );
-    draw_scrollbar(
+    render_row_table(
         f,
-        rows_area,
-        grouped_rows.len(),
-        scroll_offset,
-        visible_rows,
+        area,
+        header,
+        rows,
+        &widths,
+        RowWindow {
+            selected: ui_state.get_selected_grouped_index(grouped_rows),
+            scroll_offset,
+            total_rows: grouped_rows.len(),
+            visible_rows,
+        },
+        click_regions,
     );
-
-    // Register click regions for visible grouped rows
-    click_regions.scroll_area = Some(area);
-    let visible_start_y = area.y + header_height;
-    let max_visible_rows = area.height.saturating_sub(header_height) as usize;
-
-    for i in 0..max_visible_rows {
-        let row_idx = scroll_offset + i;
-        if row_idx >= grouped_rows.len() {
-            break;
-        }
-        let row_y = visible_start_y + i as u16;
-        let row_rect = Rect::new(area.x, row_y, area.width, 1);
-        click_regions.register(row_rect, ClickAction::SelectConnection(row_idx));
-    }
 }
 
 /// A process-group header row rendered on the shared grid: name and count in
@@ -744,6 +687,56 @@ fn render_section_separator(f: &mut Frame, area: Rect) {
     f.render_widget(para, area);
 }
 
+/// Effective-UID privilege line shared by the Linux and macOS Security
+/// sections. (Windows reports Administrator status instead.)
+#[cfg(any(
+    target_os = "linux",
+    all(target_os = "macos", feature = "macos-sandbox")
+))]
+fn privilege_line() -> Line<'static> {
+    let uid = crate::network::privileges::effective_uid();
+    let (priv_label, priv_style) = if uid == 0 {
+        (
+            "Process: running as root".to_string(),
+            theme::fg(theme::warn()),
+        )
+    } else {
+        (format!("Process: UID {uid}"), theme::fg(theme::ok()))
+    };
+    Line::from(Span::styled(priv_label, priv_style))
+}
+
+/// Shared tail of the Security section: the platform-specific `head`
+/// lines, the feature bullets (or the "no restrictions" warning), and
+/// the privilege line.
+#[cfg(any(
+    target_os = "linux",
+    all(target_os = "macos", feature = "macos-sandbox"),
+    target_os = "windows"
+))]
+fn sandbox_lines<'a, S: AsRef<str>>(
+    head: Vec<Line<'a>>,
+    features: &[S],
+    privilege: Line<'a>,
+) -> Vec<Line<'a>> {
+    let mut lines = head;
+    if features.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No restrictions active",
+            theme::fg(theme::warn()),
+        )));
+    } else {
+        for f in features {
+            lines.push(Line::from(Span::styled(
+                format!("• {}", f.as_ref()),
+                theme::fg(theme::muted()),
+            )));
+        }
+    }
+    lines.push(privilege);
+    lines
+}
+
 fn draw_stats_panel(
     f: &mut Frame,
     connection_counts: ConnectionCounts,
@@ -814,38 +807,17 @@ fn draw_stats_panel(
             Span::styled("Landlock: kernel unsupported", theme::fg(theme::muted()))
         };
 
-        let uid = crate::network::privileges::effective_uid();
-        let (priv_label, priv_style) = if uid == 0 {
-            (
-                "Process: running as root".to_string(),
-                theme::fg(theme::warn()),
-            )
-        } else {
-            (format!("Process: UID {uid}"), theme::fg(theme::ok()))
-        };
-
-        let mut lines = vec![
-            Line::from(vec![
-                Span::raw("Sandbox: "),
-                Span::styled(sandbox_info.status, status_style),
-            ]),
-            Line::from(available_indicator),
-        ];
-        if features.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "No restrictions active",
-                theme::fg(theme::warn()),
-            )));
-        } else {
-            for f in &features {
-                lines.push(Line::from(Span::styled(
-                    format!("• {f}"),
-                    theme::fg(theme::muted()),
-                )));
-            }
-        }
-        lines.push(Line::from(Span::styled(priv_label, priv_style)));
-        lines
+        sandbox_lines(
+            vec![
+                Line::from(vec![
+                    Span::raw("Sandbox: "),
+                    Span::styled(sandbox_info.status, status_style),
+                ]),
+                Line::from(available_indicator),
+            ],
+            &features,
+            privilege_line(),
+        )
     };
 
     #[cfg(all(target_os = "macos", feature = "macos-sandbox"))]
@@ -872,35 +844,14 @@ fn draw_stats_panel(
             features.push("Net blocked");
         }
 
-        let uid = crate::network::privileges::effective_uid();
-        let (priv_label, priv_style) = if uid == 0 {
-            (
-                "Process: running as root".to_string(),
-                theme::fg(theme::warn()),
-            )
-        } else {
-            (format!("Process: UID {uid}"), theme::fg(theme::ok()))
-        };
-
-        let mut lines = vec![Line::from(vec![
-            Span::raw("Seatbelt: "),
-            Span::styled(sandbox_info.status, status_style),
-        ])];
-        if features.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "No restrictions active",
-                theme::fg(theme::warn()),
-            )));
-        } else {
-            for f in &features {
-                lines.push(Line::from(Span::styled(
-                    format!("• {f}"),
-                    theme::fg(theme::muted()),
-                )));
-            }
-        }
-        lines.push(Line::from(Span::styled(priv_label, priv_style)));
-        lines
+        sandbox_lines(
+            vec![Line::from(vec![
+                Span::raw("Seatbelt: "),
+                Span::styled(sandbox_info.status, status_style),
+            ])],
+            &features,
+            privilege_line(),
+        )
     };
 
     #[cfg(all(
@@ -956,25 +907,14 @@ fn draw_stats_panel(
             ("Process: standard user".to_string(), theme::fg(theme::ok()))
         };
 
-        let mut lines = vec![Line::from(vec![
-            Span::raw("Sandbox: "),
-            Span::styled(sandbox_info.status, status_style),
-        ])];
-        if features.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "No restrictions active",
-                theme::fg(theme::warn()),
-            )));
-        } else {
-            for f in &features {
-                lines.push(Line::from(Span::styled(
-                    format!("• {f}"),
-                    theme::fg(theme::muted()),
-                )));
-            }
-        }
-        lines.push(Line::from(Span::styled(priv_label, priv_style)));
-        lines
+        sandbox_lines(
+            vec![Line::from(vec![
+                Span::raw("Sandbox: "),
+                Span::styled(sandbox_info.status, status_style),
+            ])],
+            &features,
+            Line::from(Span::styled(priv_label, priv_style)),
+        )
     };
 
     // 1 line for the "Security" heading + one line per content line.
@@ -1302,6 +1242,33 @@ fn mini_wave(
     )
 }
 
+/// One sidebar sparkline row: the colored RX/TX label, then the
+/// smoothed mini wave. Both traffic rows differ only in label, rate
+/// source, and color ramp.
+fn draw_mini_wave_row(
+    f: &mut Frame,
+    area: Rect,
+    label: &'static str,
+    rates: &[u64],
+    frac: f64,
+    window: usize,
+    wave: fn(f64) -> Color,
+) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .split(area);
+
+    let label = Paragraph::new(label).style(theme::fg(wave(MINI_WAVE_INTENSITY)));
+    f.render_widget(label, cols[0]);
+
+    let data = smooth_mini_wave(rates);
+    f.render_widget(
+        Paragraph::new(mini_wave(&data, cols[1].width, frac, window, wave)),
+        cols[1],
+    );
+}
+
 /// Draw interface stats section with embedded traffic sparklines
 fn draw_interface_stats_with_graph(f: &mut Frame, app: &App, area: Rect) -> Result<()> {
     // Heading + sparklines (3 lines) + interface details (remaining).
@@ -1338,48 +1305,26 @@ fn draw_interface_stats_with_graph(f: &mut Frame, app: &App, area: Rect) -> Resu
         ])
         .split(sections[0]);
 
-    // RX row: label + wave
-    let rx_cols = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(3), Constraint::Min(0)])
-        .split(sparkline_rows[0]);
-
-    let rx_label = Paragraph::new("RX").style(theme::fg(theme::rx_wave(MINI_WAVE_INTENSITY)));
-    f.render_widget(rx_label, rx_cols[0]);
-
     let rx_rates = traffic_history.get_rx_sparkline_data(usize::MAX);
-    let rx_data = smooth_mini_wave(&rx_rates);
-    f.render_widget(
-        Paragraph::new(mini_wave(
-            &rx_data,
-            rx_cols[1].width,
-            frac,
-            window,
-            theme::rx_wave,
-        )),
-        rx_cols[1],
+    draw_mini_wave_row(
+        f,
+        sparkline_rows[0],
+        "RX",
+        &rx_rates,
+        frac,
+        window,
+        theme::rx_wave,
     );
 
-    // TX row: label + wave
-    let tx_cols = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(3), Constraint::Min(0)])
-        .split(sparkline_rows[1]);
-
-    let tx_label = Paragraph::new("TX").style(theme::fg(theme::tx_wave(MINI_WAVE_INTENSITY)));
-    f.render_widget(tx_label, tx_cols[0]);
-
     let tx_rates = traffic_history.get_tx_sparkline_data(usize::MAX);
-    let tx_data = smooth_mini_wave(&tx_rates);
-    f.render_widget(
-        Paragraph::new(mini_wave(
-            &tx_data,
-            tx_cols[1].width,
-            frac,
-            window,
-            theme::tx_wave,
-        )),
-        tx_cols[1],
+    draw_mini_wave_row(
+        f,
+        sparkline_rows[1],
+        "TX",
+        &tx_rates,
+        frac,
+        window,
+        theme::tx_wave,
     );
 
     // Current rates row


### PR DESCRIPTION
TUI-internal dedup pass (net -252 lines), all snapshots byte-identical:

- shared visible_window/render_row_table pipeline for the flat and grouped Overview tables
- render_details/heading_row harness collapses ~250 lines of repeated snapshot-test setup
- cfg-free privilege_line/sandbox_lines helpers shrink the four platform security_text blocks
- pulse_lines unifies the mirrored TX/RX pulse rendering in Activity and Overview
- push_detail_field variants become thin wrappers over one general form
- help tab renders from const key/description data via kv_line/section_title

No behavior change; no changelog entry (internal refactor).