### PR TITLE
fix(ui): keep Details tab rows at fixed positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Details Tab Layout Stability**: rows in the Details tab no longer appear
+  or disappear with data availability. MAC, Attributed Name/Via, the
+  Attribution card's process fields, the Kubernetes card's fields, and the
+  inbound Ping RTT row now always render for their connection class, showing
+  `-` when unresolved, so labels and the cards below keep fixed positions
+  while navigating between connections. Placeholder rows are not
+  click-to-copy targets (#554)
 - **macOS lsof Attribution UID**: When libproc details resolve, lsof-based
   attribution now reports the process's live effective UID from libproc
   instead of the UID captured in the earlier lsof scan, matching the other

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1150,7 +1150,7 @@ mod snapshot_tests {
     /// One observed ARP reply between the gateway and this host. Seeds the
     /// tracker's neighbor cache so Details can label on-link addresses with
     /// MAC + vendor. The fixture's remote (140.82.121.4) is public and never
-    /// ARPs, so no "Remote MAC" row is rendered for it.
+    /// ARPs, so its "Remote MAC" row renders the placeholder.
     fn gateway_arp_reply() -> crate::network::parser::ParsedPacket {
         use crate::network::types::{AddrKind, ArpInfo, ArpOperation};
 
@@ -1171,6 +1171,39 @@ mod snapshot_tests {
                 target_mac: "68:5e:dd:09:15:5e".to_string(),
                 target_ip: host,
                 sender_vendor: Some("ASUSTek COMPUTER INC.".to_string()),
+                target_vendor: Some("Apple, Inc.".to_string()),
+            }),
+            is_outgoing: false,
+            packet_len: 42,
+            dpi_result: None,
+            process_name: None,
+            process_id: None,
+        }
+    }
+
+    /// An ARP reply from the sshd fixture's on-link peer (10.0.0.5). Seeds
+    /// the neighbor cache so a Details render of that connection resolves
+    /// its "Remote MAC" row to an actual address.
+    fn sshd_peer_arp_reply() -> crate::network::parser::ParsedPacket {
+        use crate::network::types::{AddrKind, ArpInfo, ArpOperation};
+
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+        let host = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10));
+        crate::network::parser::ParsedPacket {
+            protocol: Protocol::Arp,
+            local_addr: SocketAddr::new(host, 0),
+            remote_addr: SocketAddr::new(peer, 0),
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
+            tcp_header: None,
+            protocol_state: ProtocolState::Arp(ArpInfo {
+                operation: ArpOperation::Reply,
+                sender_mac: "b8:27:eb:12:34:56".to_string(),
+                sender_ip: peer,
+                target_mac: "68:5e:dd:09:15:5e".to_string(),
+                target_ip: host,
+                sender_vendor: Some("Raspberry Pi Foundation".to_string()),
                 target_vendor: Some("Apple, Inc.".to_string()),
             }),
             is_outgoing: false,
@@ -1436,11 +1469,12 @@ mod snapshot_tests {
         assert!(!output.contains("No transport metrics for this protocol"));
     }
 
-    /// Inbound pings are answered here but timed by the remote sender, so the
-    /// responder view drops the Ping RTT row instead of showing a permanent
-    /// placeholder.
+    /// Inbound pings are answered here but timed by the remote sender: the
+    /// Ping RTT row keeps its place with a placeholder (the row set depends
+    /// on the class, not on direction, which resolves asynchronously) and
+    /// the footnote explains who measures it.
     #[test]
-    fn details_tab_inbound_ping_hides_rtt_row() {
+    fn details_tab_inbound_ping_keeps_rtt_placeholder_row() {
         let app = test_app();
         let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)), 0);
         let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 20)), 0);
@@ -1461,7 +1495,17 @@ mod snapshot_tests {
         app.set_connections_snapshot_for_test(connections.clone());
         let output = render_details(&app, &connections, 0);
 
-        assert!(!output.contains("Ping RTT"));
+        let rtt_row = output
+            .lines()
+            .find(|line| line.contains("Ping RTT"))
+            .expect("inbound echo must keep the Ping RTT row");
+        let rtt_value = rtt_row
+            .split_once("Ping RTT")
+            .and_then(|(_, rest)| rest.split_whitespace().next());
+        assert!(
+            rtt_value == Some(NONE_PLACEHOLDER),
+            "an unmeasured inbound Ping RTT must render the placeholder, got: {rtt_row}"
+        );
         assert!(output.contains("Last Sequence") && output.contains("4242"));
         assert!(output.contains("RTT is timed by the remote sender"));
     }
@@ -1550,8 +1594,8 @@ mod snapshot_tests {
         connections[0].pid = None;
         let unattributed = render_connections(&connections);
         assert!(
-            !unattributed.contains("Attribution"),
-            "an unattributed connection must not render an empty Attribution card"
+            unattributed.contains("Attribution"),
+            "the Attribution card renders placeholders even when nothing resolved"
         );
 
         connections[0].pid = Some(2001);
@@ -1588,8 +1632,10 @@ mod snapshot_tests {
         assert!(attributed.contains("exact tuple"));
     }
 
-    /// Partial attribution is the common case off Linux: render the fields that
-    /// resolved and leave the rest out entirely.
+    /// Partial attribution is the common case off Linux: resolved fields carry
+    /// values while unresolved ones keep their rows with a placeholder, so the
+    /// card never changes height. Placeholder rows must not register a
+    /// click-to-copy target.
     #[test]
     fn details_tab_renders_partial_attribution() {
         use crate::network::types::MatchQuality;
@@ -1599,18 +1645,35 @@ mod snapshot_tests {
         connections[0].attribution_quality = Some(MatchQuality::ListenerSocket);
         app.set_connections_snapshot_for_test(connections.clone());
 
-        // 40 rows: the Attribution card must stay visible on a 40-row
-        // terminal — unresolved MAC rows are omitted, not rendered as
-        // placeholders, precisely so the dashboard column does not grow.
-        let output = render_details(&app, &connections, 0);
+        // 52 rows so the Attribution card rows sit above the fold.
+        let (output, click_regions) = render_details_frame(&app, &connections, 0, 52);
 
         assert!(output.contains("Attribution"));
         assert!(output.contains("listener socket"));
-        assert!(
-            !output.contains("Executable"),
-            "an unresolved executable must not leave a labelled blank row"
-        );
-        assert!(!output.contains("User "));
+        for label in ["Executable", "User"] {
+            let row = output
+                .lines()
+                .find(|line| line.trim_start().starts_with(label))
+                .unwrap_or_else(|| panic!("missing {label} row"));
+            assert!(
+                row.split_whitespace().nth(1) == Some(NONE_PLACEHOLDER),
+                "an unresolved {label} must keep its row with a placeholder, got: {row}"
+            );
+        }
+        let copyable_labels: Vec<String> = (0..52u16)
+            .flat_map(|row| (0..140u16).map(move |col| (col, row)))
+            .filter_map(|(col, row)| click_regions.hit_test(col, row).cloned())
+            .filter_map(|action| match action {
+                ClickAction::CopyField { label, .. } => Some(label),
+                _ => None,
+            })
+            .collect();
+        for placeholder_label in ["Executable", "User"] {
+            assert!(
+                !copyable_labels.iter().any(|l| l == placeholder_label),
+                "placeholder {placeholder_label} row must not be clickable"
+            );
+        }
     }
 
     /// Long executable paths shorten from the middle so the location prefix
@@ -1630,8 +1693,8 @@ mod snapshot_tests {
         connections[0].attribution_quality = Some(MatchQuality::ExactTuple);
         app.set_connections_snapshot_for_test(connections.clone());
 
-        // 40 rows for the same reason as the partial-attribution test above.
-        let (output, click_regions) = render_details_frame(&app, &connections, 0, 40);
+        // 52 rows so the Attribution card rows sit above the fold.
+        let (output, click_regions) = render_details_frame(&app, &connections, 0, 52);
 
         assert!(
             output.contains("/nix/store/"),
@@ -1646,7 +1709,7 @@ mod snapshot_tests {
 
         // The shortening is display-only: hit-test every cell and confirm the
         // Executable copy region still carries the unshortened path.
-        let copied = (0..40u16)
+        let copied = (0..52u16)
             .flat_map(|row| (0..140u16).map(move |col| (col, row)))
             .filter_map(|(col, row)| click_regions.hit_test(col, row).cloned())
             .find_map(|action| match action {
@@ -1732,6 +1795,181 @@ mod snapshot_tests {
             assert_eq!(
                 enriched_row, plain_row,
                 "{heading} moved between enriched TCP and plain UDP records"
+            );
+        }
+    }
+
+    /// The Details row set depends only on the connection class, never on
+    /// data availability: a fully enriched record and a bare one must render
+    /// the same labels at the same vertical positions, so a hovered
+    /// click-to-copy row never turns into a different field while navigating.
+    #[test]
+    fn details_tab_row_positions_do_not_depend_on_data_availability() {
+        use crate::network::types::{
+            AttributedHostname, AttributionSource, MatchQuality, ProcessAncestor, ProcessLineage,
+        };
+        use std::path::{Path, PathBuf};
+        use std::sync::Arc;
+
+        // Enriched: neighbor cache seeded, DNS attribution, full process
+        // attribution. Bare: the same TCP connection with none of it.
+        let rich_app = test_app();
+        rich_app.ingest_packet_for_test(&gateway_arp_reply());
+        let mut rich_connections = sample_connections();
+        rich_connections[0].attributed_hostname = Some(AttributedHostname {
+            name: "lb-140-82-121-4.github.com".to_string(),
+            source: AttributionSource::CapturedDns,
+            observed_at: SystemTime::now(),
+        });
+        rich_connections[0].process_ppid = Some(1900);
+        rich_connections[0].executable = Some(Arc::from(Path::new("/usr/lib/firefox/firefox")));
+        rich_connections[0].process_uid = Some(1000);
+        rich_connections[0].process_gid = Some(1000);
+        rich_connections[0].attribution_quality = Some(MatchQuality::ExactTuple);
+        rich_connections[0].process_lineage = Some(Arc::new(ProcessLineage {
+            ancestors: vec![ProcessAncestor {
+                pid: 1900,
+                name: "bash".to_string(),
+                executable: Some(PathBuf::from("/usr/bin/bash")),
+                started_at_unix_ms: Some(1_700_000_010_000),
+            }],
+            truncated: false,
+        }));
+        rich_app.set_connections_snapshot_for_test(rich_connections.clone());
+        let rich = render_details_frame(&rich_app, &rich_connections, 0, 52).0;
+
+        let bare_app = test_app();
+        let mut bare_connections = sample_connections();
+        bare_connections[0].pid = None;
+        bare_app.set_connections_snapshot_for_test(bare_connections.clone());
+        let bare = render_details_frame(&bare_app, &bare_connections, 0, 52).0;
+
+        // Every card heading and every conditional-looking label must sit on
+        // the same row in both renders.
+        for needle in [
+            "Network Context",
+            "Local MAC",
+            "Attributed Name",
+            "Attributed Via",
+            "Remote MAC",
+            "Attribution",
+            "PPID",
+            "Process Tree",
+            "Executable",
+            "User",
+            "Match",
+            "Transport Health",
+            "Traffic Statistics",
+        ] {
+            assert_eq!(
+                heading_row(&rich, needle),
+                heading_row(&bare, needle),
+                "{needle} moved between the enriched and the bare record"
+            );
+        }
+
+        // Stronger form: the whole label column of the details body is
+        // identical, only values differ. The body starts at the dashboard
+        // card header; the continuity strip above legitimately differs
+        // (the bare record has no PID to show there).
+        let label_column = |render: &str| -> Vec<String> {
+            let body_start = heading_row(render, "Protocol");
+            render
+                .lines()
+                .skip(body_start)
+                .map(|line| {
+                    line.chars()
+                        .take(tabs::details::DETAIL_LABEL_WIDTH)
+                        .collect::<String>()
+                        .trim_end()
+                        .to_string()
+                })
+                .collect()
+        };
+        assert_eq!(
+            label_column(&rich),
+            label_column(&bare),
+            "the label column must not depend on data availability"
+        );
+
+        // The resolved direction of the Remote MAC row: the sshd remote
+        // (10.0.0.5) is on-link and seeded in the neighbor cache, so its row
+        // must carry the actual MAC while sitting exactly where the
+        // placeholder sits for the off-link remote above. This is the
+        // scroll-between-on-link-and-off-link case the fixed row set exists
+        // for.
+        rich_app.ingest_packet_for_test(&sshd_peer_arp_reply());
+        let on_link = render_details_frame(&rich_app, &rich_connections, 2, 52).0;
+        let remote_mac_row = heading_row(&on_link, "Remote MAC");
+        assert_eq!(
+            remote_mac_row,
+            heading_row(&rich, "Remote MAC"),
+            "Remote MAC must sit on the same row for on-link and off-link remotes"
+        );
+        assert!(
+            on_link
+                .lines()
+                .nth(remote_mac_row)
+                .expect("Remote MAC row")
+                .contains("b8:27:eb:12:34:56"),
+            "an on-link remote must render its resolved MAC on the Remote MAC row"
+        );
+    }
+
+    /// The one class distinction in the Details row set: ARP has no owning
+    /// process, and its MACs already live in the Application card as
+    /// Sender/Target MAC, so it renders neither the Attribution card nor the
+    /// Network Context MAC and attributed-hostname rows.
+    #[test]
+    fn details_tab_arp_connection_skips_mac_and_attribution_rows() {
+        use crate::network::types::{ArpInfo, ArpOperation};
+
+        let app = test_app();
+        app.ingest_packet_for_test(&gateway_arp_reply());
+        let gateway = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        let host = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10));
+        let arp = Connection::new(
+            Protocol::Arp,
+            SocketAddr::new(host, 0),
+            SocketAddr::new(gateway, 0),
+            ProtocolState::Arp(ArpInfo {
+                operation: ArpOperation::Reply,
+                sender_mac: "04:d9:f5:c5:ed:e8".to_string(),
+                sender_ip: gateway,
+                target_mac: "68:5e:dd:09:15:5e".to_string(),
+                target_ip: host,
+                sender_vendor: Some("ASUSTek COMPUTER INC.".to_string()),
+                target_vendor: Some("Apple, Inc.".to_string()),
+            }),
+        );
+        let connections = vec![arp];
+        app.set_connections_snapshot_for_test(connections.clone());
+
+        let output = render_details_frame(&app, &connections, 0, 52).0;
+
+        assert!(output.contains("Network Context"));
+        assert!(output.contains("Application: ARP"));
+        assert!(output.contains("Sender MAC") && output.contains("Target MAC"));
+        assert!(
+            !output.contains("Attribution"),
+            "ARP must not render the Attribution card:\n{output}"
+        );
+        // Both endpoints are in the neighbor cache (the ingested reply seeds
+        // them), so these rows would resolve if the ARP guard regressed.
+        for label in [
+            "Local MAC",
+            "Remote MAC",
+            "Attributed Name",
+            "Attributed Via",
+            "PPID",
+            "Process Tree",
+            "Executable",
+            "User ",
+            "Match ",
+        ] {
+            assert!(
+                !output.contains(label),
+                "ARP must not render a {label} row:\n{output}"
             );
         }
     }

--- a/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__details_tab_tcp_https.snap
+++ b/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__details_tab_tcp_https.snap
@@ -11,27 +11,28 @@ expression: output
   sshd (1500)             10.0.0.5:51022            192.168.1.10:22    ssh        TCP                       ESTABLISHED        -         -/-
                                                                                                                                             
 ▎ firefox → 140.82.121.4:443 · click a field to copy                                                                                        
-Connection                                                            Application                                                           
-Protocol              TCP                                             Detected              -                                               
-Status                Active (last seen <T> ago)                                                                                             
-Local Address         192.168.1.10:51234                                                                                                    
-Remote Address        140.82.121.4:443                                                                                                      
-Scope                 PUBLIC                                                                                                                
-State                 ESTABLISHED                                                                                                           
-Process               firefox                                                                                                               
-PID                   2001                                                                                                                  
-Service               https                                                                                                                 
-                                                                                                                                            
-Network Context                                                       Transport Health                                                      
-Local Hostname        -                                               Initial RTT           -                                               
-Local MAC             68:5e:dd:09:15:5e (Apple, Inc.)                 Live RTT              -                                               
-Remote Hostname       -                                               TCP Retransmits       0                                               
-Country               -                                               Out-of-Order Packets  0                                               
-City                  -                                               Duplicate ACKs        0                                               
-ASN                   -                                               Fast Retransmits      0                                               
-                                                                      Window Size           0                                               
-Attribution                                                                                                                                 
-PID                   2001                                                                                                                  
+Connection                                                            Application                                                          █
+Protocol              TCP                                             Detected              -                                              █
+Status                Active (last seen <T> ago)                                                                                            █
+Local Address         192.168.1.10:51234                                                                                                   █
+Remote Address        140.82.121.4:443                                                                                                     █
+Scope                 PUBLIC                                                                                                               █
+State                 ESTABLISHED                                                                                                          █
+Process               firefox                                                                                                              █
+PID                   2001                                                                                                                 █
+Service               https                                                                                                                █
+                                                                                                                                           █
+Network Context                                                       Transport Health                                                     █
+Local Hostname        -                                               Initial RTT           -                                              █
+Local MAC             68:5e:dd:09:15:5e (Apple, Inc.)                 Live RTT              -                                              █
+Remote Hostname       -                                               TCP Retransmits       0                                              █
+Attributed Name       -                                               Out-of-Order Packets  0                                              █
+Attributed Via        -                                               Duplicate ACKs        0                                              █
+Remote MAC            -                                               Fast Retransmits      0                                              ║
+Country               -                                               Window Size           0                                              ║
+City                  -                                                                                                                    ║
+ASN                   -                                                                                                                    ║
+                                                                                                                                           ║
                                                                                                                                             
 ▎ Traffic Statistics                                                                                                                        
 ↓ RX -           →                                 peak           -   ↑ TX -           →                                 peak           -   
@@ -40,5 +41,4 @@ Total 234.38 KB  ·  234 packets                                       Total 12.
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
-                                                                                                                                            
  'h' help | 1-5 jump | Tab/[/] cycle | j/k prev/next | Ctrl-d/u scroll | 'c' copy remote addr | Esc back

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -41,7 +41,7 @@ use crate::ui::{
 /// Padded width for detail labels so values line up vertically.
 /// Sized for the longest expected label ("Out-of-Order Packets" = 20 chars)
 /// plus 2 chars of breathing room before the value column.
-const DETAIL_LABEL_WIDTH: usize = 22;
+pub(in crate::ui) const DETAIL_LABEL_WIDTH: usize = 22;
 
 /// Below this terminal width the Details info panes collapse back to a
 /// single column. With label width 22 plus reasonable values, ~50 cells
@@ -846,8 +846,9 @@ pub(in crate::ui) fn draw_connection_details(
     let mut right_ranges: Vec<std::ops::Range<usize>> = Vec::new();
 
     // Unlike regular sections, the first card starts without a blank separator.
-    // Together with the Network Context card below this gives the left
-    // dashboard column a 17-row footprint, plus one row per resolved MAC.
+    // Together with the fixed nine-row Network Context card below this gives
+    // the left dashboard column a 21-row footprint (17 for ARP, which has no
+    // MAC or attribution rows), so the cards below never move.
     details_text.push(Line::from(Span::styled(
         "Connection",
         theme::bold_fg(theme::heading()),
@@ -1052,17 +1053,19 @@ pub(in crate::ui) fn draw_connection_details(
         label_style,
         theme::fg(theme::field_local_addr()),
     );
-    // MAC rows appear only once the neighbor cache actually resolved the
-    // address (like the Attribution card's fields): most connections —
-    // every public remote, for one — can never resolve, and a permanent
-    // placeholder row would push the Attribution card below the fold on
-    // shorter terminals.
-    if let Some(entry) = local_mac {
+    // MAC and attribution rows depend on the connection class, never on data
+    // availability: they always render for non-ARP connections, with a
+    // placeholder when unresolved, so the cards below keep static positions
+    // while navigating. The details pane scrolls, so the fixed rows cannot
+    // make content unreachable on short terminals.
+    if conn.protocol != Protocol::Arp {
         push_detail_field_styled(
             &mut details_text,
             &mut detail_fields,
             "Local MAC",
-            format_mac(entry),
+            local_mac
+                .map(format_mac)
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
             label_style,
             theme::fg(theme::field_local_addr()),
         );
@@ -1077,36 +1080,39 @@ pub(in crate::ui) fn draw_connection_details(
     );
     // Hostname inferred from a DNS response observed on the wire, with
     // its provenance and age so it reads as an inference, not a lookup.
-    // Conditional like the MAC rows: a permanent placeholder would push
-    // the Attribution card below the fold for the many connections that
-    // can never be attributed.
-    if let Some(att) = &conn.attributed_hostname {
-        let source = match att.source {
-            crate::network::types::AttributionSource::CapturedDns => "Captured DNS",
+    // Name and provenance on separate rows: a combined value clips at
+    // the card boundary for hostnames of ordinary length, hiding the
+    // provenance entirely.
+    if conn.protocol != Protocol::Arp {
+        let (attributed_name, attributed_via) = match &conn.attributed_hostname {
+            Some(att) => {
+                let source = match att.source {
+                    crate::network::types::AttributionSource::CapturedDns => "Captured DNS",
+                };
+                let age = att
+                    .observed_at
+                    .elapsed()
+                    .ok()
+                    .map(|d| {
+                        let s = d.as_secs();
+                        if s < 60 {
+                            format!("{}s ago", s)
+                        } else if s < 3600 {
+                            format!("{}m ago", s / 60)
+                        } else {
+                            format!("{}h ago", s / 3600)
+                        }
+                    })
+                    .unwrap_or_else(|| NONE_PLACEHOLDER.to_string());
+                (format!("~{}", att.name), format!("{}, {}", source, age))
+            }
+            None => (NONE_PLACEHOLDER.to_string(), NONE_PLACEHOLDER.to_string()),
         };
-        let age = att
-            .observed_at
-            .elapsed()
-            .ok()
-            .map(|d| {
-                let s = d.as_secs();
-                if s < 60 {
-                    format!("{}s ago", s)
-                } else if s < 3600 {
-                    format!("{}m ago", s / 60)
-                } else {
-                    format!("{}h ago", s / 3600)
-                }
-            })
-            .unwrap_or_else(|| NONE_PLACEHOLDER.to_string());
-        // Name and provenance on separate rows: a combined value clips at
-        // the card boundary for hostnames of ordinary length, hiding the
-        // provenance entirely.
         push_detail_field_styled(
             &mut details_text,
             &mut detail_fields,
             "Attributed Name",
-            format!("~{}", att.name),
+            attributed_name,
             label_style,
             theme::fg(theme::field_attributed_hostname()),
         );
@@ -1114,17 +1120,17 @@ pub(in crate::ui) fn draw_connection_details(
             &mut details_text,
             &mut detail_fields,
             "Attributed Via",
-            format!("{}, {}", source, age),
+            attributed_via,
             label_style,
             theme::fg(theme::field_attributed_hostname()),
         );
-    }
-    if let Some(entry) = remote_mac {
         push_detail_field_styled(
             &mut details_text,
             &mut detail_fields,
             "Remote MAC",
-            format_mac(entry),
+            remote_mac
+                .map(format_mac)
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
             label_style,
             theme::fg(theme::field_remote_addr()),
         );
@@ -1155,43 +1161,36 @@ pub(in crate::ui) fn draw_connection_details(
         location_value_style,
     );
 
-    // Richer process attribution, when the platform's lookup could resolve it.
-    // Rendered like the Kubernetes block below: each row appears only when the
-    // backend actually observed that field, and the whole section disappears
-    // when none of them did. That keeps platforms which structurally cannot
-    // supply a field (no executable path, no uid) from showing a permanent
-    // placeholder, and keeps this section out of the fixed-height card
-    // geometry that `APPLICATION_CARD_ROWS` anchors.
-    let has_attribution = conn.pid.is_some()
-        || conn.process_ppid.is_some()
-        || conn.executable.is_some()
-        || conn.process_uid.is_some()
-        || conn.attribution_quality.is_some()
-        || conn.process_lineage.is_some();
-    if has_attribution {
+    // Richer process attribution. The row set depends on the connection class,
+    // never on data availability: every row renders with a placeholder when
+    // the platform's lookup could not resolve it, so the cards below keep
+    // static positions while navigating. ARP has no owning process, so it
+    // skips the card entirely. The Kubernetes block below stays conditional:
+    // being a k8s workload is a class distinction, not missing data.
+    if conn.protocol != Protocol::Arp {
         let process_value_style = theme::fg(theme::field_process());
         push_detail_section(&mut details_text, &mut detail_fields, "Attribution");
 
-        if let Some(pid) = conn.pid {
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
-                "PID",
-                pid.to_string(),
-                label_style,
-                process_value_style,
-            );
-        }
-        if let Some(ppid) = conn.process_ppid {
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
-                "PPID",
-                ppid.to_string(),
-                label_style,
-                process_value_style,
-            );
-        }
+        push_detail_field_styled(
+            &mut details_text,
+            &mut detail_fields,
+            "PID",
+            conn.pid
+                .map(|pid| pid.to_string())
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            label_style,
+            process_value_style,
+        );
+        push_detail_field_styled(
+            &mut details_text,
+            &mut detail_fields,
+            "PPID",
+            conn.process_ppid
+                .map(|ppid| ppid.to_string())
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            label_style,
+            process_value_style,
+        );
         if let (Some(lineage), Some(owner_name)) =
             (&conn.process_lineage, conn.process_name.as_deref())
         {
@@ -1201,6 +1200,15 @@ pub(in crate::ui) fn draw_connection_details(
                 "Process Tree",
                 process_tree_value(lineage, owner_name, value_width),
                 process_tree_value(lineage, owner_name, usize::MAX),
+                label_style,
+                process_value_style,
+            );
+        } else {
+            push_detail_field_styled(
+                &mut details_text,
+                &mut detail_fields,
+                "Process Tree",
+                NONE_PLACEHOLDER.to_string(),
                 label_style,
                 process_value_style,
             );
@@ -1216,102 +1224,116 @@ pub(in crate::ui) fn draw_connection_details(
                 label_style,
                 process_value_style,
             );
-        }
-        if let Some(uid) = conn.process_uid {
-            push_detail_field(
-                &mut details_text,
-                &mut detail_fields,
-                "User",
-                format_user_group(uid, conn.process_gid),
-                label_style,
-            );
-        }
-        if let Some(quality) = conn.attribution_quality {
-            // A relaxed match is a plausible owner, not a proven one, so it
-            // reads as a warning rather than as confirmed fact.
-            let quality_color = if quality.is_exact() {
-                theme::ok()
-            } else if quality == MatchQuality::Unspecified {
-                theme::muted()
-            } else {
-                theme::warn()
-            };
+        } else {
             push_detail_field_styled(
                 &mut details_text,
                 &mut detail_fields,
-                "Match",
-                quality.to_string(),
+                "Executable",
+                NONE_PLACEHOLDER.to_string(),
                 label_style,
-                theme::fg(quality_color),
+                process_value_style,
             );
         }
+        push_detail_field(
+            &mut details_text,
+            &mut detail_fields,
+            "User",
+            conn.process_uid
+                .map(|uid| format_user_group(uid, conn.process_gid))
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            label_style,
+        );
+        // A relaxed match is a plausible owner, not a proven one, so it
+        // reads as a warning rather than as confirmed fact.
+        let quality_color = match conn.attribution_quality {
+            Some(quality) if quality.is_exact() => theme::ok(),
+            Some(MatchQuality::Unspecified) | None => theme::muted(),
+            Some(_) => theme::warn(),
+        };
+        push_detail_field_styled(
+            &mut details_text,
+            &mut detail_fields,
+            "Match",
+            conn.attribution_quality
+                .map(|quality| quality.to_string())
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            label_style,
+            theme::fg(quality_color),
+        );
     }
 
     // Kubernetes attribution (pod / container) when the owning process is in
-    // a kubepods cgroup. Only rendered when the resolver populated `k8s_info`.
+    // a kubepods cgroup. The card's presence is the class distinction (being
+    // a k8s workload); once present, every row renders with a placeholder
+    // when unresolved, so the cards below keep static positions while the
+    // enrichment thread fills fields in.
     #[cfg(feature = "kubernetes")]
     if let Some(ref k8s) = conn.k8s_info {
         let k8s_value_style = theme::fg(theme::field_process());
         push_detail_section(&mut details_text, &mut detail_fields, "Kubernetes");
         // Prefer the human-readable pod name over the raw UID; show both when
         // both are present.
-        if let Some(ref name) = k8s.pod_name {
-            let pod_display = if let Some(ref ns) = k8s.pod_namespace {
-                format!("{}/{}", ns, name)
-            } else {
-                name.clone()
-            };
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
-                "Pod",
-                pod_display,
-                label_style,
-                k8s_value_style,
-            );
-        }
-        if let Some(ref uid) = k8s.pod_uid {
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
-                "Pod UID",
-                uid.clone(),
-                label_style,
-                k8s_value_style,
-            );
-        }
-        if let Some(ref cname) = k8s.container_name {
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
-                "Container",
-                cname.clone(),
-                label_style,
-                k8s_value_style,
-            );
-        }
-        if let Some(ref cid) = k8s.container_id {
-            // Container IDs are 64 hex chars; truncate to the short form
-            // typically shown by `kubectl get pod ... -o wide`.
-            let short = if cid.len() >= 12 { &cid[..12] } else { cid };
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
-                "Container ID",
-                short.to_string(),
-                label_style,
-                k8s_value_style,
-            );
-        }
-        if let Some(ref path) = k8s.cgroup_path {
-            push_detail_field(
-                &mut details_text,
-                &mut detail_fields,
-                "Cgroup",
-                path.clone(),
-                label_style,
-            );
-        }
+        let pod_display = match (&k8s.pod_name, &k8s.pod_namespace) {
+            (Some(name), Some(ns)) => format!("{}/{}", ns, name),
+            (Some(name), None) => name.clone(),
+            (None, _) => NONE_PLACEHOLDER.to_string(),
+        };
+        push_detail_field_styled(
+            &mut details_text,
+            &mut detail_fields,
+            "Pod",
+            pod_display,
+            label_style,
+            k8s_value_style,
+        );
+        push_detail_field_styled(
+            &mut details_text,
+            &mut detail_fields,
+            "Pod UID",
+            k8s.pod_uid
+                .clone()
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            label_style,
+            k8s_value_style,
+        );
+        push_detail_field_styled(
+            &mut details_text,
+            &mut detail_fields,
+            "Container",
+            k8s.container_name
+                .clone()
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            label_style,
+            k8s_value_style,
+        );
+        // Container IDs are 64 hex chars; truncate to the short form
+        // typically shown by `kubectl get pod ... -o wide`.
+        push_detail_field_styled(
+            &mut details_text,
+            &mut detail_fields,
+            "Container ID",
+            k8s.container_id
+                .as_deref()
+                .map(|cid| {
+                    if cid.len() >= 12 {
+                        cid[..12].to_string()
+                    } else {
+                        cid.to_string()
+                    }
+                })
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            label_style,
+            k8s_value_style,
+        );
+        push_detail_field(
+            &mut details_text,
+            &mut detail_fields,
+            "Cgroup",
+            k8s.cgroup_path
+                .clone()
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            label_style,
+        );
     }
 
     // Add DPI / application protocol information. Section heading carries
@@ -2198,18 +2220,18 @@ pub(in crate::ui) fn draw_connection_details(
             "Paired by originate timestamp echo",
         );
     } else if let Some(sequence) = icmp_echo_sequence {
-        // A flow the remote side initiated is only ever answered here, so
-        // there is no round trip to measure and no point in a placeholder.
+        // The row set depends only on the class (an echo flow), never on
+        // direction or measurement, which both resolve asynchronously. An
+        // inbound echo keeps the row as a placeholder; the footnote explains
+        // that the remote sender is the one timing it.
         let is_responder = conn.connection_direction == Some(false);
-        if conn.icmp_echo_rtt.is_some() || !is_responder {
-            push_rtt_field(
-                &mut details_text,
-                &mut detail_fields,
-                "Ping RTT",
-                conn.icmp_echo_rtt,
-                label_style,
-            );
-        }
+        push_rtt_field(
+            &mut details_text,
+            &mut detail_fields,
+            "Ping RTT",
+            conn.icmp_echo_rtt,
+            label_style,
+        );
         push_detail_field(
             &mut details_text,
             &mut detail_fields,


### PR DESCRIPTION
Rows in the Details tab appeared or disappeared depending on data availability, so labels and cards jumped around while scrolling between connections. The tab now derives its row set only from the connection class and renders "-" for absent data, keeping every row at a fixed position. A snapshot-backed layout-stability test asserts row positions do not depend on data availability.