### PR TITLE
refactor: share process attribution helpers in rustnet-host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **macOS lsof Attribution UID**: When libproc details resolve, lsof-based
+  attribution now reports the process's live effective UID from libproc
+  instead of the UID captured in the earlier lsof scan, matching the other
+  platforms (#545)
 - **Broadcast/Multicast Endpoint Display**: A broadcast or multicast datagram
   sent by a peer (e.g. NetBIOS to 192.168.0.255) used to render its
   destination as a normal-looking Local address. Such endpoints now render as

--- a/crates/rustnet-host/src/freebsd/process.rs
+++ b/crates/rustnet-host/src/freebsd/process.rs
@@ -2,14 +2,14 @@
 
 use crate::{
     AttributionBackend, ConnectionKey, MatchQuality, ProcessAncestor, ProcessAttribution,
-    ProcessLineage, ProcessLookup, collect_process_lineage, relaxed_lookup,
+    ProcessLineage, ProcessLookup, ancestor_display_name, collect_process_lineage,
+    decode_process_name, memoized, parse_socket_addr_text, relaxed_lookup,
 };
 use anyhow::{Context, Result};
 use rustnet_core::network::types::{Connection, Protocol};
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::mem::{MaybeUninit, size_of};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::ptr;
@@ -152,7 +152,7 @@ impl FreeBSDProcessLookup {
             ppid: u32::try_from(info.ki_ppid).ok()?,
             uid: info.ki_uid,
             gid,
-            name: Self::decode_process_name(&info.ki_comm),
+            name: decode_process_name(&info.ki_comm).unwrap_or_default(),
             executable: Self::resolve_executable(pid),
             started_at_unix_ms: Self::timeval_unix_ms(&info.ki_start),
         })
@@ -164,48 +164,21 @@ impl FreeBSDProcessLookup {
         seconds.checked_mul(1_000)?.checked_add(micros / 1_000)
     }
 
-    fn decode_process_name(chars: &[libc::c_char]) -> String {
-        let bytes: Vec<u8> = chars
-            .iter()
-            .copied()
-            .take_while(|value| *value != 0)
-            .map(|value| value as u8)
-            .collect();
-        String::from_utf8_lossy(&bytes).into_owned()
-    }
-
     fn process_details(&self, pid: u32) -> Option<FreeBsdProcessDetails> {
-        if let Some(details) = self
-            .process_details
-            .read()
-            .expect("process details cache lock poisoned")
-            .get(&pid)
-        {
-            return details.clone();
-        }
-
-        let details = Self::read_process_details(pid);
-        self.process_details
-            .write()
-            .expect("process details cache lock poisoned")
-            .insert(pid, details.clone());
-        details
+        memoized(
+            &self.process_details,
+            pid,
+            "process details cache lock poisoned",
+            || Self::read_process_details(pid),
+        )
     }
 
     fn process_lineage(&self, pid: u32, ppid: u32) -> Option<ProcessLineage> {
         collect_process_lineage(pid, ppid, |ancestor_pid| {
             let details = self.process_details(ancestor_pid)?;
             let parent_pid = details.ppid;
-            let name = if details.name.is_empty() {
-                details
-                    .executable
-                    .as_deref()
-                    .and_then(|path| path.file_name())
-                    .map(|name| name.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| format!("PID {ancestor_pid}"))
-            } else {
-                details.name
-            };
+            let name =
+                ancestor_display_name(details.name, details.executable.as_deref(), ancestor_pid);
             Some((
                 ProcessAncestor {
                     pid: ancestor_pid,
@@ -311,13 +284,13 @@ impl FreeBSDProcessLookup {
             };
 
             // Parse local address (index 5)
-            let local_addr = match Self::parse_address(parts[5]) {
+            let local_addr = match parse_socket_addr_text(parts[5]) {
                 Some(addr) => addr,
                 None => continue,
             };
 
             // Parse foreign address (index 6)
-            let foreign_addr = match Self::parse_address(parts[6]) {
+            let foreign_addr = match parse_socket_addr_text(parts[6]) {
                 Some(addr) => addr,
                 None => continue,
             };
@@ -340,44 +313,6 @@ impl FreeBSDProcessLookup {
 
         result
     }
-
-    /// Parse address in format "ip:port", "*:port", or "[ipv6]:port"
-    fn parse_address(addr_str: &str) -> Option<SocketAddr> {
-        // Handle wildcard addresses
-        if addr_str.starts_with("*:") {
-            let port = addr_str.strip_prefix("*:")?.parse::<u16>().ok()?;
-            // Use unspecified address for wildcards
-            return Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port));
-        }
-
-        // Handle IPv6 with brackets: [::1]:8080
-        if addr_str.starts_with('[') {
-            let closing_bracket = addr_str.find(']')?;
-            let ip_str = &addr_str[1..closing_bracket];
-            let port_str = addr_str.get(closing_bracket + 2..)?; // Skip "]:"
-            let port = port_str.parse::<u16>().ok()?;
-            let ip = IpAddr::V6(ip_str.parse().ok()?);
-            return Some(SocketAddr::new(ip, port));
-        }
-
-        // Split by last colon to handle addresses
-        let last_colon = addr_str.rfind(':')?;
-        let (ip_str, port_str) = addr_str.split_at(last_colon);
-        let port_str = &port_str[1..]; // Remove the colon
-
-        let port = port_str.parse::<u16>().ok()?;
-
-        // Detect IPv6 (contains colons) vs IPv4
-        let ip = if ip_str.contains(':') {
-            // IPv6 address without brackets (e.g., "::1" or "fe80::1")
-            IpAddr::V6(ip_str.parse().ok()?)
-        } else {
-            // IPv4 address
-            IpAddr::V4(ip_str.parse().ok()?)
-        };
-
-        Some(SocketAddr::new(ip, port))
-    }
 }
 
 impl ProcessLookup for FreeBSDProcessLookup {
@@ -397,11 +332,12 @@ impl ProcessLookup for FreeBSDProcessLookup {
         attribution.uid = Some(process.uid);
         if let Some(details) = self.process_details(process.pid) {
             let lineage = self.process_lineage(process.pid, details.ppid);
-            attribution = attribution
-                .with_parent_pid(details.ppid)
-                .with_credentials(details.uid, details.gid)
-                .with_executable(details.executable)
-                .with_lineage(lineage);
+            attribution = attribution.with_details(
+                details.ppid,
+                Some((details.uid, details.gid)),
+                details.executable,
+                lineage,
+            );
         }
         Some(attribution)
     }
@@ -429,7 +365,6 @@ impl ProcessLookup for FreeBSDProcessLookup {
 mod tests {
     use super::*;
     use rustnet_core::network::types::{ProtocolState, TcpState};
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
     fn tcp_connection(local: &str, remote: &str) -> Connection {
         Connection::new(
@@ -479,113 +414,6 @@ root server 42 3 tcp4 127.0.0.1:8080 0.0.0.0:0
     }
 
     #[test]
-    fn test_parse_ipv4_address() {
-        let addr = FreeBSDProcessLookup::parse_address("192.168.1.1:8080");
-        assert_eq!(
-            addr,
-            Some(SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
-                8080
-            ))
-        );
-    }
-
-    #[test]
-    fn test_parse_ipv4_loopback() {
-        let addr = FreeBSDProcessLookup::parse_address("127.0.0.1:80");
-        assert_eq!(
-            addr,
-            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80))
-        );
-    }
-
-    #[test]
-    fn test_parse_ipv6_with_brackets() {
-        let addr = FreeBSDProcessLookup::parse_address("[::1]:8080");
-        assert_eq!(
-            addr,
-            Some(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080))
-        );
-    }
-
-    #[test]
-    fn test_parse_ipv6_full_address_with_brackets() {
-        let addr = FreeBSDProcessLookup::parse_address("[2001:db8::1]:443");
-        assert_eq!(
-            addr,
-            Some(SocketAddr::new(
-                IpAddr::V6("2001:db8::1".parse().unwrap()),
-                443
-            ))
-        );
-    }
-
-    #[test]
-    fn test_parse_ipv6_link_local_with_brackets() {
-        let addr = FreeBSDProcessLookup::parse_address("[fe80::1]:22");
-        assert_eq!(
-            addr,
-            Some(SocketAddr::new(IpAddr::V6("fe80::1".parse().unwrap()), 22))
-        );
-    }
-
-    #[test]
-    fn test_parse_ipv6_without_brackets() {
-        // This may occur in some sockstat outputs
-        let addr = FreeBSDProcessLookup::parse_address("::1:8080");
-        // This should parse as IPv6 ::1 with port 8080
-        // Note: This is ambiguous, but our logic treats multiple colons as IPv6
-        assert!(addr.is_some());
-        if let Some(socket_addr) = addr {
-            assert_eq!(socket_addr.port(), 8080);
-        }
-    }
-
-    #[test]
-    fn test_parse_wildcard_address() {
-        let addr = FreeBSDProcessLookup::parse_address("*:80");
-        assert_eq!(
-            addr,
-            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 80))
-        );
-    }
-
-    #[test]
-    fn test_parse_wildcard_high_port() {
-        let addr = FreeBSDProcessLookup::parse_address("*:65535");
-        assert_eq!(
-            addr,
-            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 65535))
-        );
-    }
-
-    #[test]
-    fn test_parse_invalid_address() {
-        // Missing port
-        assert_eq!(FreeBSDProcessLookup::parse_address("192.168.1.1"), None);
-    }
-
-    #[test]
-    fn test_parse_invalid_ipv6_brackets() {
-        // Missing closing bracket
-        assert_eq!(FreeBSDProcessLookup::parse_address("[::1:8080"), None);
-    }
-
-    #[test]
-    fn test_parse_invalid_port() {
-        // Port out of range
-        assert_eq!(
-            FreeBSDProcessLookup::parse_address("192.168.1.1:99999"),
-            None
-        );
-    }
-
-    #[test]
-    fn test_parse_empty_string() {
-        assert_eq!(FreeBSDProcessLookup::parse_address(""), None);
-    }
-
-    #[test]
     fn test_current_process_details() {
         let details = FreeBSDProcessLookup::read_process_details(std::process::id())
             .expect("current process details must resolve");
@@ -610,18 +438,5 @@ root server 42 3 tcp4 127.0.0.1:8080 0.0.0.0:0
     #[test]
     fn test_missing_process_has_no_details() {
         assert!(FreeBSDProcessLookup::read_process_details(u32::MAX).is_none());
-    }
-
-    #[test]
-    fn test_parse_ipv4_mapped_ipv6() {
-        // IPv4-mapped IPv6 address
-        let addr = FreeBSDProcessLookup::parse_address("[::ffff:192.168.1.1]:80");
-        assert_eq!(
-            addr,
-            Some(SocketAddr::new(
-                IpAddr::V6("::ffff:192.168.1.1".parse().unwrap()),
-                80
-            ))
-        );
     }
 }

--- a/crates/rustnet-host/src/lib.rs
+++ b/crates/rustnet-host/src/lib.rs
@@ -204,6 +204,29 @@ impl ProcessAttribution {
         self
     }
 
+    /// Attach everything a platform's per-process details lookup resolved in
+    /// one step: parent pid, credentials, executable path, and lineage.
+    /// Credentials and executable are left untouched when the lookup does not
+    /// resolve them.
+    pub fn with_details(
+        mut self,
+        ppid: u32,
+        credentials: Option<(u32, u32)>,
+        executable: Option<PathBuf>,
+        lineage: Option<ProcessLineage>,
+    ) -> Self {
+        self.ppid = Some(ppid);
+        if let Some((uid, gid)) = credentials {
+            self.uid = Some(uid);
+            self.gid = Some(gid);
+        }
+        if let Some(executable) = executable {
+            self.executable = Some(executable);
+        }
+        self.lineage = lineage;
+        self
+    }
+
     /// Reduce to the legacy `(pid, process_name)` pair.
     pub fn into_pid_name(self) -> (u32, String) {
         (self.tgid, self.name)
@@ -254,6 +277,96 @@ where
         ancestors,
         truncated,
     })
+}
+
+/// Decode a NUL-terminated C char array (`ki_comm`, `pbi_comm`, ...) into a
+/// process name. `None` when the array is empty.
+#[cfg(any(target_os = "freebsd", target_os = "macos"))]
+pub(crate) fn decode_process_name(chars: &[libc::c_char]) -> Option<String> {
+    let bytes: Vec<u8> = chars
+        .iter()
+        .copied()
+        .take_while(|value| *value != 0)
+        .map(|value| value as u8)
+        .collect();
+    (!bytes.is_empty()).then(|| String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// Display name for a lineage ancestor: the OS-reported name, else the
+/// executable's file name, else a `PID <n>` placeholder.
+#[cfg(any(target_os = "freebsd", target_os = "macos"))]
+pub(crate) fn ancestor_display_name(
+    name: String,
+    executable: Option<&std::path::Path>,
+    pid: u32,
+) -> String {
+    if name.is_empty() {
+        executable
+            .and_then(|path| path.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| format!("PID {pid}"))
+    } else {
+        name
+    }
+}
+
+/// Return the cached value for `key`, computing and caching it on a miss.
+/// Caches misses too when `V` is an `Option`. `poisoned` is the lock's
+/// expect message.
+#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+pub(crate) fn memoized<K, V>(
+    cache: &std::sync::RwLock<HashMap<K, V>>,
+    key: K,
+    poisoned: &str,
+    compute: impl FnOnce() -> V,
+) -> V
+where
+    K: Eq + std::hash::Hash,
+    V: Clone,
+{
+    if let Some(value) = cache.read().expect(poisoned).get(&key) {
+        return value.clone();
+    }
+
+    let value = compute();
+    cache.write().expect(poisoned).insert(key, value.clone());
+    value
+}
+
+/// Parse a socket address as printed by OS socket-table tools (`sockstat`,
+/// `lsof`): `ip:port`, `*:port` (wildcard), `[ipv6]:port`, or bracketless
+/// IPv6 like `::1:8080` (the last colon splits off the port).
+pub fn parse_socket_addr_text(addr_str: &str) -> Option<SocketAddr> {
+    // Handle wildcard addresses
+    if addr_str.starts_with("*:") {
+        let port = addr_str.strip_prefix("*:")?.parse::<u16>().ok()?;
+        // Use unspecified address for wildcards
+        return Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port));
+    }
+
+    // Handle IPv6 with brackets: [::1]:8080. Std parsing also accepts scope
+    // ids like [fe80::1%1]:22, which Ipv6Addr alone would reject.
+    if addr_str.starts_with('[') {
+        return addr_str.parse().ok();
+    }
+
+    // Split by last colon to handle addresses
+    let last_colon = addr_str.rfind(':')?;
+    let (ip_str, port_str) = addr_str.split_at(last_colon);
+    let port_str = &port_str[1..]; // Remove the colon
+
+    let port = port_str.parse::<u16>().ok()?;
+
+    // Detect IPv6 (contains colons) vs IPv4
+    let ip = if ip_str.contains(':') {
+        // IPv6 address without brackets (e.g., "::1" or "fe80::1")
+        IpAddr::V6(ip_str.parse().ok()?)
+    } else {
+        // IPv4 address
+        IpAddr::V4(ip_str.parse().ok()?)
+    };
+
+    Some(SocketAddr::new(ip, port))
 }
 
 impl From<ProcessAttribution> for (u32, String) {
@@ -663,6 +776,36 @@ mod tests {
         assert_eq!(attribution.lineage, None);
     }
 
+    #[test]
+    fn with_details_leaves_unresolved_credentials_and_executable_untouched() {
+        let base = || {
+            ProcessAttribution::new(
+                7,
+                "sshd",
+                AttributionBackend::PlatformNative,
+                MatchQuality::Unspecified,
+            )
+        };
+
+        let full = base().with_details(
+            1,
+            Some((1000, 100)),
+            Some(PathBuf::from("/usr/sbin/sshd")),
+            None,
+        );
+        assert_eq!(full.ppid, Some(1));
+        assert_eq!((full.uid, full.gid), (Some(1000), Some(100)));
+        assert_eq!(full.executable, Some(PathBuf::from("/usr/sbin/sshd")));
+
+        let sparse = base()
+            .with_credentials(500, 50)
+            .with_executable(Some(PathBuf::from("/usr/sbin/sshd")))
+            .with_details(1, None, None, None);
+        assert_eq!(sparse.ppid, Some(1));
+        assert_eq!((sparse.uid, sparse.gid), (Some(500), Some(50)));
+        assert_eq!(sparse.executable, Some(PathBuf::from("/usr/sbin/sshd")));
+    }
+
     fn ancestor(pid: u32) -> ProcessAncestor {
         ProcessAncestor {
             pid,
@@ -858,6 +1001,91 @@ mod tests {
         assert!(
             relaxed_lookup(&map, &key(Protocol::Icmp, "192.168.1.10:0", "8.8.8.8:0")).is_none()
         );
+    }
+
+    #[test]
+    fn socket_addr_text_parses_ipv4() {
+        assert_eq!(
+            parse_socket_addr_text("192.168.1.1:8080"),
+            Some(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+                8080
+            ))
+        );
+        assert_eq!(
+            parse_socket_addr_text("127.0.0.1:80"),
+            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80))
+        );
+    }
+
+    #[test]
+    fn socket_addr_text_parses_ipv6_with_brackets() {
+        assert_eq!(
+            parse_socket_addr_text("[::1]:8080"),
+            Some(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080))
+        );
+        assert_eq!(
+            parse_socket_addr_text("[2001:db8::1]:443"),
+            Some(SocketAddr::new(
+                IpAddr::V6("2001:db8::1".parse().unwrap()),
+                443
+            ))
+        );
+        assert_eq!(
+            parse_socket_addr_text("[fe80::1]:22"),
+            Some(SocketAddr::new(IpAddr::V6("fe80::1".parse().unwrap()), 22))
+        );
+        // Numeric scope id, accepted by the old macOS parser
+        assert_eq!(
+            parse_socket_addr_text("[fe80::1%1]:22"),
+            Some("[fe80::1%1]:22".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn socket_addr_text_parses_ipv4_mapped_ipv6() {
+        assert_eq!(
+            parse_socket_addr_text("[::ffff:192.168.1.1]:80"),
+            Some(SocketAddr::new(
+                IpAddr::V6("::ffff:192.168.1.1".parse().unwrap()),
+                80
+            ))
+        );
+    }
+
+    #[test]
+    fn socket_addr_text_parses_bare_ipv6_without_brackets() {
+        // Occurs in some sockstat outputs. Ambiguous, but multiple colons
+        // are treated as IPv6 with the last colon splitting off the port.
+        assert_eq!(
+            parse_socket_addr_text("::1:8080"),
+            Some(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080))
+        );
+    }
+
+    #[test]
+    fn socket_addr_text_parses_wildcards_as_unspecified() {
+        assert_eq!(
+            parse_socket_addr_text("*:80"),
+            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 80))
+        );
+        assert_eq!(
+            parse_socket_addr_text("*:65535"),
+            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 65535))
+        );
+    }
+
+    #[test]
+    fn socket_addr_text_rejects_malformed_input() {
+        // Missing port
+        assert_eq!(parse_socket_addr_text("192.168.1.1"), None);
+        // Missing closing bracket
+        assert_eq!(parse_socket_addr_text("[::1:8080"), None);
+        // Missing ':' after the closing bracket
+        assert_eq!(parse_socket_addr_text("[::1]x80"), None);
+        // Port out of range
+        assert_eq!(parse_socket_addr_text("192.168.1.1:99999"), None);
+        assert_eq!(parse_socket_addr_text(""), None);
     }
 
     #[test]

--- a/crates/rustnet-host/src/linux/process.rs
+++ b/crates/rustnet-host/src/linux/process.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     AttributionBackend, ConnectionKey, MatchQuality, ProcessAncestor, ProcessAttribution,
-    ProcessLineage, ProcessLookup, collect_process_lineage, relaxed_lookup,
+    ProcessLineage, ProcessLookup, collect_process_lineage, memoized, relaxed_lookup,
 };
 use anyhow::Result;
 use rustnet_core::network::types::{Connection, Protocol};
@@ -259,21 +259,9 @@ impl LinuxProcessLookup {
     /// Resolve a process's parent chain, memoized per TGID until the next
     /// socket-table refresh bounds PID-reuse staleness.
     pub(crate) fn lineage_for(&self, tgid: u32, ppid: u32) -> Option<ProcessLineage> {
-        if let Some(lineage) = self
-            .lineages
-            .read()
-            .expect("lineages lock poisoned")
-            .get(&tgid)
-        {
-            return lineage.clone();
-        }
-
-        let lineage = resolve_process_lineage(tgid, ppid);
-        self.lineages
-            .write()
-            .expect("lineages lock poisoned")
-            .insert(tgid, lineage.clone());
-        lineage
+        memoized(&self.lineages, tgid, "lineages lock poisoned", || {
+            resolve_process_lineage(tgid, ppid)
+        })
     }
 
     /// Turn a procfs socket-table match into a rich attribution by reading the

--- a/crates/rustnet-host/src/macos/mod.rs
+++ b/crates/rustnet-host/src/macos/mod.rs
@@ -55,10 +55,12 @@ impl ProcessLookup for PktapProcessLookup {
         )
         .with_executable(process::resolve_executable(pid));
         if let Some(details) = process::resolve_process_details(pid) {
-            attribution = attribution
-                .with_parent_pid(details.ppid)
-                .with_credentials(details.uid, details.gid)
-                .with_lineage(process::resolve_process_lineage(pid, details.ppid));
+            attribution = attribution.with_details(
+                details.ppid,
+                Some((details.uid, details.gid)),
+                None,
+                process::resolve_process_lineage(pid, details.ppid),
+            );
         }
         Some(attribution)
     }

--- a/crates/rustnet-host/src/macos/process.rs
+++ b/crates/rustnet-host/src/macos/process.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     AttributionBackend, ConnectionKey, DegradationReason, MatchQuality, ProcessAncestor,
-    ProcessAttribution, ProcessLineage, ProcessLookup, collect_process_lineage, relaxed_lookup,
+    ProcessAttribution, ProcessLineage, ProcessLookup, ancestor_display_name,
+    collect_process_lineage, decode_process_name, parse_socket_addr_text, relaxed_lookup,
 };
 use anyhow::Result;
 use log::{debug, error, info, warn};
@@ -126,29 +127,11 @@ fn resolve_short_process_details(pid: libc::c_int) -> Option<ProcessDetails> {
     })
 }
 
-fn decode_process_name(chars: &[libc::c_char]) -> Option<String> {
-    let bytes: Vec<u8> = chars
-        .iter()
-        .copied()
-        .take_while(|value| *value != 0)
-        .map(|value| value as u8)
-        .collect();
-    (!bytes.is_empty()).then(|| String::from_utf8_lossy(&bytes).into_owned())
-}
-
 pub(super) fn resolve_process_lineage(pid: u32, ppid: u32) -> Option<ProcessLineage> {
     collect_process_lineage(pid, ppid, |ancestor_pid| {
         let details = resolve_process_details(ancestor_pid)?;
         let executable = resolve_executable(ancestor_pid);
-        let name = if details.name.is_empty() {
-            executable
-                .as_deref()
-                .and_then(|path| path.file_name())
-                .map(|name| name.to_string_lossy().into_owned())
-                .unwrap_or_else(|| format!("PID {ancestor_pid}"))
-        } else {
-            details.name
-        };
+        let name = ancestor_display_name(details.name, executable.as_deref(), ancestor_pid);
         Some((
             ProcessAncestor {
                 pid: ancestor_pid,
@@ -356,10 +339,12 @@ impl ProcessLookup for MacOSProcessLookup {
                 .with_executable(resolve_executable(process.pid));
         attribution.uid = Some(process.uid);
         if let Some(details) = resolve_process_details(process.pid) {
-            attribution = attribution
-                .with_parent_pid(details.ppid)
-                .with_credentials(process.uid, details.gid)
-                .with_lineage(resolve_process_lineage(process.pid, details.ppid));
+            attribution = attribution.with_details(
+                details.ppid,
+                Some((details.uid, details.gid)),
+                None,
+                resolve_process_lineage(process.pid, details.ppid),
+            );
         }
         Some(attribution)
     }
@@ -414,8 +399,8 @@ fn parse_lsof_connection_with_hint(
             "    Parsing arrow connection: '{}' -> '{}'",
             parts[0], parts[1]
         );
-        let local = parse_socket_addr(parts[0])?;
-        let remote = parse_socket_addr(parts[1])?;
+        let local = parse_socket_addr_text(parts[0])?;
+        let remote = parse_socket_addr_text(parts[1])?;
 
         // Use hint if available, otherwise assume TCP for established connections
         let protocol = protocol_hint.unwrap_or(Protocol::Tcp);
@@ -431,7 +416,7 @@ fn parse_lsof_connection_with_hint(
     } else if name.contains(":") {
         // UDP or listening socket
         debug!("    Parsing single address: '{}'", name);
-        let local = parse_socket_addr(name)?;
+        let local = parse_socket_addr_text(name)?;
 
         // For UDP or listening, we create a dummy remote address
         let remote = match local {
@@ -451,28 +436,6 @@ fn parse_lsof_connection_with_hint(
     } else {
         debug!("    Failed: no recognizable connection format");
         None
-    }
-}
-
-fn parse_socket_addr(addr_str: &str) -> Option<SocketAddr> {
-    debug!("      Parsing socket address: '{}'", addr_str);
-
-    // Handle IPv6 addresses in brackets
-    if addr_str.starts_with('[') {
-        let result = addr_str.parse().ok();
-        debug!("      IPv6 parse result: {:?}", result);
-        result
-    } else if addr_str.starts_with('*') {
-        // Listening on all interfaces
-        let port_str = addr_str.strip_prefix("*:")?;
-        let port = port_str.parse().ok()?;
-        let result = Some(SocketAddr::new("0.0.0.0".parse().ok()?, port));
-        debug!("      Wildcard parse result: {:?}", result);
-        result
-    } else {
-        let result = addr_str.parse().ok();
-        debug!("      Regular parse result: {:?}", result);
-        result
     }
 }
 

--- a/crates/rustnet-host/src/windows/process.rs
+++ b/crates/rustnet-host/src/windows/process.rs
@@ -747,10 +747,7 @@ impl ProcessLookup for WindowsProcessLookup {
         );
         if let Some(details) = self.process_details(pid) {
             let lineage = self.process_lineage(pid, details.ppid);
-            attribution = attribution
-                .with_parent_pid(details.ppid)
-                .with_executable(details.executable)
-                .with_lineage(lineage);
+            attribution = attribution.with_details(details.ppid, None, details.executable, lineage);
         }
         Some(attribution)
     }


### PR DESCRIPTION
Dedup pass in rustnet-host:

- ProcessAttribution::with_details builder replaces the four per-platform assembly sites; the macOS lsof site now uses the libproc uid like the other platforms (see changelog entry)
- decode_process_name and the ancestor-name fallback move to lib.rs, shared by FreeBSD and macOS
- one shared parse_socket_addr_text (FreeBSD superset; bracketed forms keep std SocketAddr parsing so scoped IPv6 still parses); FreeBSD parser tests ported to lib.rs and now run on Linux
- generic memoized() helper for the read-lock/compute/write-lock pattern (FreeBSD, Linux)

Verified with cargo check --target x86_64-unknown-freebsd; macOS/Windows compile relies on CI (no cross toolchain here). Side effect on macOS: the old parser's per-call debug logs are gone.