### PR TITLE
fix(ui): extend the fixed Details row layout to ARP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ target/
 .aider*
 /logs
 .venv
+
+# Local GeoIP databases and packet captures used for manual testing
+*.mmdb
+*.pcap
+*.pcapng
+*.pcap.connections.jsonl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole Attribution card, so Traffic Statistics and the cards below jumped
   when moving between ARP and non-ARP entries. ARP now renders the same
   left-column row set with `-` placeholders, and its MAC rows resolve from
-  the neighbor cache like any other on-link connection (#555)
+  the neighbor cache like any other on-link connection. The Status and
+  Attributed Via ages now share one formatter, so connections closed or idle
+  for over an hour show `2h ago` instead of a large minute count (#555)
 - **Details Tab Layout Stability**: rows in the Details tab no longer appear
   or disappear with data availability. MAC, Attributed Name/Via, the
   Attribution card's process fields, the Kubernetes card's fields, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Details Tab ARP Layout**: ARP connections were exempt from the fixed
+  Details layout and dropped the Network Context MAC/attribution rows and the
+  whole Attribution card, so Traffic Statistics and the cards below jumped
+  when moving between ARP and non-ARP entries. ARP now renders the same
+  left-column row set with `-` placeholders, and its MAC rows resolve from
+  the neighbor cache like any other on-link connection (#555)
 - **Details Tab Layout Stability**: rows in the Details tab no longer appear
   or disappear with data availability. MAC, Attributed Name/Via, the
   Attribution card's process fields, the Kubernetes card's fields, and the

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1950,12 +1950,13 @@ mod snapshot_tests {
         );
     }
 
-    /// The one class distinction in the Details row set: ARP has no owning
-    /// process, and its MACs already live in the Application card as
-    /// Sender/Target MAC, so it renders neither the Attribution card nor the
-    /// Network Context MAC and attributed-hostname rows.
+    /// ARP is not exempt from the fixed row layout: it renders the same
+    /// Network Context rows and the same Attribution card (all placeholders,
+    /// there is no owning process), so the cards below sit on the same rows
+    /// as for any other connection while the selection moves through a mixed
+    /// list of ARP and non-ARP entries.
     #[test]
-    fn details_tab_arp_connection_skips_mac_and_attribution_rows() {
+    fn details_tab_arp_uses_the_same_row_layout() {
         use crate::network::types::{ArpInfo, ArpOperation};
 
         let app = test_app();
@@ -1976,34 +1977,53 @@ mod snapshot_tests {
                 target_vendor: Some("Apple, Inc.".to_string()),
             }),
         );
-        let connections = vec![arp];
+        let mut connections = sample_connections();
+        connections.push(arp);
+        let arp_index = connections.len() - 1;
         app.set_connections_snapshot_for_test(connections.clone());
 
-        let output = render_details_frame(&app, &connections, 0, 52).0;
+        let arp_render = render_details_frame(&app, &connections, arp_index, 52).0;
+        let tcp_render = render_details_frame(&app, &connections, 0, 52).0;
 
-        assert!(output.contains("Network Context"));
-        assert!(output.contains("Application: ARP"));
-        assert!(output.contains("Sender MAC") && output.contains("Target MAC"));
-        assert!(
-            !output.contains("Attribution"),
-            "ARP must not render the Attribution card:\n{output}"
-        );
-        // Both endpoints are in the neighbor cache (the ingested reply seeds
-        // them), so these rows would resolve if the ARP guard regressed.
-        for label in [
+        assert!(arp_render.contains("Application: ARP"));
+        assert!(arp_render.contains("Sender MAC") && arp_render.contains("Target MAC"));
+
+        // Every shared card heading and left-column label sits on the same
+        // row for the ARP record as for the TCP record; only the Application
+        // card content is allowed to differ between classes.
+        for needle in [
+            "Network Context",
             "Local MAC",
-            "Remote MAC",
             "Attributed Name",
             "Attributed Via",
+            "Remote MAC",
+            "Attribution",
             "PPID",
             "Process Tree",
             "Executable",
             "User ",
             "Match ",
+            "Transport Health",
+            "Traffic Statistics",
         ] {
+            assert_eq!(
+                heading_row(&arp_render, needle),
+                heading_row(&tcp_render, needle),
+                "{needle} moved between the ARP and the TCP record"
+            );
+        }
+
+        // The ingested reply seeds both endpoints in the neighbor cache, so
+        // the ARP record's MAC rows resolve like any other on-link
+        // connection instead of pinning dead placeholders.
+        for (label, mac) in [
+            ("Remote MAC", "04:d9:f5:c5:ed:e8"),
+            ("Local MAC", "68:5e:dd:09:15:5e"),
+        ] {
+            let row = heading_row(&arp_render, label);
             assert!(
-                !output.contains(label),
-                "ARP must not render a {label} row:\n{output}"
+                arp_render.lines().nth(row).expect("MAC row").contains(mac),
+                "ARP must resolve its on-link {label}:\n{arp_render}"
             );
         }
     }

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -847,8 +847,8 @@ pub(in crate::ui) fn draw_connection_details(
 
     // Unlike regular sections, the first card starts without a blank separator.
     // Together with the fixed nine-row Network Context card below this gives
-    // the left dashboard column a 21-row footprint (17 for ARP, which has no
-    // MAC or attribution rows), so the cards below never move.
+    // the left dashboard column a 21-row footprint for every protocol, ARP
+    // included, so the cards below never move.
     details_text.push(Line::from(Span::styled(
         "Connection",
         theme::bold_fg(theme::heading()),
@@ -975,7 +975,6 @@ pub(in crate::ui) fn draw_connection_details(
     // while asynchronous DNS and GeoIP data arrives, which prevents the lower
     // dashboard and traffic section from jumping during connection navigation.
     let (local_hostname, remote_hostname) = dns_resolver
-        .filter(|_| conn.protocol != Protocol::Arp)
         .map(|resolver| {
             (
                 resolver.get_hostname(&conn.local_addr.ip()),
@@ -986,17 +985,11 @@ pub(in crate::ui) fn draw_connection_details(
 
     // MAC + vendor from the neighbor cache (learned from ARP and NDP).
     // Present only for on-link addresses that appeared in such an exchange,
-    // so a public remote can never show the router's identity. ARP
-    // connections never show the rows; their Application card already
-    // shows both MACs.
-    let (local_mac, remote_mac) = if conn.protocol == Protocol::Arp {
-        (None, None)
-    } else {
-        (
-            ctx.app.lookup_neighbor(conn.local_addr.ip()),
-            ctx.app.lookup_neighbor(conn.remote_addr.ip()),
-        )
-    };
+    // so a public remote can never show the router's identity.
+    let (local_mac, remote_mac) = (
+        ctx.app.lookup_neighbor(conn.local_addr.ip()),
+        ctx.app.lookup_neighbor(conn.remote_addr.ip()),
+    );
     let format_mac = |entry: crate::network::neighbors::NeighborEntry| {
         if let Some(vendor) = entry.vendor {
             format!("{} ({})", entry.mac, vendor)
@@ -1053,23 +1046,20 @@ pub(in crate::ui) fn draw_connection_details(
         label_style,
         theme::fg(theme::field_local_addr()),
     );
-    // MAC and attribution rows depend on the connection class, never on data
-    // availability: they always render for non-ARP connections, with a
-    // placeholder when unresolved, so the cards below keep static positions
-    // while navigating. The details pane scrolls, so the fixed rows cannot
-    // make content unreachable on short terminals.
-    if conn.protocol != Protocol::Arp {
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
-            "Local MAC",
-            local_mac
-                .map(format_mac)
-                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
-            theme::fg(theme::field_local_addr()),
-        );
-    }
+    // MAC and attribution rows always render, with a placeholder when
+    // unresolved, so the cards below keep static positions while navigating,
+    // for every protocol including ARP. The details pane scrolls, so the
+    // fixed rows cannot make content unreachable on short terminals.
+    push_detail_field_styled(
+        &mut details_text,
+        &mut detail_fields,
+        "Local MAC",
+        local_mac
+            .map(format_mac)
+            .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+        label_style,
+        theme::fg(theme::field_local_addr()),
+    );
     push_detail_field_styled(
         &mut details_text,
         &mut detail_fields,
@@ -1083,58 +1073,56 @@ pub(in crate::ui) fn draw_connection_details(
     // Name and provenance on separate rows: a combined value clips at
     // the card boundary for hostnames of ordinary length, hiding the
     // provenance entirely.
-    if conn.protocol != Protocol::Arp {
-        let (attributed_name, attributed_via) = match &conn.attributed_hostname {
-            Some(att) => {
-                let source = match att.source {
-                    crate::network::types::AttributionSource::CapturedDns => "Captured DNS",
-                };
-                let age = att
-                    .observed_at
-                    .elapsed()
-                    .ok()
-                    .map(|d| {
-                        let s = d.as_secs();
-                        if s < 60 {
-                            format!("{}s ago", s)
-                        } else if s < 3600 {
-                            format!("{}m ago", s / 60)
-                        } else {
-                            format!("{}h ago", s / 3600)
-                        }
-                    })
-                    .unwrap_or_else(|| NONE_PLACEHOLDER.to_string());
-                (format!("~{}", att.name), format!("{}, {}", source, age))
-            }
-            None => (NONE_PLACEHOLDER.to_string(), NONE_PLACEHOLDER.to_string()),
-        };
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
-            "Attributed Name",
-            attributed_name,
-            label_style,
-            theme::fg(theme::field_attributed_hostname()),
-        );
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
-            "Attributed Via",
-            attributed_via,
-            label_style,
-            theme::fg(theme::field_attributed_hostname()),
-        );
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
-            "Remote MAC",
-            remote_mac
-                .map(format_mac)
-                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
-            theme::fg(theme::field_remote_addr()),
-        );
-    }
+    let (attributed_name, attributed_via) = match &conn.attributed_hostname {
+        Some(att) => {
+            let source = match att.source {
+                crate::network::types::AttributionSource::CapturedDns => "Captured DNS",
+            };
+            let age = att
+                .observed_at
+                .elapsed()
+                .ok()
+                .map(|d| {
+                    let s = d.as_secs();
+                    if s < 60 {
+                        format!("{}s ago", s)
+                    } else if s < 3600 {
+                        format!("{}m ago", s / 60)
+                    } else {
+                        format!("{}h ago", s / 3600)
+                    }
+                })
+                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string());
+            (format!("~{}", att.name), format!("{}, {}", source, age))
+        }
+        None => (NONE_PLACEHOLDER.to_string(), NONE_PLACEHOLDER.to_string()),
+    };
+    push_detail_field_styled(
+        &mut details_text,
+        &mut detail_fields,
+        "Attributed Name",
+        attributed_name,
+        label_style,
+        theme::fg(theme::field_attributed_hostname()),
+    );
+    push_detail_field_styled(
+        &mut details_text,
+        &mut detail_fields,
+        "Attributed Via",
+        attributed_via,
+        label_style,
+        theme::fg(theme::field_attributed_hostname()),
+    );
+    push_detail_field_styled(
+        &mut details_text,
+        &mut detail_fields,
+        "Remote MAC",
+        remote_mac
+            .map(format_mac)
+            .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+        label_style,
+        theme::fg(theme::field_remote_addr()),
+    );
     let location_value_style = theme::fg(theme::field_location());
     push_detail_field_styled(
         &mut details_text,
@@ -1161,106 +1149,104 @@ pub(in crate::ui) fn draw_connection_details(
         location_value_style,
     );
 
-    // Richer process attribution. The row set depends on the connection class,
-    // never on data availability: every row renders with a placeholder when
+    // Richer process attribution. Every row renders with a placeholder when
     // the platform's lookup could not resolve it, so the cards below keep
-    // static positions while navigating. ARP has no owning process, so it
-    // skips the card entirely. The Kubernetes block below stays conditional:
-    // being a k8s workload is a class distinction, not missing data.
-    if conn.protocol != Protocol::Arp {
-        let process_value_style = theme::fg(theme::field_process());
-        push_detail_section(&mut details_text, &mut detail_fields, "Attribution");
+    // static positions while navigating. ARP has no owning process and shows
+    // all placeholders, which keeps Traffic Statistics from jumping when the
+    // selection moves between an ARP entry and its neighbors in the list.
+    // The Kubernetes block below stays conditional: being a k8s workload is
+    // a class distinction, not missing data.
+    let process_value_style = theme::fg(theme::field_process());
+    push_detail_section(&mut details_text, &mut detail_fields, "Attribution");
 
-        push_detail_field_styled(
+    push_detail_field_styled(
+        &mut details_text,
+        &mut detail_fields,
+        "PID",
+        conn.pid
+            .map(|pid| pid.to_string())
+            .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+        label_style,
+        process_value_style,
+    );
+    push_detail_field_styled(
+        &mut details_text,
+        &mut detail_fields,
+        "PPID",
+        conn.process_ppid
+            .map(|ppid| ppid.to_string())
+            .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+        label_style,
+        process_value_style,
+    );
+    if let (Some(lineage), Some(owner_name)) = (&conn.process_lineage, conn.process_name.as_deref())
+    {
+        push_detail_field_with_copy(
             &mut details_text,
             &mut detail_fields,
-            "PID",
-            conn.pid
-                .map(|pid| pid.to_string())
-                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            "Process Tree",
+            process_tree_value(lineage, owner_name, value_width),
+            process_tree_value(lineage, owner_name, usize::MAX),
             label_style,
             process_value_style,
         );
+    } else {
         push_detail_field_styled(
             &mut details_text,
             &mut detail_fields,
-            "PPID",
-            conn.process_ppid
-                .map(|ppid| ppid.to_string())
-                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+            "Process Tree",
+            NONE_PLACEHOLDER.to_string(),
             label_style,
             process_value_style,
-        );
-        if let (Some(lineage), Some(owner_name)) =
-            (&conn.process_lineage, conn.process_name.as_deref())
-        {
-            push_detail_field_with_copy(
-                &mut details_text,
-                &mut detail_fields,
-                "Process Tree",
-                process_tree_value(lineage, owner_name, value_width),
-                process_tree_value(lineage, owner_name, usize::MAX),
-                label_style,
-                process_value_style,
-            );
-        } else {
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
-                "Process Tree",
-                NONE_PLACEHOLDER.to_string(),
-                label_style,
-                process_value_style,
-            );
-        }
-        if let Some(ref executable) = conn.executable {
-            let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
-            push_detail_field_with_copy(
-                &mut details_text,
-                &mut detail_fields,
-                "Executable",
-                shorten_executable_path(executable, home.as_deref(), value_width),
-                executable.display().to_string(),
-                label_style,
-                process_value_style,
-            );
-        } else {
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
-                "Executable",
-                NONE_PLACEHOLDER.to_string(),
-                label_style,
-                process_value_style,
-            );
-        }
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "User",
-            conn.process_uid
-                .map(|uid| format_user_group(uid, conn.process_gid))
-                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
-        );
-        // A relaxed match is a plausible owner, not a proven one, so it
-        // reads as a warning rather than as confirmed fact.
-        let quality_color = match conn.attribution_quality {
-            Some(quality) if quality.is_exact() => theme::ok(),
-            Some(MatchQuality::Unspecified) | None => theme::muted(),
-            Some(_) => theme::warn(),
-        };
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
-            "Match",
-            conn.attribution_quality
-                .map(|quality| quality.to_string())
-                .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
-            theme::fg(quality_color),
         );
     }
+    if let Some(ref executable) = conn.executable {
+        let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
+        push_detail_field_with_copy(
+            &mut details_text,
+            &mut detail_fields,
+            "Executable",
+            shorten_executable_path(executable, home.as_deref(), value_width),
+            executable.display().to_string(),
+            label_style,
+            process_value_style,
+        );
+    } else {
+        push_detail_field_styled(
+            &mut details_text,
+            &mut detail_fields,
+            "Executable",
+            NONE_PLACEHOLDER.to_string(),
+            label_style,
+            process_value_style,
+        );
+    }
+    push_detail_field(
+        &mut details_text,
+        &mut detail_fields,
+        "User",
+        conn.process_uid
+            .map(|uid| format_user_group(uid, conn.process_gid))
+            .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+        label_style,
+    );
+    // A relaxed match is a plausible owner, not a proven one, so it
+    // reads as a warning rather than as confirmed fact.
+    let quality_color = match conn.attribution_quality {
+        Some(quality) if quality.is_exact() => theme::ok(),
+        Some(MatchQuality::Unspecified) | None => theme::muted(),
+        Some(_) => theme::warn(),
+    };
+    push_detail_field_styled(
+        &mut details_text,
+        &mut detail_fields,
+        "Match",
+        conn.attribution_quality
+            .map(|quality| quality.to_string())
+            .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
+        label_style,
+        theme::fg(quality_color),
+    );
 
     // Kubernetes attribution (pod / container) when the owning process is in
     // a kubepods cgroup. The card's presence is the class distinction (being

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -385,6 +385,18 @@ fn shorten_executable_path(
     fit_path_middle(&display, max_width)
 }
 
+/// Compact elapsed-time display: "5s ago", "3m ago", "2h ago".
+fn format_age(elapsed: std::time::Duration) -> String {
+    let s = elapsed.as_secs();
+    if s < 60 {
+        format!("{}s ago", s)
+    } else if s < 3600 {
+        format!("{}m ago", s / 60)
+    } else {
+        format!("{}h ago", s / 3600)
+    }
+}
+
 fn process_tree_value(lineage: &ProcessLineage, owner_name: &str, max_width: usize) -> String {
     let mut names: Vec<&str> = lineage
         .ancestors
@@ -864,12 +876,10 @@ pub(in crate::ui) fn draw_connection_details(
     );
     if conn.is_historic {
         let closed_display = if let Some(closed_at) = conn.closed_at {
-            let ago = closed_at.elapsed().unwrap_or_default();
-            if ago.as_secs() < 60 {
-                format!("Closed ({}s ago)", ago.as_secs())
-            } else {
-                format!("Closed ({}m ago)", ago.as_secs() / 60)
-            }
+            format!(
+                "Closed ({})",
+                format_age(closed_at.elapsed().unwrap_or_default())
+            )
         } else {
             "Closed".to_string()
         };
@@ -886,12 +896,10 @@ pub(in crate::ui) fn draw_connection_details(
         // user can see how recently traffic moved on this connection.
         // Color follows the same staleness progression as the Overview row
         // styling so the cue is consistent across views.
-        let ago = conn.last_activity.elapsed().unwrap_or_default();
-        let active_display = if ago.as_secs() < 60 {
-            format!("Active (last seen {}s ago)", ago.as_secs())
-        } else {
-            format!("Active (last seen {}m ago)", ago.as_secs() / 60)
-        };
+        let active_display = format!(
+            "Active (last seen {})",
+            format_age(conn.last_activity.elapsed().unwrap_or_default())
+        );
         let staleness = conn.staleness_ratio();
         let active_color = theme::expiry_glow_intensity(staleness)
             .map(theme::expiry_glow)
@@ -1082,16 +1090,7 @@ pub(in crate::ui) fn draw_connection_details(
                 .observed_at
                 .elapsed()
                 .ok()
-                .map(|d| {
-                    let s = d.as_secs();
-                    if s < 60 {
-                        format!("{}s ago", s)
-                    } else if s < 3600 {
-                        format!("{}m ago", s / 60)
-                    } else {
-                        format!("{}h ago", s / 3600)
-                    }
-                })
+                .map(format_age)
                 .unwrap_or_else(|| NONE_PLACEHOLDER.to_string());
             (format!("~{}", att.name), format!("{}, {}", source, age))
         }


### PR DESCRIPTION
The layout stability fix in #554 exempted ARP from the fixed row set, so Traffic Statistics and the cards below still jumped when moving between an ARP entry and its neighbors in the list. ARP now renders the same Network Context rows and Attribution card with "-" placeholders, and its MAC and hostname rows resolve from the neighbor cache and DNS resolver instead of being forced empty. The ARP test now asserts layout parity with a TCP record. Also adds gitignore rules for local GeoIP databases and packet captures.