### PR TITLE
refactor: remove dead public API from the library crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each socket-table refresh (#513)
 
 ### Changed
+- **Dead Library-Crate API Removed**: The workspace crates dropped public API
+  nothing in the workspace uses: a never-compiling procfs-only module and
+  write-only lookup statistics in `rustnet-host`, the unused thread-id and
+  monotonic-timestamp attribution fields, and assorted unused methods and
+  write-only fields in `rustnet-core` (including the crate-root flat
+  re-exports and the `psh`/`urg` TCP flags) (#551)
 - **Interface Stats Moved to rustnet-core**: The per-platform interface
   statistics providers (sysfs on Linux, getifaddrs on macOS/FreeBSD, IP
   Helper on Windows) moved from the binary into `rustnet-core` behind a new

--- a/benches/connection_merge.rs
+++ b/benches/connection_merge.rs
@@ -46,8 +46,6 @@ fn make_parsed_packet() -> rustnet_monitor::network::parser::ParsedPacket {
                 ack: true,
                 fin: false,
                 rst: false,
-                psh: true,
-                urg: false,
             },
             payload_len: 1400,
         }),

--- a/benches/tracker_ingest.rs
+++ b/benches/tracker_ingest.rs
@@ -28,8 +28,6 @@ fn make_packet(flow: u16, seq: u32) -> ParsedPacket {
                 ack: true,
                 fin: false,
                 rst: false,
-                psh: true,
-                urg: false,
             },
             payload_len: 1400,
         }),

--- a/crates/rustnet-core/README.md
+++ b/crates/rustnet-core/README.md
@@ -24,9 +24,7 @@ to analyze.
 
 ## Layout
 
-Everything lives under the [`network`] module and is re-exported at the crate
-root, so both `rustnet_core::network::types` and `rustnet_core::types` resolve
-to the same place.
+Everything lives under the [`network`] module.
 
 ## Status
 

--- a/crates/rustnet-core/src/lib.rs
+++ b/crates/rustnet-core/src/lib.rs
@@ -24,16 +24,6 @@
 //!
 //! ## Layout
 //!
-//! All modules live under [`network`]. They are also re-exported at the crate
-//! root for convenience, so both `rustnet_core::network::types` and
-//! `rustnet_core::types` resolve to the same module.
+//! All modules live under [`network`].
 
 pub mod network;
-
-// Flat re-exports so external users can write `rustnet_core::types` instead of
-// `rustnet_core::network::types`. The `network` module remains the canonical
-// home and keeps internal `crate::network::*` paths working unchanged.
-pub use network::{
-    bogon, dns, dpi, geoip, interface_stats, link_layer, merge, neighbors, oui, parser,
-    process_activity, protocol, services, tracker, types, util,
-};

--- a/crates/rustnet-core/src/network/interface_stats/mod.rs
+++ b/crates/rustnet-core/src/network/interface_stats/mod.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 mod bsd;
@@ -68,7 +68,6 @@ impl InterfaceStats {
         InterfaceTrafficWindow {
             rx_bytes: self.rx_bytes.saturating_sub(previous.rx_bytes),
             tx_bytes: self.tx_bytes.saturating_sub(previous.tx_bytes),
-            sampled_for,
         }
     }
 }
@@ -85,7 +84,6 @@ pub struct InterfaceRates {
 pub struct InterfaceTrafficWindow {
     pub rx_bytes: u64,
     pub tx_bytes: u64,
-    pub sampled_for: Duration,
 }
 
 /// Trait for platform-specific interface statistics providers
@@ -258,6 +256,5 @@ mod tests {
         let window = second.traffic_since(&first);
         assert_eq!(window.rx_bytes, 8_000);
         assert_eq!(window.tx_bytes, 2_000);
-        assert_eq!(window.sampled_for, Duration::from_secs(60));
     }
 }

--- a/crates/rustnet-core/src/network/link_layer/tun_tap.rs
+++ b/crates/rustnet-core/src/network/link_layer/tun_tap.rs
@@ -28,11 +28,6 @@ pub fn is_tap_interface(name: &str) -> bool {
     name.starts_with("tap")
 }
 
-/// Detect if an interface name is any tunnel interface (TUN or TAP)
-pub fn is_tunnel_interface(name: &str) -> bool {
-    is_tun_interface(name) || is_tap_interface(name)
-}
-
 /// Parse a TUN packet (raw IP, no link-layer header)
 ///
 /// TUN devices operate at the network layer (Layer 3) and carry raw IP packets.
@@ -136,16 +131,6 @@ mod tests {
         assert!(!is_tap_interface("tun0"));
         assert!(!is_tap_interface("eth0"));
         assert!(!is_tap_interface("wlan0"));
-    }
-
-    #[test]
-    fn test_tunnel_interface_detection() {
-        assert!(is_tunnel_interface("tun0"));
-        assert!(is_tunnel_interface("tap0"));
-        assert!(is_tunnel_interface("utun0"));
-        assert!(!is_tunnel_interface("eth0"));
-        assert!(!is_tunnel_interface("wlan0"));
-        assert!(!is_tunnel_interface("lo"));
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -1025,8 +1025,6 @@ mod tests {
                     ack: false,
                     fin,
                     rst: false,
-                    psh: false,
-                    urg: false,
                 },
                 payload_len: 60, // Simulated payload length
             },
@@ -1298,8 +1296,6 @@ mod tests {
             ack: false,
             fin: false,
             rst: false,
-            psh: false,
-            urg: false,
         };
         let new_state = update_tcp_state(TcpState::Unknown, &flags, true);
         assert_eq!(new_state, TcpState::SynSent);
@@ -1310,8 +1306,6 @@ mod tests {
             ack: true,
             fin: false,
             rst: false,
-            psh: false,
-            urg: false,
         };
         let new_state = update_tcp_state(TcpState::SynSent, &flags, false);
         assert_eq!(new_state, TcpState::Established);
@@ -1322,8 +1316,6 @@ mod tests {
             ack: false,
             fin: true,
             rst: false,
-            psh: false,
-            urg: false,
         };
         let new_state = update_tcp_state(TcpState::Established, &flags, true);
         assert_eq!(new_state, TcpState::FinWait1);
@@ -1334,8 +1326,6 @@ mod tests {
             ack: false,
             fin: false,
             rst: true,
-            psh: false,
-            urg: false,
         };
         let new_state = update_tcp_state(TcpState::Established, &flags, true);
         assert_eq!(new_state, TcpState::Closed);

--- a/crates/rustnet-core/src/network/process_activity.rs
+++ b/crates/rustnet-core/src/network/process_activity.rs
@@ -117,20 +117,15 @@ pub struct ProcessActivity {
     pub destinations_truncated: bool,
     pub top_tx_destination: Option<DestinationActivity>,
     pub top_rx_destination: Option<DestinationActivity>,
-    pub current_tx_share: f64,
-    pub current_rx_share: f64,
     pub window_tx_share: f64,
     pub window_rx_share: f64,
     pub retained_tx_share: f64,
     pub retained_rx_share: f64,
-    pub first_seen: SystemTime,
-    pub last_seen: SystemTime,
 }
 
 /// Immutable point-in-time process activity view.
 #[derive(Debug, Clone)]
 pub struct ProcessActivitySnapshot {
-    pub generated_at: SystemTime,
     pub processes: Vec<ProcessActivity>,
     pub current_tx_bps: f64,
     pub current_rx_bps: f64,
@@ -145,7 +140,6 @@ pub struct ProcessActivitySnapshot {
 impl Default for ProcessActivitySnapshot {
     fn default() -> Self {
         Self {
-            generated_at: SystemTime::UNIX_EPOCH,
             processes: Vec::new(),
             current_tx_bps: 0.0,
             current_rx_bps: 0.0,
@@ -182,8 +176,6 @@ struct FlowActivity {
     bytes_received: u64,
     remote_addr: SocketAddr,
     remote_label: Option<String>,
-    created_at: SystemTime,
-    last_activity: SystemTime,
 }
 
 impl FlowActivity {
@@ -194,8 +186,6 @@ impl FlowActivity {
             bytes_received: conn.bytes_received,
             remote_addr: conn.remote_addr,
             remote_label: destination_label(conn),
-            created_at: conn.created_at,
-            last_activity: conn.last_activity,
         }
     }
 }
@@ -249,20 +239,16 @@ struct ProcessAccumulator {
     active_connections: usize,
     completed_connections: u64,
     destinations: HashMap<SocketAddr, DestinationActivity>,
-    first_seen: SystemTime,
-    last_seen: SystemTime,
 }
 
 impl ProcessAccumulator {
-    fn new(first_seen: SystemTime) -> Self {
+    fn new() -> Self {
         Self {
             tx_bytes: 0,
             rx_bytes: 0,
             active_connections: 0,
             completed_connections: 0,
             destinations: HashMap::new(),
-            first_seen,
-            last_seen: first_seen,
         }
     }
 
@@ -274,8 +260,6 @@ impl ProcessAccumulator {
         } else {
             self.active_connections = self.active_connections.saturating_add(1);
         }
-        self.first_seen = self.first_seen.min(flow.created_at);
-        self.last_seen = self.last_seen.max(flow.last_activity);
         self.add_destination(flow);
     }
 
@@ -522,7 +506,7 @@ impl ProcessActivityTracker {
                 let identity = flow.identity.clone();
                 sample
                     .entry(identity.clone())
-                    .or_insert_with(|| ProcessAccumulator::new(flow.created_at))
+                    .or_insert_with(ProcessAccumulator::new)
                     .add_flow(&flow, false);
                 traffic_deltas
                     .entry(identity)
@@ -562,7 +546,7 @@ impl ProcessActivityTracker {
                 };
                 sample
                     .entry(identity.clone())
-                    .or_insert_with(|| ProcessAccumulator::new(flow.created_at))
+                    .or_insert_with(ProcessAccumulator::new)
                     .add_flow(&flow, true);
                 traffic_deltas
                     .entry(identity)
@@ -658,14 +642,10 @@ impl ProcessActivityTracker {
                     > self.config.max_destinations_per_process,
                 top_tx_destination,
                 top_rx_destination,
-                current_tx_share: 0.0,
-                current_rx_share: 0.0,
                 window_tx_share: 0.0,
                 window_rx_share: 0.0,
                 retained_tx_share: 0.0,
                 retained_rx_share: 0.0,
-                first_seen: aggregate.first_seen,
-                last_seen: aggregate.last_seen,
             });
         }
 
@@ -687,8 +667,6 @@ impl ProcessActivityTracker {
             .sum();
 
         for process in &mut processes {
-            process.current_tx_share = percentage(process.current_tx_bps, current_tx_bps);
-            process.current_rx_share = percentage(process.current_rx_bps, current_rx_bps);
             process.window_tx_share =
                 percentage(process.window_tx_bytes as f64, window_tx_bytes as f64);
             process.window_rx_share =
@@ -706,7 +684,6 @@ impl ProcessActivityTracker {
         });
 
         self.snapshot = ProcessActivitySnapshot {
-            generated_at: now,
             processes,
             current_tx_bps,
             current_rx_bps,

--- a/crates/rustnet-core/src/network/protocol/tcp.rs
+++ b/crates/rustnet-core/src/network/protocol/tcp.rs
@@ -10,20 +10,15 @@ use std::net::SocketAddr;
 const TCP_FIN: u8 = 0x01;
 const TCP_SYN: u8 = 0x02;
 const TCP_RST: u8 = 0x04;
-const TCP_PSH: u8 = 0x08;
 const TCP_ACK: u8 = 0x10;
-const TCP_URG: u8 = 0x20;
 
 /// TCP flags from the TCP header
-/// All flags are public fields as they represent the actual TCP flags
 #[derive(Debug, Clone, Copy)]
 pub struct TcpFlags {
     pub fin: bool,
     pub syn: bool,
     pub rst: bool,
-    pub psh: bool,
     pub ack: bool,
-    pub urg: bool,
 }
 
 /// TCP header information extracted from the packet
@@ -42,9 +37,7 @@ pub fn parse_tcp_flags(flags: u8) -> TcpFlags {
         fin: (flags & TCP_FIN) != 0,
         syn: (flags & TCP_SYN) != 0,
         rst: (flags & TCP_RST) != 0,
-        psh: (flags & TCP_PSH) != 0,
         ack: (flags & TCP_ACK) != 0,
-        urg: (flags & TCP_URG) != 0,
     }
 }
 
@@ -99,13 +92,11 @@ pub fn parse(
 
     // Log TCP flags for debugging
     log::trace!(
-        "TCP flags: FIN={} SYN={} RST={} PSH={} ACK={} URG={}",
+        "TCP flags: FIN={} SYN={} RST={} ACK={}",
         tcp_flags.fin,
         tcp_flags.syn,
         tcp_flags.rst,
-        tcp_flags.psh,
-        tcp_flags.ack,
-        tcp_flags.urg
+        tcp_flags.ack
     );
 
     // Determine direction based on local IPs

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -945,11 +945,6 @@ impl ConnectionTracker {
         self.neighbors.clear();
     }
 
-    /// The tracker's configuration.
-    pub fn config(&self) -> &TrackerConfig {
-        &self.config
-    }
-
     /// Direct access to the active connection table.
     ///
     /// Use this for in-place enrichment (e.g. attaching process, DNS, or GeoIP
@@ -1039,14 +1034,7 @@ mod tests {
                 seq: 1_000,
                 ack: 2_000,
                 window: 65_535,
-                flags: TcpFlags {
-                    syn,
-                    ack,
-                    fin,
-                    rst,
-                    psh: false,
-                    urg: false,
-                },
+                flags: TcpFlags { syn, ack, fin, rst },
                 payload_len: 0,
             },
         );

--- a/crates/rustnet-core/src/network/types/connection.rs
+++ b/crates/rustnet-core/src/network/types/connection.rs
@@ -320,12 +320,6 @@ impl Connection {
         }
     }
 
-    /// Check whether this is a live connection that has not reached its
-    /// protocol-aware cleanup deadline.
-    pub fn is_active(&self) -> bool {
-        !self.is_historic && !self.should_cleanup(SystemTime::now())
-    }
-
     /// Get time since last activity
     pub fn idle_time(&self) -> Duration {
         self.last_activity.elapsed().unwrap_or_default()

--- a/crates/rustnet-core/src/network/types/graph.rs
+++ b/crates/rustnet-core/src/network/types/graph.rs
@@ -393,17 +393,6 @@ impl TrafficHistory {
             .collect()
     }
 
-    /// Get data for Chart widget: (time_offset, rate) pairs, smoothed with moving average
-    /// Time offset is negative seconds from now
-    pub fn get_chart_data(&self) -> (ChartData, ChartData) {
-        let now = Instant::now();
-        // Apply smoothing with window of 3
-        let window = 3;
-        let rx = self.windowed_series(now, window, |s| s.rx_bytes_per_sec as f64);
-        let tx = self.windowed_series(now, window, |s| s.tx_bytes_per_sec as f64);
-        (rx, tx)
-    }
-
     /// Get network health chart data: (packet_loss_pct, rtt_ms) as ChartData pairs
     /// Time offset is negative seconds from now
     pub fn get_health_chart_data(&self) -> (ChartData, ChartData) {

--- a/crates/rustnet-host/README.md
+++ b/crates/rustnet-host/README.md
@@ -46,11 +46,10 @@ if let Some(attribution) = lookup.get_process_attribution(&conn) {
 `MatchQuality` records how the connection was matched, so a relaxed
 wildcard/listener guess is never mistaken for a proven 4-tuple hit; use
 `quality.is_exact()` to tell them apart. Linux resolves PPID from procfs for
-both socket-table and eBPF matches. The eBPF backends also fill in the thread
-id, effective UID/GID, and an observation timestamp taken from a **monotonic**
-clock (`bpf_ktime_get_ns`), which is not wall-clock time. The executable path is
-resolved once from `/proc/<tgid>/exe`; an unreadable link yields
-`executable: None` and never fails the attribution.
+both socket-table and eBPF matches. The eBPF backends also fill in the
+effective UID/GID. The executable path is resolved once from
+`/proc/<tgid>/exe`; an unreadable link yields `executable: None` and never
+fails the attribution.
 
 Every platform also resolves up to four parent processes, ordered from the
 oldest retained ancestor to the direct parent. Each entry includes its PID,
@@ -76,9 +75,8 @@ When a platform can't use its optimal method, `ProcessLookup::get_degradation_re
 reports why (e.g. missing `CAP_BPF`, no root for PKTAP) via `DegradationReason`,
 which front-ends can surface to the user.
 
-Linux callers can inspect `ProcessLookup::get_attribution_backend()` and
-`ProcessLookup::get_attribution_capabilities()` to distinguish fentry/fexit,
-legacy kprobes, procfs, and partial protocol coverage.
+Linux callers can inspect `ProcessLookup::get_attribution_backend()` to
+distinguish fentry/fexit, legacy kprobes, and procfs.
 
 Both Linux BPF objects use CO-RE for safe socket field access and therefore
 require usable target BTF. A compatible target-BTF kernel tries fentry/fexit

--- a/crates/rustnet-host/src/lib.rs
+++ b/crates/rustnet-host/src/lib.rs
@@ -15,11 +15,11 @@
 //! - **FreeBSD**: `sockstat` enriched with native `sysctl` process metadata.
 //!
 //! [`ProcessLookup::get_process_attribution`] returns the richer
-//! [`ProcessAttribution`]: parent and thread ids, effective UID/GID, executable
-//! path, process lineage, the producing [`AttributionBackend`], a
-//! [`MatchQuality`] saying how the connection was matched, and a monotonic
-//! observation time. Platforms that only implement the tuple API are bridged
-//! automatically, so `get_process_for_connection` keeps working everywhere.
+//! [`ProcessAttribution`]: parent process id, effective UID/GID, executable
+//! path, process lineage, the producing [`AttributionBackend`], and a
+//! [`MatchQuality`] saying how the connection was matched. Platforms that only
+//! implement the tuple API are bridged automatically, so
+//! `get_process_for_connection` keeps working everywhere.
 //!
 //! When a platform can't use its optimal method, [`ProcessLookup::get_degradation_reason`]
 //! reports why via [`DegradationReason`] (e.g. missing `CAP_BPF`, no root for
@@ -73,7 +73,7 @@ impl std::fmt::Display for AttributionBackend {
 bitflags::bitflags! {
     /// Connection operations covered by the active Linux eBPF backend.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-    pub struct AttributionCapabilities: u32 {
+    pub(crate) struct AttributionCapabilities: u32 {
         const TCP_V4_CONNECT = 1 << 0;
         const TCP_V6_CONNECT = 1 << 1;
         const TCP_ACCEPT     = 1 << 2;
@@ -101,11 +101,9 @@ pub use rustnet_core::network::types::{
 /// A rich process-attribution result.
 ///
 /// Everything past `tgid`/`name` is best effort: a backend fills in what it
-/// actually observed and leaves the rest `None` rather than guessing. Only the
-/// Linux eBPF backends currently report thread ids and an observation
-/// timestamp. Every supported platform can report parent process ids,
-/// executable paths, and a capped parent chain. Linux, macOS, and FreeBSD can
-/// report credentials.
+/// actually observed and leaves the rest `None` rather than guessing. Every
+/// supported platform can report parent process ids, executable paths, and a
+/// capped parent chain. Linux, macOS, and FreeBSD can report credentials.
 ///
 /// Marked `#[non_exhaustive]` because cgroup and container fields are expected
 /// to land here later. Build values with [`ProcessAttribution::new`] plus the
@@ -117,10 +115,6 @@ pub struct ProcessAttribution {
     pub tgid: u32,
     /// Parent process id, resolved from the live process when available.
     pub ppid: Option<u32>,
-    /// Kernel thread id that performed the operation, when the backend sees
-    /// per-thread identity. `None` for socket-table backends, and equal to
-    /// `tgid` when the main thread did the work.
-    pub tid: Option<u32>,
     /// Process name: `/proc/<tgid>/comm` on Linux, the OS-reported name elsewhere.
     pub name: String,
     /// Effective user id of the owning process.
@@ -134,11 +128,6 @@ pub struct ProcessAttribution {
     pub backend: AttributionBackend,
     /// How the connection key matched the backend's records.
     pub quality: MatchQuality,
-    /// Observation time in nanoseconds on a **monotonic** clock
-    /// (`CLOCK_MONOTONIC` on Linux). This is not wall-clock time: it is only
-    /// meaningful relative to other monotonic readings from the same boot, and
-    /// must never be formatted as a date.
-    pub observed_at_ns: Option<u64>,
     /// Best-effort parent chain, ordered oldest retained ancestor first.
     pub lineage: Option<ProcessLineage>,
 }
@@ -154,14 +143,12 @@ impl ProcessAttribution {
         Self {
             tgid,
             ppid: None,
-            tid: None,
             name: name.into(),
             uid: None,
             gid: None,
             executable: None,
             backend,
             quality,
-            observed_at_ns: None,
             lineage: None,
         }
     }
@@ -169,12 +156,6 @@ impl ProcessAttribution {
     /// Attach the parent process id.
     pub fn with_parent_pid(mut self, ppid: u32) -> Self {
         self.ppid = Some(ppid);
-        self
-    }
-
-    /// Attach the kernel thread id that performed the operation.
-    pub fn with_tid(mut self, tid: u32) -> Self {
-        self.tid = Some(tid);
         self
     }
 
@@ -189,12 +170,6 @@ impl ProcessAttribution {
     /// stored as such: failing to read the path never fails the attribution.
     pub fn with_executable(mut self, executable: Option<PathBuf>) -> Self {
         self.executable = executable;
-        self
-    }
-
-    /// Attach a **monotonic** observation timestamp in nanoseconds.
-    pub fn with_observed_at_ns(mut self, observed_at_ns: u64) -> Self {
-        self.observed_at_ns = Some(observed_at_ns);
         self
     }
 
@@ -225,11 +200,6 @@ impl ProcessAttribution {
         }
         self.lineage = lineage;
         self
-    }
-
-    /// Reduce to the legacy `(pid, process_name)` pair.
-    pub fn into_pid_name(self) -> (u32, String) {
-        (self.tgid, self.name)
     }
 }
 
@@ -369,12 +339,6 @@ pub fn parse_socket_addr_text(addr_str: &str) -> Option<SocketAddr> {
     Some(SocketAddr::new(ip, port))
 }
 
-impl From<ProcessAttribution> for (u32, String) {
-    fn from(attribution: ProcessAttribution) -> Self {
-        attribution.into_pid_name()
-    }
-}
-
 /// Reasons why process detection may be degraded from optimal
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum DegradationReason {
@@ -391,9 +355,6 @@ pub enum DegradationReason {
     /// Missing both CAP_BPF and CAP_PERFMON
     #[cfg(target_os = "linux")]
     MissingBpfCapabilities,
-    /// eBPF feature not compiled in
-    #[cfg(all(target_os = "linux", not(feature = "ebpf")))]
-    EbpfFeatureDisabled,
     /// Kernel doesn't support required eBPF features (e.g. ENOSYS from bpf(2))
     #[cfg(target_os = "linux")]
     KernelUnsupported,
@@ -446,8 +407,6 @@ impl DegradationReason {
             Self::MissingCapPerfmon => Cow::Borrowed("needs CAP_PERFMON"),
             #[cfg(target_os = "linux")]
             Self::MissingBpfCapabilities => Cow::Borrowed("needs CAP_BPF+CAP_PERFMON"),
-            #[cfg(all(target_os = "linux", not(feature = "ebpf")))]
-            Self::EbpfFeatureDisabled => Cow::Borrowed("eBPF feature disabled"),
             #[cfg(target_os = "linux")]
             Self::KernelUnsupported => Cow::Borrowed("kernel unsupported"),
             #[cfg(target_os = "linux")]
@@ -497,8 +456,6 @@ impl DegradationReason {
             | Self::BtfUnavailable
             | Self::EbpfLoadFailed(_)
             | Self::BinaryOnNosuidMount => Some("eBPF"),
-            #[cfg(all(target_os = "linux", not(feature = "ebpf")))]
-            Self::EbpfFeatureDisabled => Some("eBPF"),
             #[cfg(target_os = "macos")]
             Self::MissingRootPrivileges
             | Self::NoBpfDeviceAccess
@@ -576,13 +533,6 @@ pub trait ProcessLookup: Send + Sync {
     /// Return the active attribution backend.
     fn get_attribution_backend(&self) -> AttributionBackend {
         AttributionBackend::PlatformNative
-    }
-
-    /// Return the connection operations covered by the active eBPF backend.
-    ///
-    /// Non-eBPF backends return an empty set.
-    fn get_attribution_capabilities(&self) -> AttributionCapabilities {
-        AttributionCapabilities::empty()
     }
 
     /// Fallback lookup that relaxes the connection key to handle sockets stored
@@ -736,25 +686,17 @@ mod tests {
             MatchQuality::ExactTuple,
         )
         .with_parent_pid(1)
-        .with_tid(43)
         .with_credentials(1000, 100)
-        .with_executable(Some(PathBuf::from("/usr/bin/curl")))
-        .with_observed_at_ns(9_000);
+        .with_executable(Some(PathBuf::from("/usr/bin/curl")));
 
         assert_eq!(attribution.ppid, Some(1));
-        assert_eq!(attribution.tid, Some(43));
         assert_eq!(attribution.uid, Some(1000));
         assert_eq!(attribution.gid, Some(100));
         assert_eq!(
             attribution.executable.as_deref(),
             Some(Path::new("/usr/bin/curl"))
         );
-        assert_eq!(attribution.observed_at_ns, Some(9_000));
         assert_eq!(attribution.lineage, None);
-
-        let (pid, name) = <(u32, String)>::from(attribution);
-        assert_eq!(pid, 42);
-        assert_eq!(name, "curl");
     }
 
     #[test]
@@ -768,11 +710,9 @@ mod tests {
         .with_executable(None);
 
         assert_eq!(attribution.ppid, None);
-        assert_eq!(attribution.tid, None);
         assert_eq!(attribution.uid, None);
         assert_eq!(attribution.gid, None);
         assert_eq!(attribution.executable, None);
-        assert_eq!(attribution.observed_at_ns, None);
         assert_eq!(attribution.lineage, None);
     }
 
@@ -878,7 +818,6 @@ mod tests {
         // the exact 4-tuple was proven.
         assert_eq!(attribution.quality, MatchQuality::Unspecified);
         assert!(!attribution.quality.is_exact());
-        assert_eq!(attribution.tid, None);
         assert_eq!(attribution.executable, None);
     }
 

--- a/crates/rustnet-host/src/linux/ebpf/tracker_libbpf.rs
+++ b/crates/rustnet-host/src/linux/ebpf/tracker_libbpf.rs
@@ -303,13 +303,6 @@ impl LibbpfSocketTracker {
         }
     }
 
-    /// Check if the tracker is healthy and operational
-    pub fn is_healthy(&self) -> bool {
-        // Simple health check - in a real implementation you might
-        // check if programs are still attached, etc.
-        true
-    }
-
     /// Clean up stale entries from the eBPF map
     /// Returns the number of entries cleaned up
     pub fn cleanup_stale_entries(&mut self, stale_threshold_secs: u64) -> u32 {

--- a/crates/rustnet-host/src/linux/enhanced.rs
+++ b/crates/rustnet-host/src/linux/enhanced.rs
@@ -1,8 +1,7 @@
 //! Enhanced Linux process lookup combining eBPF and procfs approaches
 
 use crate::{
-    AttributionBackend, AttributionCapabilities, ConnectionKey, DegradationReason,
-    ProcessAttribution, ProcessLookup,
+    AttributionBackend, ConnectionKey, DegradationReason, ProcessAttribution, ProcessLookup,
 };
 
 use super::process::LinuxProcessLookup;
@@ -10,882 +9,479 @@ use anyhow::Result;
 use log::{debug, info, warn};
 use rustnet_core::network::types::{Connection, Protocol};
 use std::collections::HashMap;
-use std::net::IpAddr;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
-#[cfg(feature = "ebpf")]
 use super::ebpf::EbpfSocketTracker;
+use crate::linux::ebpf::SocketMatch;
+use crate::linux::process::{refine_truncated_name, resolve_executable, resolve_parent_pid};
+use rustnet_core::network::types::ProtocolState;
 
-// When eBPF is enabled, use the full enhanced implementation
-#[cfg(feature = "ebpf")]
-mod ebpf_enhanced {
-    use super::*;
-    use crate::linux::ebpf::SocketMatch;
-    use crate::linux::process::{refine_truncated_name, resolve_executable, resolve_parent_pid};
-    use rustnet_core::network::types::ProtocolState;
+/// Enhanced process lookup that combines eBPF (fast path) with procfs (fallback)
+pub struct EnhancedLinuxProcessLookup {
+    ebpf_tracker: RwLock<Option<Box<EbpfSocketTracker>>>,
+    procfs_lookup: LinuxProcessLookup,
+    unified_cache: RwLock<ProcessCache>,
+    cleanup_config: CleanupConfig,
+    last_cleanup: RwLock<Instant>,
+    degradation_reason: DegradationReason,
+}
 
-    /// Enhanced process lookup that combines eBPF (fast path) with procfs (fallback)
-    pub struct EnhancedLinuxProcessLookup {
-        ebpf_tracker: RwLock<Option<Box<EbpfSocketTracker>>>,
-        procfs_lookup: LinuxProcessLookup,
-        unified_cache: RwLock<ProcessCache>,
-        stats: RwLock<LookupStats>,
-        cleanup_config: CleanupConfig,
-        last_cleanup: RwLock<Instant>,
-        degradation_reason: DegradationReason,
+pub struct ProcessCache {
+    // Full attributions, not just (pid, name): caching the tuple would drop
+    // the credentials, executable path, and match quality on the first hit
+    // and silently downgrade every subsequent lookup.
+    lookup: HashMap<ConnectionKey, ProcessAttribution>,
+    last_refresh: Instant,
+}
+
+#[derive(Debug, Clone)]
+pub struct CleanupConfig {
+    pub cleanup_interval_secs: u64,
+    pub stale_threshold_secs: u64,
+}
+
+impl Default for CleanupConfig {
+    fn default() -> Self {
+        Self {
+            cleanup_interval_secs: 30,
+            stale_threshold_secs: 60,
+        }
     }
+}
 
-    pub struct ProcessCache {
-        // Full attributions, not just (pid, name): caching the tuple would drop
-        // the credentials, thread id, executable path, and match quality on the
-        // first hit and silently downgrade every subsequent lookup.
-        lookup: HashMap<ConnectionKey, ProcessAttribution>,
-        last_refresh: Instant,
-    }
+impl EnhancedLinuxProcessLookup {
+    pub fn new() -> Result<Self> {
+        let cleanup_config = CleanupConfig::default();
+        let procfs_lookup = LinuxProcessLookup::new()?;
 
-    #[derive(Debug, Clone)]
-    pub struct CleanupConfig {
-        pub cleanup_interval_secs: u64,
-        pub stale_threshold_secs: u64,
-    }
-
-    impl Default for CleanupConfig {
-        fn default() -> Self {
-            Self {
-                cleanup_interval_secs: 30,
-                stale_threshold_secs: 60,
+        let (ebpf_tracker, degradation_reason) = match EbpfSocketTracker::new() {
+            Ok((tracker_opt, reason)) => {
+                if tracker_opt.is_some() {
+                    info!("eBPF socket tracker initialized successfully");
+                } else {
+                    info!(
+                        "eBPF not available ({}), using procfs only",
+                        reason.description()
+                    );
+                }
+                (tracker_opt.map(Box::new), reason)
             }
-        }
+            Err(e) => {
+                warn!(
+                    "Failed to initialize eBPF tracker: {}, falling back to procfs",
+                    e
+                );
+                (None, DegradationReason::EbpfLoadFailed(e.to_string()))
+            }
+        };
+
+        Ok(Self {
+            ebpf_tracker: RwLock::new(ebpf_tracker),
+            procfs_lookup,
+            unified_cache: RwLock::new(ProcessCache {
+                lookup: HashMap::new(),
+                last_refresh: Instant::now() - Duration::from_secs(3600),
+            }),
+            cleanup_config,
+            last_cleanup: RwLock::new(Instant::now() - Duration::from_secs(3600)),
+            degradation_reason,
+        })
     }
 
-    #[derive(Debug, Default)]
-    pub struct LookupStats {
-        ebpf_hits: u64,
-        procfs_hits: u64,
-        cache_hits: u64,
-        total_lookups: u64,
-        ipv4_lookups: u64,
-        ipv6_lookups: u64,
-        tcp_lookups: u64,
-        udp_lookups: u64,
-        cache_entries: u64,
-        failed_lookups: u64,
-        ebpf_available: bool,
-    }
-
-    impl EnhancedLinuxProcessLookup {
-        pub fn new() -> Result<Self> {
-            Self::new_with_config(CleanupConfig::default())
-        }
-
-        pub fn new_with_config(cleanup_config: CleanupConfig) -> Result<Self> {
-            let procfs_lookup = LinuxProcessLookup::new()?;
-
-            let (ebpf_tracker, degradation_reason) = match EbpfSocketTracker::new() {
-                Ok((tracker_opt, reason)) => {
-                    if tracker_opt.is_some() {
-                        info!("eBPF socket tracker initialized successfully");
-                    } else {
-                        info!(
-                            "eBPF not available ({}), using procfs only",
-                            reason.description()
-                        );
+    /// Try eBPF lookup first, fall back to procfs
+    fn lookup_process_enhanced(&self, conn: &Connection) -> Option<ProcessAttribution> {
+        // Try eBPF first for TCP/UDP/ICMP connections
+        match conn.protocol {
+            Protocol::Tcp | Protocol::Udp => {
+                debug!(
+                    "Enhanced lookup: Trying eBPF for {}:{} -> {}:{} ({})",
+                    conn.local_addr.ip(),
+                    conn.local_addr.port(),
+                    conn.remote_addr.ip(),
+                    conn.remote_addr.port(),
+                    match conn.protocol {
+                        Protocol::Tcp => "TCP",
+                        Protocol::Udp => "UDP",
+                        _ => "Unknown",
                     }
-                    (tracker_opt.map(Box::new), reason)
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to initialize eBPF tracker: {}, falling back to procfs",
-                        e
-                    );
-                    (None, DegradationReason::EbpfLoadFailed(e.to_string()))
-                }
-            };
+                );
 
-            Ok(Self {
-                ebpf_tracker: RwLock::new(ebpf_tracker),
-                procfs_lookup,
-                unified_cache: RwLock::new(ProcessCache {
-                    lookup: HashMap::new(),
-                    last_refresh: Instant::now() - Duration::from_secs(3600),
-                }),
-                stats: RwLock::new(LookupStats::default()),
-                cleanup_config,
-                last_cleanup: RwLock::new(Instant::now() - Duration::from_secs(3600)),
-                degradation_reason,
-            })
-        }
-
-        /// Try eBPF lookup first, fall back to procfs
-        fn lookup_process_enhanced(&self, conn: &Connection) -> Option<ProcessAttribution> {
-            // Try eBPF first for TCP/UDP/ICMP connections
-            match conn.protocol {
-                Protocol::Tcp | Protocol::Udp => {
+                if let Some(result) = self.try_ebpf_lookup(conn) {
                     debug!(
-                        "Enhanced lookup: Trying eBPF for {}:{} -> {}:{} ({})",
+                        "Enhanced lookup: eBPF hit for PID {} ({}, {} match)",
+                        result.tgid, result.name, result.quality
+                    );
+                    return Some(result);
+                } else {
+                    debug!("Enhanced lookup: eBPF miss, falling back to procfs");
+                }
+            }
+            Protocol::Icmp => {
+                // Try eBPF lookup for ICMP using the echo ID
+                if let ProtocolState::Icmp {
+                    icmp_id: Some(id), ..
+                } = &conn.protocol_state
+                {
+                    debug!(
+                        "Enhanced lookup: Trying eBPF for ICMP {} -> {} (ID: {})",
                         conn.local_addr.ip(),
-                        conn.local_addr.port(),
                         conn.remote_addr.ip(),
-                        conn.remote_addr.port(),
-                        match conn.protocol {
-                            Protocol::Tcp => "TCP",
-                            Protocol::Udp => "UDP",
-                            _ => "Unknown",
-                        }
+                        id
                     );
 
-                    if let Some(result) = self.try_ebpf_lookup(conn) {
-                        let mut stats = self.stats.write().expect("stats lock poisoned");
-                        stats.ebpf_hits += 1;
+                    if let Some(result) = self.try_ebpf_icmp_lookup(conn, *id) {
                         debug!(
-                            "Enhanced lookup: eBPF hit for PID {} ({}, {} match)",
+                            "Enhanced lookup: eBPF ICMP hit for PID {} ({}, {} match)",
                             result.tgid, result.name, result.quality
                         );
                         return Some(result);
                     } else {
-                        debug!("Enhanced lookup: eBPF miss, falling back to procfs");
+                        debug!("Enhanced lookup: eBPF ICMP miss");
                     }
                 }
-                Protocol::Icmp => {
-                    // Try eBPF lookup for ICMP using the echo ID
-                    if let ProtocolState::Icmp {
-                        icmp_id: Some(id), ..
-                    } = &conn.protocol_state
-                    {
-                        debug!(
-                            "Enhanced lookup: Trying eBPF for ICMP {} -> {} (ID: {})",
-                            conn.local_addr.ip(),
-                            conn.remote_addr.ip(),
-                            id
-                        );
+            }
+            _ => {}
+        }
 
-                        if let Some(result) = self.try_ebpf_icmp_lookup(conn, *id) {
-                            let mut stats = self.stats.write().expect("stats lock poisoned");
-                            stats.ebpf_hits += 1;
-                            debug!(
-                                "Enhanced lookup: eBPF ICMP hit for PID {} ({}, {} match)",
-                                result.tgid, result.name, result.quality
-                            );
-                            return Some(result);
-                        } else {
-                            debug!("Enhanced lookup: eBPF ICMP miss");
-                        }
-                    }
+        // Fall back to procfs approach
+        self.procfs_lookup.get_process_attribution(conn)
+    }
+
+    /// Turn a socket-map hit into a rich attribution.
+    ///
+    /// The TGID, credentials, and match quality the kernel recorded are
+    /// carried through unchanged. The process name, parent PID, and
+    /// executable path are resolved in user space.
+    fn attribution_from_ebpf(
+        &self,
+        matched: SocketMatch,
+        backend: AttributionBackend,
+    ) -> ProcessAttribution {
+        let SocketMatch { info, quality } = matched;
+
+        // eBPF captures the group leader's short comm at socket creation.
+        // /proc/<tgid>/comm is the current main-process name and wins when
+        // the process is still alive. Short-lived tools (curl, dig) have
+        // already exited by the time we look, so the eBPF comm is the
+        // fallback rather than the other way round.
+        let name = self
+            .procfs_lookup
+            .get_process_name_by_pid(info.pid)
+            .unwrap_or_else(|| info.comm.clone());
+
+        // Resolve the executable now, while the process is most likely
+        // still around. Failure is not an attribution failure. A
+        // comm-truncated name is recovered from the executable's file name.
+        let executable = resolve_executable(info.pid);
+        let name = refine_truncated_name(name, executable.as_deref());
+        let ppid = resolve_parent_pid(info.pid);
+
+        debug!(
+            "eBPF attribution: TGID {}, PPID {:?}, TID {}, UID {}, GID {}, eBPF comm {}, resolved {}, exe {:?}, {} match, observed {}ns (monotonic)",
+            info.pid,
+            ppid,
+            info.tid,
+            info.uid,
+            info.gid,
+            info.comm,
+            name,
+            executable,
+            quality,
+            info.timestamp
+        );
+
+        let mut attribution = ProcessAttribution::new(info.pid, name, backend, quality)
+            .with_credentials(info.uid, info.gid)
+            .with_executable(executable);
+        if let Some(ppid) = ppid {
+            attribution = attribution
+                .with_parent_pid(ppid)
+                .with_lineage(self.procfs_lookup.lineage_for(info.pid, ppid));
+        }
+        attribution
+    }
+
+    fn try_ebpf_lookup(&self, conn: &Connection) -> Option<ProcessAttribution> {
+        // Scoped so the tracker write lock is released before
+        // attribution_from_ebpf touches /proc. Note `backend()` is read
+        // here rather than via get_attribution_backend(), which would take
+        // the same non-reentrant lock again.
+        let (matched, backend) = {
+            let mut tracker_guard = self
+                .ebpf_tracker
+                .write()
+                .expect("ebpf_tracker lock poisoned");
+            let tracker = match tracker_guard.as_mut() {
+                Some(t) => {
+                    debug!("eBPF lookup: Tracker available, performing lookup");
+                    t
                 }
-                _ => {}
-            }
+                None => {
+                    debug!("eBPF lookup: No tracker available");
+                    return None;
+                }
+            };
 
-            // Fall back to procfs approach
-            if let Some(result) = self.procfs_lookup.get_process_attribution(conn) {
-                let mut stats = self.stats.write().expect("stats lock poisoned");
-                stats.procfs_hits += 1;
-                return Some(result);
-            }
+            let is_tcp = matches!(conn.protocol, Protocol::Tcp);
+            let backend = tracker.backend();
 
+            match tracker.lookup(
+                conn.local_addr.ip(),
+                conn.remote_addr.ip(),
+                conn.local_addr.port(),
+                conn.remote_addr.port(),
+                is_tcp,
+            ) {
+                Some(matched) => (matched, backend),
+                None => {
+                    debug!(
+                        "eBPF lookup missed for {}:{} -> {}:{}",
+                        conn.local_addr.ip(),
+                        conn.local_addr.port(),
+                        conn.remote_addr.ip(),
+                        conn.remote_addr.port()
+                    );
+                    return None;
+                }
+            }
+        };
+
+        Some(self.attribution_from_ebpf(matched, backend))
+    }
+
+    fn try_ebpf_icmp_lookup(&self, conn: &Connection, icmp_id: u16) -> Option<ProcessAttribution> {
+        let (matched, backend) = {
+            let mut tracker_guard = self
+                .ebpf_tracker
+                .write()
+                .expect("ebpf_tracker lock poisoned");
+            let tracker = tracker_guard.as_mut()?;
+            let backend = tracker.backend();
+
+            match tracker.lookup_icmp(conn.local_addr.ip(), conn.remote_addr.ip(), icmp_id) {
+                Some(matched) => (matched, backend),
+                None => {
+                    debug!(
+                        "eBPF ICMP lookup missed for {} -> {} (ID: {})",
+                        conn.local_addr.ip(),
+                        conn.remote_addr.ip(),
+                        icmp_id
+                    );
+                    return None;
+                }
+            }
+        };
+
+        Some(self.attribution_from_ebpf(matched, backend))
+    }
+
+    /// Seed the unified cache with a ready-made attribution and mark it
+    /// fresh, so cache-preservation behaviour can be tested without a
+    /// loaded eBPF backend.
+    #[cfg(test)]
+    fn seed_cache(&self, key: ConnectionKey, attribution: ProcessAttribution) {
+        let mut cache = self
+            .unified_cache
+            .write()
+            .expect("unified_cache lock poisoned");
+        cache.last_refresh = Instant::now();
+        cache.lookup.insert(key, attribution);
+    }
+
+    /// Perform periodic cleanup of stale eBPF map entries
+    fn maybe_cleanup_ebpf_map(&self) {
+        let now = Instant::now();
+        let mut last_cleanup = self
+            .last_cleanup
+            .write()
+            .expect("last_cleanup lock poisoned");
+
+        if now.duration_since(*last_cleanup).as_secs() >= self.cleanup_config.cleanup_interval_secs
+        {
+            *last_cleanup = now;
+            drop(last_cleanup);
+
+            // Perform cleanup
+            if let Some(tracker) = self
+                .ebpf_tracker
+                .write()
+                .expect("ebpf_tracker lock poisoned")
+                .as_mut()
+            {
+                let cleaned =
+                    tracker.cleanup_stale_entries(self.cleanup_config.stale_threshold_secs);
+                if cleaned > 0 {
+                    debug!("eBPF map cleanup: removed {} stale entries", cleaned);
+                }
+            }
+        }
+    }
+}
+
+impl ProcessLookup for EnhancedLinuxProcessLookup {
+    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
+        // Safe because get_process_attribution is overridden below: this
+        // does not fall through to the trait's default bridge.
+        self.get_process_attribution(conn)
+            .map(|attribution| (attribution.tgid, attribution.name))
+    }
+
+    fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
+        // Perform periodic cleanup of stale eBPF entries
+        self.maybe_cleanup_ebpf_map();
+
+        let key = ConnectionKey::from_connection(conn);
+
+        // Try cache first
+        {
+            let cache = self
+                .unified_cache
+                .read()
+                .expect("unified_cache lock poisoned");
+            if cache.last_refresh.elapsed() < Duration::from_secs(2)
+                && let Some(attribution) = cache.lookup.get(&key)
+            {
+                // Returned verbatim, match quality included: a cached
+                // relaxed match stays a relaxed match.
+                return Some(attribution.clone());
+            }
+        }
+
+        // Cache miss or stale - do enhanced lookup
+        if let Some(result) = self.lookup_process_enhanced(conn) {
+            // Update cache with the result
+            let mut cache = self
+                .unified_cache
+                .write()
+                .expect("unified_cache lock poisoned");
+            cache.lookup.insert(key, result.clone());
+            Some(result)
+        } else {
             None
         }
+    }
 
-        /// Turn a socket-map hit into a rich attribution.
-        ///
-        /// Everything the kernel recorded is carried through unchanged: TGID,
-        /// TID, credentials, and the monotonic observation timestamp. The
-        /// process name, parent PID, and executable path are resolved in user
-        /// space.
-        fn attribution_from_ebpf(
-            &self,
-            matched: SocketMatch,
-            backend: AttributionBackend,
-        ) -> ProcessAttribution {
-            let SocketMatch { info, quality } = matched;
+    fn refresh(&self) -> Result<()> {
+        // Refresh the procfs lookup
+        self.procfs_lookup.refresh()?;
 
-            // eBPF captures the group leader's short comm at socket creation.
-            // /proc/<tgid>/comm is the current main-process name and wins when
-            // the process is still alive. Short-lived tools (curl, dig) have
-            // already exited by the time we look, so the eBPF comm is the
-            // fallback rather than the other way round.
-            let name = self
-                .procfs_lookup
-                .get_process_name_by_pid(info.pid)
-                .unwrap_or_else(|| info.comm.clone());
-
-            // Resolve the executable now, while the process is most likely
-            // still around. Failure is not an attribution failure. A
-            // comm-truncated name is recovered from the executable's file name.
-            let executable = resolve_executable(info.pid);
-            let name = refine_truncated_name(name, executable.as_deref());
-            let ppid = resolve_parent_pid(info.pid);
-
-            debug!(
-                "eBPF attribution: TGID {}, PPID {:?}, TID {}, UID {}, GID {}, eBPF comm {}, resolved {}, exe {:?}, {} match, observed {}ns (monotonic)",
-                info.pid,
-                ppid,
-                info.tid,
-                info.uid,
-                info.gid,
-                info.comm,
-                name,
-                executable,
-                quality,
-                info.timestamp
-            );
-
-            let mut attribution = ProcessAttribution::new(info.pid, name, backend, quality)
-                .with_tid(info.tid)
-                .with_credentials(info.uid, info.gid)
-                .with_executable(executable)
-                .with_observed_at_ns(info.timestamp);
-            if let Some(ppid) = ppid {
-                attribution = attribution
-                    .with_parent_pid(ppid)
-                    .with_lineage(self.procfs_lookup.lineage_for(info.pid, ppid));
-            }
-            attribution
-        }
-
-        fn try_ebpf_lookup(&self, conn: &Connection) -> Option<ProcessAttribution> {
-            // Scoped so the tracker write lock is released before
-            // attribution_from_ebpf touches /proc. Note `backend()` is read
-            // here rather than via get_attribution_backend(), which would take
-            // the same non-reentrant lock again.
-            let (matched, backend) = {
-                let mut tracker_guard = self
-                    .ebpf_tracker
-                    .write()
-                    .expect("ebpf_tracker lock poisoned");
-                let tracker = match tracker_guard.as_mut() {
-                    Some(t) => {
-                        debug!("eBPF lookup: Tracker available, performing lookup");
-                        t
-                    }
-                    None => {
-                        debug!("eBPF lookup: No tracker available");
-                        return None;
-                    }
-                };
-
-                let is_tcp = matches!(conn.protocol, Protocol::Tcp);
-                let backend = tracker.backend();
-
-                match tracker.lookup(
-                    conn.local_addr.ip(),
-                    conn.remote_addr.ip(),
-                    conn.local_addr.port(),
-                    conn.remote_addr.port(),
-                    is_tcp,
-                ) {
-                    Some(matched) => (matched, backend),
-                    None => {
-                        debug!(
-                            "eBPF lookup missed for {}:{} -> {}:{}",
-                            conn.local_addr.ip(),
-                            conn.local_addr.port(),
-                            conn.remote_addr.ip(),
-                            conn.remote_addr.port()
-                        );
-                        return None;
-                    }
-                }
-            };
-
-            Some(self.attribution_from_ebpf(matched, backend))
-        }
-
-        fn try_ebpf_icmp_lookup(
-            &self,
-            conn: &Connection,
-            icmp_id: u16,
-        ) -> Option<ProcessAttribution> {
-            let (matched, backend) = {
-                let mut tracker_guard = self
-                    .ebpf_tracker
-                    .write()
-                    .expect("ebpf_tracker lock poisoned");
-                let tracker = tracker_guard.as_mut()?;
-                let backend = tracker.backend();
-
-                match tracker.lookup_icmp(conn.local_addr.ip(), conn.remote_addr.ip(), icmp_id) {
-                    Some(matched) => (matched, backend),
-                    None => {
-                        debug!(
-                            "eBPF ICMP lookup missed for {} -> {} (ID: {})",
-                            conn.local_addr.ip(),
-                            conn.remote_addr.ip(),
-                            icmp_id
-                        );
-                        return None;
-                    }
-                }
-            };
-
-            Some(self.attribution_from_ebpf(matched, backend))
-        }
-
-        /// Seed the unified cache with a ready-made attribution and mark it
-        /// fresh, so cache-preservation behaviour can be tested without a
-        /// loaded eBPF backend.
-        #[cfg(test)]
-        fn seed_cache(&self, key: ConnectionKey, attribution: ProcessAttribution) {
+        // Update our cache timestamp
+        {
             let mut cache = self
                 .unified_cache
                 .write()
                 .expect("unified_cache lock poisoned");
             cache.last_refresh = Instant::now();
-            cache.lookup.insert(key, attribution);
+            // Optionally clear cache to force fresh lookups
+            cache.lookup.clear();
         }
 
-        /// Check if eBPF is available and functioning
-        pub fn is_ebpf_available(&self) -> bool {
-            self.ebpf_tracker
-                .read()
-                .expect("ebpf_tracker lock poisoned")
-                .as_ref()
-                .map(|t| t.is_healthy())
-                .unwrap_or(false)
-        }
+        debug!("Enhanced process lookup refreshed");
+        Ok(())
+    }
 
-        /// Perform periodic cleanup of stale eBPF map entries
-        fn maybe_cleanup_ebpf_map(&self) {
-            let now = Instant::now();
-            let mut last_cleanup = self
-                .last_cleanup
-                .write()
-                .expect("last_cleanup lock poisoned");
-
-            if now.duration_since(*last_cleanup).as_secs()
-                >= self.cleanup_config.cleanup_interval_secs
-            {
-                *last_cleanup = now;
-                drop(last_cleanup);
-
-                // Perform cleanup
-                if let Some(tracker) = self
-                    .ebpf_tracker
-                    .write()
-                    .expect("ebpf_tracker lock poisoned")
-                    .as_mut()
-                {
-                    let cleaned =
-                        tracker.cleanup_stale_entries(self.cleanup_config.stale_threshold_secs);
-                    if cleaned > 0 {
-                        debug!("eBPF map cleanup: removed {} stale entries", cleaned);
-                    }
-                }
-            }
+    fn get_detection_method(&self) -> &str {
+        match self.get_attribution_backend() {
+            AttributionBackend::EbpfFentry => "eBPF fentry/fexit + procfs",
+            AttributionBackend::EbpfKprobe => "eBPF kprobe + procfs",
+            _ => "procfs",
         }
     }
 
-    impl ProcessLookup for EnhancedLinuxProcessLookup {
-        fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
-            // Safe because get_process_attribution is overridden below: this
-            // does not fall through to the trait's default bridge.
-            self.get_process_attribution(conn).map(Into::into)
-        }
-
-        fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
-            // Perform periodic cleanup of stale eBPF entries
-            self.maybe_cleanup_ebpf_map();
-
-            let key = ConnectionKey::from_connection(conn);
-
-            // Update protocol statistics
-            {
-                let mut stats = self.stats.write().expect("stats lock poisoned");
-                stats.total_lookups += 1;
-
-                // Track IP version
-                match conn.local_addr.ip() {
-                    IpAddr::V4(_) => stats.ipv4_lookups += 1,
-                    IpAddr::V6(_) => stats.ipv6_lookups += 1,
-                }
-
-                // Track protocol type
-                match conn.protocol {
-                    Protocol::Tcp => stats.tcp_lookups += 1,
-                    Protocol::Udp => stats.udp_lookups += 1,
-                    _ => {}
-                }
-
-                // Update eBPF availability status
-                stats.ebpf_available = self.is_ebpf_available();
-            }
-
-            // Try cache first
-            {
-                let cache = self
-                    .unified_cache
-                    .read()
-                    .expect("unified_cache lock poisoned");
-                if cache.last_refresh.elapsed() < Duration::from_secs(2)
-                    && let Some(attribution) = cache.lookup.get(&key)
-                {
-                    let mut stats = self.stats.write().expect("stats lock poisoned");
-                    stats.cache_hits += 1;
-                    // Returned verbatim, match quality included: a cached
-                    // relaxed match stays a relaxed match.
-                    return Some(attribution.clone());
-                }
-            }
-
-            // Cache miss or stale - do enhanced lookup
-            if let Some(result) = self.lookup_process_enhanced(conn) {
-                // Update cache with the result
-                {
-                    let mut cache = self
-                        .unified_cache
-                        .write()
-                        .expect("unified_cache lock poisoned");
-                    cache.lookup.insert(key, result.clone());
-
-                    let mut stats = self.stats.write().expect("stats lock poisoned");
-                    stats.cache_entries = cache.lookup.len() as u64;
-                }
-                Some(result)
-            } else {
-                // Track failed lookups
-                let mut stats = self.stats.write().expect("stats lock poisoned");
-                stats.failed_lookups += 1;
-                None
-            }
-        }
-
-        fn refresh(&self) -> Result<()> {
-            // Refresh the procfs lookup
-            self.procfs_lookup.refresh()?;
-
-            // Update our cache timestamp
-            {
-                let mut cache = self
-                    .unified_cache
-                    .write()
-                    .expect("unified_cache lock poisoned");
-                cache.last_refresh = Instant::now();
-                // Optionally clear cache to force fresh lookups
-                cache.lookup.clear();
-            }
-
-            debug!("Enhanced process lookup refreshed");
-            Ok(())
-        }
-
-        fn get_detection_method(&self) -> &str {
-            match self.get_attribution_backend() {
-                AttributionBackend::EbpfFentry => "eBPF fentry/fexit + procfs",
-                AttributionBackend::EbpfKprobe => "eBPF kprobe + procfs",
-                _ => "procfs",
-            }
-        }
-
-        fn get_degradation_reason(&self) -> DegradationReason {
-            self.degradation_reason.clone()
-        }
-
-        fn get_attribution_backend(&self) -> AttributionBackend {
-            self.ebpf_tracker
-                .read()
-                .expect("ebpf_tracker lock poisoned")
-                .as_ref()
-                .map(|tracker| tracker.backend())
-                .unwrap_or(AttributionBackend::Procfs)
-        }
-
-        fn get_attribution_capabilities(&self) -> AttributionCapabilities {
-            self.ebpf_tracker
-                .read()
-                .expect("ebpf_tracker lock poisoned")
-                .as_ref()
-                .map(|tracker| tracker.capabilities())
-                .unwrap_or_default()
-        }
+    fn get_degradation_reason(&self) -> DegradationReason {
+        self.degradation_reason.clone()
     }
 
-    impl Clone for LookupStats {
-        fn clone(&self) -> Self {
-            Self {
-                ebpf_hits: self.ebpf_hits,
-                procfs_hits: self.procfs_hits,
-                cache_hits: self.cache_hits,
-                total_lookups: self.total_lookups,
-                ipv4_lookups: self.ipv4_lookups,
-                ipv6_lookups: self.ipv6_lookups,
-                tcp_lookups: self.tcp_lookups,
-                udp_lookups: self.udp_lookups,
-                cache_entries: self.cache_entries,
-                failed_lookups: self.failed_lookups,
-                ebpf_available: self.ebpf_available,
-            }
-        }
-    }
-
-    impl std::fmt::Display for LookupStats {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            if self.total_lookups == 0 {
-                write!(f, "No lookups performed yet")
-            } else {
-                let cache_hit_rate = (self.cache_hits as f64 / self.total_lookups as f64) * 100.0;
-                let ebpf_rate = (self.ebpf_hits as f64 / self.total_lookups as f64) * 100.0;
-                let procfs_rate = (self.procfs_hits as f64 / self.total_lookups as f64) * 100.0;
-                let success_rate = ((self.total_lookups - self.failed_lookups) as f64
-                    / self.total_lookups as f64)
-                    * 100.0;
-
-                writeln!(f, "Process Lookup Statistics:")?;
-                writeln!(
-                    f,
-                    "  Total lookups: {} (success: {:.1}%)",
-                    self.total_lookups, success_rate
-                )?;
-                writeln!(
-                    f,
-                    "  Cache: {} hits ({:.1}%)",
-                    self.cache_hits, cache_hit_rate
-                )?;
-                writeln!(
-                    f,
-                    "  eBPF: {} lookups ({:.1}%) | Available: {}",
-                    self.ebpf_hits, ebpf_rate, self.ebpf_available
-                )?;
-                writeln!(
-                    f,
-                    "  procfs: {} lookups ({:.1}%)",
-                    self.procfs_hits, procfs_rate
-                )?;
-                writeln!(
-                    f,
-                    "  Protocols - IPv4: {} | IPv6: {}",
-                    self.ipv4_lookups, self.ipv6_lookups
-                )?;
-                write!(
-                    f,
-                    "  Types - TCP: {} | UDP: {} | Cache entries: {}",
-                    self.tcp_lookups, self.udp_lookups, self.cache_entries
-                )
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use crate::MatchQuality;
-        use rustnet_core::network::types::{ProtocolState, TcpState};
-        use std::path::PathBuf;
-
-        fn connection(local: &str, remote: &str) -> Connection {
-            Connection::new(
-                Protocol::Tcp,
-                local.parse().unwrap(),
-                remote.parse().unwrap(),
-                ProtocolState::Tcp(TcpState::Established),
-            )
-        }
-
-        /// A result carrying everything only eBPF can observe, so a cache round
-        /// trip that drops any of it is visible.
-        fn ebpf_attribution() -> ProcessAttribution {
-            ProcessAttribution::new(
-                4242,
-                "curl",
-                AttributionBackend::EbpfFentry,
-                MatchQuality::WildcardLocalAddress,
-            )
-            .with_parent_pid(4000)
-            .with_tid(4299)
-            .with_credentials(1000, 100)
-            .with_executable(Some(PathBuf::from("/usr/bin/curl")))
-            .with_observed_at_ns(123_456_789)
-        }
-
-        #[test]
-        fn cached_results_keep_every_field_the_backend_reported() {
-            let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
-            let conn = connection("192.168.1.10:5000", "1.1.1.1:443");
-            let expected = ebpf_attribution();
-            lookup.seed_cache(ConnectionKey::from_connection(&conn), expected.clone());
-
-            let cached = lookup
-                .get_process_attribution(&conn)
-                .expect("seeded entry must be served from the cache");
-
-            // The whole struct, not just (pid, name): storing the tuple would
-            // silently drop the TID, credentials, executable, and timestamp.
-            assert_eq!(cached, expected);
-        }
-
-        #[test]
-        fn a_cached_relaxed_match_is_not_upgraded_to_exact() {
-            let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
-            let conn = connection("192.168.1.10:5001", "1.1.1.1:443");
-            lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
-
-            for _ in 0..3 {
-                let cached = lookup.get_process_attribution(&conn).unwrap();
-                assert_eq!(cached.quality, MatchQuality::WildcardLocalAddress);
-                assert!(!cached.quality.is_exact());
-            }
-        }
-
-        #[test]
-        fn the_tuple_api_serves_the_cached_attribution() {
-            let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
-            let conn = connection("192.168.1.10:5002", "1.1.1.1:443");
-            lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
-
-            assert_eq!(
-                lookup.get_process_for_connection(&conn),
-                Some((4242, "curl".to_string()))
-            );
-        }
-
-        #[test]
-        fn refresh_clears_the_cache() {
-            let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
-            let conn = connection("192.168.1.10:5003", "1.1.1.1:443");
-            lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
-            lookup.refresh().expect("refresh must succeed");
-
-            // The synthetic entry is gone; a real /proc scan cannot produce it.
-            assert!(lookup.get_process_attribution(&conn).is_none());
-        }
+    fn get_attribution_backend(&self) -> AttributionBackend {
+        self.ebpf_tracker
+            .read()
+            .expect("ebpf_tracker lock poisoned")
+            .as_ref()
+            .map(|tracker| tracker.backend())
+            .unwrap_or(AttributionBackend::Procfs)
     }
 }
 
-// When eBPF is disabled, use a simpler procfs-only implementation
-#[cfg(not(feature = "ebpf"))]
-mod procfs_only {
+#[cfg(test)]
+mod tests {
     use super::*;
+    use crate::MatchQuality;
+    use rustnet_core::network::types::{ProtocolState, TcpState};
+    use std::path::PathBuf;
 
-    /// Simplified process lookup using only procfs (no eBPF)
-    pub struct EnhancedLinuxProcessLookup {
-        procfs_lookup: LinuxProcessLookup,
-        unified_cache: RwLock<ProcessCache>,
-        stats: RwLock<LookupStats>,
+    fn connection(local: &str, remote: &str) -> Connection {
+        Connection::new(
+            Protocol::Tcp,
+            local.parse().unwrap(),
+            remote.parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Established),
+        )
     }
 
-    // Stub tracker for non-eBPF builds
-    pub struct EbpfSocketTracker;
-
-    impl EbpfSocketTracker {
-        pub fn new() -> anyhow::Result<Option<Self>> {
-            Ok(None)
-        }
-
-        pub fn cleanup_stale_entries(&mut self, _stale_threshold_secs: u64) -> u32 {
-            0
-        }
-
-        pub fn is_healthy(&self) -> bool {
-            false
-        }
+    /// A result carrying everything only eBPF can observe, so a cache round
+    /// trip that drops any of it is visible.
+    fn ebpf_attribution() -> ProcessAttribution {
+        ProcessAttribution::new(
+            4242,
+            "curl",
+            AttributionBackend::EbpfFentry,
+            MatchQuality::WildcardLocalAddress,
+        )
+        .with_parent_pid(4000)
+        .with_credentials(1000, 100)
+        .with_executable(Some(PathBuf::from("/usr/bin/curl")))
     }
 
-    pub struct ProcessCache {
-        lookup: HashMap<ConnectionKey, (u32, String)>,
-        last_refresh: Instant,
+    #[test]
+    fn cached_results_keep_every_field_the_backend_reported() {
+        let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
+        let conn = connection("192.168.1.10:5000", "1.1.1.1:443");
+        let expected = ebpf_attribution();
+        lookup.seed_cache(ConnectionKey::from_connection(&conn), expected.clone());
+
+        let cached = lookup
+            .get_process_attribution(&conn)
+            .expect("seeded entry must be served from the cache");
+
+        // The whole struct, not just (pid, name): storing the tuple would
+        // silently drop the credentials, executable, and match quality.
+        assert_eq!(cached, expected);
     }
 
-    #[derive(Debug, Default)]
-    pub struct LookupStats {
-        procfs_hits: u64,
-        cache_hits: u64,
-        total_lookups: u64,
-        ipv4_lookups: u64,
-        ipv6_lookups: u64,
-        tcp_lookups: u64,
-        udp_lookups: u64,
-        cache_entries: u64,
-        failed_lookups: u64,
-        ebpf_available: bool,
-    }
+    #[test]
+    fn a_cached_relaxed_match_is_not_upgraded_to_exact() {
+        let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
+        let conn = connection("192.168.1.10:5001", "1.1.1.1:443");
+        lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
 
-    impl EnhancedLinuxProcessLookup {
-        pub fn new() -> Result<Self> {
-            Self::new_with_config()
-        }
-
-        pub fn new_with_config() -> Result<Self> {
-            let procfs_lookup = LinuxProcessLookup::new()?;
-
-            Ok(Self {
-                procfs_lookup,
-                unified_cache: RwLock::new(ProcessCache {
-                    lookup: HashMap::new(),
-                    last_refresh: Instant::now() - Duration::from_secs(3600),
-                }),
-                stats: RwLock::new(LookupStats::default()),
-            })
-        }
-
-        /// Check if eBPF is available (always false when feature disabled)
-        pub fn is_ebpf_available(&self) -> bool {
-            false
+        for _ in 0..3 {
+            let cached = lookup.get_process_attribution(&conn).unwrap();
+            assert_eq!(cached.quality, MatchQuality::WildcardLocalAddress);
+            assert!(!cached.quality.is_exact());
         }
     }
 
-    impl ProcessLookup for EnhancedLinuxProcessLookup {
-        fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
-            let key = ConnectionKey::from_connection(conn);
+    #[test]
+    fn the_tuple_api_serves_the_cached_attribution() {
+        let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
+        let conn = connection("192.168.1.10:5002", "1.1.1.1:443");
+        lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
 
-            // Update protocol statistics
-            {
-                let mut stats = self.stats.write().expect("stats lock poisoned");
-                stats.total_lookups += 1;
-
-                // Track IP version
-                match conn.local_addr.ip() {
-                    IpAddr::V4(_) => stats.ipv4_lookups += 1,
-                    IpAddr::V6(_) => stats.ipv6_lookups += 1,
-                }
-
-                // Track protocol type
-                match conn.protocol {
-                    Protocol::Tcp => stats.tcp_lookups += 1,
-                    Protocol::Udp => stats.udp_lookups += 1,
-                    _ => {}
-                }
-
-                // eBPF is never available in this build
-                stats.ebpf_available = false;
-            }
-
-            // Try cache first
-            {
-                let cache = self
-                    .unified_cache
-                    .read()
-                    .expect("unified_cache lock poisoned");
-                if cache.last_refresh.elapsed() < Duration::from_secs(2)
-                    && let Some(process_info) = cache.lookup.get(&key)
-                {
-                    let mut stats = self.stats.write().expect("stats lock poisoned");
-                    stats.cache_hits += 1;
-                    return Some(process_info.clone());
-                }
-            }
-
-            // Cache miss or stale - use procfs lookup
-            if let Some(result) = self.procfs_lookup.get_process_for_connection(conn) {
-                // Update cache with the result
-                {
-                    let mut cache = self
-                        .unified_cache
-                        .write()
-                        .expect("unified_cache lock poisoned");
-                    cache.lookup.insert(key, result.clone());
-
-                    let mut stats = self.stats.write().expect("stats lock poisoned");
-                    stats.cache_entries = cache.lookup.len() as u64;
-                    stats.procfs_hits += 1;
-                }
-                Some(result)
-            } else {
-                // Track failed lookups
-                let mut stats = self.stats.write().expect("stats lock poisoned");
-                stats.failed_lookups += 1;
-                None
-            }
-        }
-
-        fn refresh(&self) -> Result<()> {
-            // Refresh the procfs lookup
-            self.procfs_lookup.refresh()?;
-
-            // Update our cache timestamp
-            {
-                let mut cache = self
-                    .unified_cache
-                    .write()
-                    .expect("unified_cache lock poisoned");
-                cache.last_refresh = Instant::now();
-                // Optionally clear cache to force fresh lookups
-                cache.lookup.clear();
-            }
-
-            debug!("Enhanced process lookup refreshed");
-            Ok(())
-        }
-
-        fn get_detection_method(&self) -> &str {
-            if self.is_ebpf_available() {
-                "eBPF + procfs"
-            } else {
-                "procfs"
-            }
-        }
-
-        fn get_degradation_reason(&self) -> DegradationReason {
-            // eBPF feature is disabled at compile time
-            DegradationReason::EbpfFeatureDisabled
-        }
-
-        fn get_attribution_backend(&self) -> AttributionBackend {
-            AttributionBackend::Procfs
-        }
+        assert_eq!(
+            lookup.get_process_for_connection(&conn),
+            Some((4242, "curl".to_string()))
+        );
     }
 
-    impl Clone for LookupStats {
-        fn clone(&self) -> Self {
-            Self {
-                procfs_hits: self.procfs_hits,
-                cache_hits: self.cache_hits,
-                total_lookups: self.total_lookups,
-                ipv4_lookups: self.ipv4_lookups,
-                ipv6_lookups: self.ipv6_lookups,
-                tcp_lookups: self.tcp_lookups,
-                udp_lookups: self.udp_lookups,
-                cache_entries: self.cache_entries,
-                failed_lookups: self.failed_lookups,
-                ebpf_available: self.ebpf_available,
-            }
-        }
-    }
+    #[test]
+    fn refresh_clears_the_cache() {
+        let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
+        let conn = connection("192.168.1.10:5003", "1.1.1.1:443");
+        lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
+        lookup.refresh().expect("refresh must succeed");
 
-    impl std::fmt::Display for LookupStats {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            if self.total_lookups == 0 {
-                write!(f, "No lookups performed yet")
-            } else {
-                let cache_hit_rate = (self.cache_hits as f64 / self.total_lookups as f64) * 100.0;
-                let procfs_rate = (self.procfs_hits as f64 / self.total_lookups as f64) * 100.0;
-                let success_rate = ((self.total_lookups - self.failed_lookups) as f64
-                    / self.total_lookups as f64)
-                    * 100.0;
-
-                writeln!(f, "Process Lookup Statistics:")?;
-                writeln!(
-                    f,
-                    "  Total lookups: {} (success: {:.1}%)",
-                    self.total_lookups, success_rate
-                )?;
-                writeln!(
-                    f,
-                    "  Cache: {} hits ({:.1}%)",
-                    self.cache_hits, cache_hit_rate
-                )?;
-                writeln!(f, "  eBPF: Not available (feature disabled)")?;
-                writeln!(
-                    f,
-                    "  procfs: {} lookups ({:.1}%)",
-                    self.procfs_hits, procfs_rate
-                )?;
-                writeln!(
-                    f,
-                    "  Protocols - IPv4: {} | IPv6: {}",
-                    self.ipv4_lookups, self.ipv6_lookups
-                )?;
-                write!(
-                    f,
-                    "  Types - TCP: {} | UDP: {} | Cache entries: {}",
-                    self.tcp_lookups, self.udp_lookups, self.cache_entries
-                )
-            }
-        }
+        // The synthetic entry is gone; a real /proc scan cannot produce it.
+        assert!(lookup.get_process_attribution(&conn).is_none());
     }
 }
-
-// Re-export the appropriate implementation based on feature flag
-#[cfg(feature = "ebpf")]
-pub use ebpf_enhanced::*;
-
-#[cfg(not(feature = "ebpf"))]
-pub use procfs_only::*;

--- a/crates/rustnet-host/src/linux/process.rs
+++ b/crates/rustnet-host/src/linux/process.rs
@@ -719,9 +719,6 @@ mod tests {
                 .map(|ancestor| ancestor.pid),
             attribution.ppid
         );
-        // procfs is a socket-table snapshot: no thread id, no observation time.
-        assert_eq!(attribution.tid, None);
-        assert_eq!(attribution.observed_at_ns, None);
     }
 
     #[test]

--- a/src/app/capture.rs
+++ b/src/app/capture.rs
@@ -768,8 +768,6 @@ mod connection_lifecycle_tests {
             rst,
             ack: false,
             fin: false,
-            psh: false,
-            urg: false,
         }
     }
 

--- a/src/app/pcapng_export.rs
+++ b/src/app/pcapng_export.rs
@@ -469,8 +469,6 @@ mod pcapng_export_tests {
                     ack: false,
                     fin: false,
                     rst: false,
-                    psh: false,
-                    urg: false,
                 },
                 payload_len: 0,
             }),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -898,7 +898,6 @@ mod activity_reset_tests {
             InterfaceTrafficWindow {
                 rx_bytes: 4_000,
                 tx_bytes: 2_000,
-                sampled_for: Duration::from_secs(30),
             },
         );
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1818,7 +1818,6 @@ mod snapshot_tests {
             InterfaceTrafficWindow {
                 rx_bytes: 4_194_304,
                 tx_bytes: 8_388_608,
-                sampled_for: Duration::from_secs(2),
             },
         );
         app

--- a/src/ui/tabs/activity.rs
+++ b/src/ui/tabs/activity.rs
@@ -808,7 +808,6 @@ fn draw_interface_pulse(f: &mut Frame, app: &App, direction: ActivityDirection, 
 mod tests {
     use super::*;
     use crate::network::process_activity::ProcessIdentity;
-    use std::time::SystemTime;
 
     fn activity(name: &str, tx: u64, rx: u64, connections: u64) -> ProcessActivity {
         ProcessActivity {
@@ -831,14 +830,10 @@ mod tests {
             destinations_truncated: false,
             top_tx_destination: None,
             top_rx_destination: None,
-            current_tx_share: 0.0,
-            current_rx_share: 0.0,
             window_tx_share: 0.0,
             window_rx_share: 0.0,
             retained_tx_share: 0.0,
             retained_rx_share: 0.0,
-            first_seen: SystemTime::UNIX_EPOCH,
-            last_seen: SystemTime::UNIX_EPOCH,
         }
     }
 


### PR DESCRIPTION
The published crates have no external consumers, so public API nothing in the workspace (binary, crates, example, tests, benches) uses is dead weight.

- rustnet-host: remove the procfs-only enhanced module (cfg-excluded in every build), the write-only LookupStats accumulator (also removes 11 lock writes from the lookup hot path), the uncalled get_attribution_capabilities trait method, the unconstructible EbpfFeatureDisabled variant, and the tid/observed_at_ns attribution fields no consumer reads.
- rustnet-core: remove unused Connection::is_active, TrafficHistory::get_chart_data, ConnectionTracker::config, is_tunnel_interface, the crate-root flat re-exports, and write-only fields (process-activity share/timestamp fields, InterfaceTrafficWindow::sampled_for, TcpFlags psh/urg).

The IngestOutcome timing fields stay: the roadmap plans the IngestOutcome-to-counter folding as exporter API.