### PR TITLE
refactor: workspace-wide dedup, dead code removal, and visibility narrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,15 +153,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guidance, instead of the TUI running on silently after capture stopped. The status
   bar grows a second row when the message and hint do not fit on one (#497)
 - **Rich Process Attribution**: `ProcessLookup::get_process_attribution()` returns a
-  `ProcessAttribution` carrying TGID, PPID, thread ID, effective UID/GID, executable
-  path, the producing backend, and a monotonic observation timestamp instead of
-  only `(pid, name)`. The new `MatchQuality` records how a connection was matched,
-  so a relaxed wildcard or listener guess is no longer indistinguishable from a proven
-  4-tuple hit. On Linux the eBPF backends carry the kernel-recorded identity through
-  unchanged and resolve `/proc/<tgid>/exe` in user space; the enhanced cache stores
-  the full result, so metadata and match quality survive the first lookup. Platforms
-  that only implement the legacy tuple API are bridged automatically, so
-  `get_process_for_connection()` keeps working everywhere (#505, #513)
+  `ProcessAttribution` carrying TGID, PPID, effective UID/GID, executable path,
+  process lineage, and match quality instead of only `(pid, name)`. `MatchQuality`
+  records how a connection was matched, so a relaxed wildcard or listener guess is
+  no longer indistinguishable from a proven 4-tuple hit. On Linux the eBPF backends
+  carry the kernel-recorded identity through unchanged and resolve process metadata
+  in user space; the enhanced cache stores the full result, so metadata and match
+  quality survive the first lookup. Every platform implements the rich lookup
+  directly (#505, #513)
 - **Process Identity, User, and Match Quality in the UI and Exports**: Connections now
   carry the owning process's PPID, executable path, effective UID/GID, and how
   confidently the attribution matched. The Attribution card in the Details pane
@@ -190,6 +189,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each socket-table refresh (#513)
 
 ### Changed
+- **Library Internals Deduplicated and Narrowed**: Removed remaining dead code
+  and test-only public API from the workspace crates, narrowed public items
+  with no external consumers to crate or module visibility (including
+  cfg-gated macOS and Windows internals the Linux lint pass could not see),
+  and deduplicated repeated logic: the four Windows socket-table refreshes,
+  the macOS/FreeBSD BPF privilege probe, PKTAP and lsof process-name
+  normalization, `ParsedPacket` construction, and the Details tab field
+  rendering (#556)
 - **Dead Library-Crate API Removed**: The workspace crates dropped public API
   nothing in the workspace uses: a never-compiling procfs-only module and
   write-only lookup statistics in `rustnet-host`, the unused thread-id and

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,36 @@
+//! Helpers shared by the criterion benches. Cargo treats every top-level
+//! `benches/*.rs` file as its own bench target, so shared code lives in this
+//! subdirectory and each bench pulls it in with `mod common;`.
+
+use rustnet_monitor::network::types::{Connection, Protocol, ProtocolState, TcpState};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+/// Create a Connection with a RateTracker filled to `n_samples` entries.
+/// `prune_every` sprinkles in `prune()` calls at the given interval to keep
+/// the tracker realistic; `None` skips pruning entirely.
+pub fn make_connection_with_samples(n_samples: usize, prune_every: Option<usize>) -> Connection {
+    let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321);
+    let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
+    let mut conn = Connection::new(
+        Protocol::Tcp,
+        local,
+        remote,
+        ProtocolState::Tcp(TcpState::Established),
+    );
+
+    // Simulate per-packet updates to fill the rate tracker with samples
+    for i in 0..n_samples {
+        conn.bytes_sent += 100;
+        conn.bytes_received += 200;
+        conn.rate_tracker
+            .update(conn.bytes_sent, conn.bytes_received);
+        conn.packets_sent += 1;
+        conn.packets_received += 1;
+        if let Some(every) = prune_every
+            && i % every == 0
+        {
+            conn.rate_tracker.prune();
+        }
+    }
+    conn
+}

--- a/benches/connection_merge.rs
+++ b/benches/connection_merge.rs
@@ -1,61 +1,42 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use rustnet_monitor::network::merge::merge_packet_into_connection;
+use rustnet_core::network::merge::merge_packet_into_connection;
 use rustnet_monitor::network::parser::{TcpFlags, TcpHeaderInfo};
 use rustnet_monitor::network::types::*;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::SystemTime;
 
+mod common;
+
 /// Create a Connection with a RateTracker filled to `n_samples` entries.
 fn make_connection_with_samples(n_samples: usize) -> Connection {
-    let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321);
-    let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
-    let mut conn = Connection::new(
-        Protocol::Tcp,
-        local,
-        remote,
-        ProtocolState::Tcp(TcpState::Established),
-    );
-
-    // Simulate rate tracker updates to fill it with samples
-    for _ in 0..n_samples {
-        conn.bytes_sent += 100;
-        conn.bytes_received += 200;
-        conn.rate_tracker
-            .update(conn.bytes_sent, conn.bytes_received);
-        conn.packets_sent += 1;
-        conn.packets_received += 1;
-    }
-    conn
+    common::make_connection_with_samples(n_samples, None)
 }
 
 /// Create a minimal ParsedPacket for merge benchmarking.
 fn make_parsed_packet() -> rustnet_monitor::network::parser::ParsedPacket {
-    rustnet_monitor::network::parser::ParsedPacket {
-        protocol: Protocol::Tcp,
-        local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321),
-        remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
-        local_addr_kind: AddrKind::Unicast,
-        remote_addr_kind: AddrKind::Unicast,
-        remote_is_gateway: false,
-        tcp_header: Some(TcpHeaderInfo {
-            seq: 1000,
-            ack: 2000,
-            window: 65535,
-            flags: TcpFlags {
-                syn: false,
-                ack: true,
-                fin: false,
-                rst: false,
-            },
-            payload_len: 1400,
-        }),
-        protocol_state: ProtocolState::Tcp(TcpState::Established),
-        is_outgoing: true,
-        packet_len: 1400,
-        dpi_result: None,
-        process_name: None,
-        process_id: None,
-    }
+    let mut packet = rustnet_monitor::network::parser::ParsedPacket::new(
+        Protocol::Tcp,
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443),
+        ProtocolState::Tcp(TcpState::Established),
+        true,
+        1400,
+        None,
+        None,
+    );
+    packet.tcp_header = Some(TcpHeaderInfo {
+        seq: 1000,
+        ack: 2000,
+        window: 65535,
+        flags: TcpFlags {
+            syn: false,
+            ack: true,
+            fin: false,
+            rst: false,
+        },
+        payload_len: 1400,
+    });
+    packet
 }
 
 fn bench_merge(c: &mut Criterion) {

--- a/benches/rate_tracker.rs
+++ b/benches/rate_tracker.rs
@@ -1,29 +1,12 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use rustnet_monitor::network::types::*;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use rustnet_monitor::network::types::Connection;
 
-/// Create a Connection with a RateTracker filled to `n_samples` entries.
+mod common;
+
+/// Create a Connection with `n` rate samples, pruning periodically to keep
+/// the tracker realistic.
 fn make_connection_with_samples(n_samples: usize) -> Connection {
-    let local = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321);
-    let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
-    let mut conn = Connection::new(
-        Protocol::Tcp,
-        local,
-        remote,
-        ProtocolState::Tcp(TcpState::Established),
-    );
-
-    for i in 0..n_samples {
-        conn.bytes_sent += 100;
-        conn.bytes_received += 200;
-        conn.rate_tracker
-            .update(conn.bytes_sent, conn.bytes_received);
-        // Sprinkle in some pruning to keep the tracker realistic
-        if i % 500 == 0 {
-            conn.rate_tracker.prune();
-        }
-    }
-    conn
+    common::make_connection_with_samples(n_samples, Some(500))
 }
 
 /// Benchmark the per-packet `update()` call on RateTracker.

--- a/benches/tracker_ingest.rs
+++ b/benches/tracker_ingest.rs
@@ -12,32 +12,29 @@ use std::time::SystemTime;
 fn make_packet(flow: u16, seq: u32) -> ParsedPacket {
     let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 10000 + flow);
     let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
-    ParsedPacket {
-        protocol: Protocol::Tcp,
+    let mut packet = ParsedPacket::new(
+        Protocol::Tcp,
         local_addr,
         remote_addr,
-        local_addr_kind: AddrKind::Unicast,
-        remote_addr_kind: AddrKind::Unicast,
-        remote_is_gateway: false,
-        tcp_header: Some(TcpHeaderInfo {
-            seq,
-            ack: seq.wrapping_add(1),
-            window: 65535,
-            flags: TcpFlags {
-                syn: false,
-                ack: true,
-                fin: false,
-                rst: false,
-            },
-            payload_len: 1400,
-        }),
-        protocol_state: ProtocolState::Tcp(TcpState::Established),
-        is_outgoing: true,
-        packet_len: 1400,
-        dpi_result: None,
-        process_name: None,
-        process_id: None,
-    }
+        ProtocolState::Tcp(TcpState::Established),
+        true,
+        1400,
+        None,
+        None,
+    );
+    packet.tcp_header = Some(TcpHeaderInfo {
+        seq,
+        ack: seq.wrapping_add(1),
+        window: 65535,
+        flags: TcpFlags {
+            syn: false,
+            ack: true,
+            fin: false,
+            rst: false,
+        },
+        payload_len: 1400,
+    });
+    packet
 }
 
 /// Interleaved packet stream: `flows` connections sending `packets_per_flow`

--- a/crates/rustnet-capture/src/lib.rs
+++ b/crates/rustnet-capture/src/lib.rs
@@ -565,12 +565,12 @@ pub struct CaptureStats {
     pub received: u32,
     pub dropped: u32,
     /// Interface-level dropped packets (platform-specific)
-    pub if_dropped: u32,
+    pub(crate) if_dropped: u32,
 }
 
 impl CaptureStats {
     /// Get total packets dropped (both kernel and interface level)
-    pub fn total_dropped(&self) -> u32 {
+    pub(crate) fn total_dropped(&self) -> u32 {
         self.dropped.saturating_add(self.if_dropped)
     }
 }
@@ -584,24 +584,5 @@ mod tests {
         let config = CaptureConfig::default();
         assert_eq!(config.snaplen, 1514);
         assert!(config.filter.is_none()); // Default starts without filter
-    }
-
-    #[test]
-    fn test_udp_routing_resolution_can_execute() {
-        // Sanity-check test to ensure the OS handles UDP metric routing cleanly.
-        // It's perfectly fine if this fails in hermetic CI environments without outbound routes.
-        if let Ok(socket) = std::net::UdpSocket::bind("0.0.0.0:0")
-            && socket.connect("8.8.8.8:53").is_ok()
-            && let Ok(addr) = socket.local_addr()
-        {
-            assert!(
-                !addr.ip().is_loopback(),
-                "Active routed IP should not be loopback"
-            );
-            assert!(
-                !addr.ip().is_unspecified(),
-                "Active routed IP should not be unspecified"
-            );
-        }
     }
 }

--- a/crates/rustnet-core/src/network/dns.rs
+++ b/crates/rustnet-core/src/network/dns.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 
 /// Resolution state for a cached entry
 #[derive(Debug, Clone, PartialEq)]
-pub enum ResolutionState {
+pub(crate) enum ResolutionState {
     /// Resolution is in progress
     Pending,
     /// Resolution succeeded
@@ -26,7 +26,7 @@ pub enum ResolutionState {
 
 /// Cached hostname entry
 #[derive(Debug, Clone)]
-pub struct CachedHostname {
+pub(crate) struct CachedHostname {
     /// The resolved hostname, if successful
     pub hostname: Option<String>,
     /// When this entry was resolved
@@ -63,7 +63,7 @@ impl CachedHostname {
 
 /// Configuration for DNS resolver
 #[derive(Debug, Clone)]
-pub struct DnsResolverConfig {
+pub(crate) struct DnsResolverConfig {
     /// Cache TTL for resolved hostnames (default: 5 minutes)
     pub cache_ttl: Duration,
     /// Cache TTL for failed lookups (default: 1 minute)
@@ -99,7 +99,7 @@ pub struct DnsResolver {
 
 impl DnsResolver {
     /// Create a new DNS resolver with the given configuration
-    pub fn new(config: DnsResolverConfig) -> Self {
+    pub(crate) fn new(config: DnsResolverConfig) -> Self {
         let cache = Arc::new(DashMap::new());
         let (request_tx, request_rx) = channel::unbounded();
         let should_stop = Arc::new(AtomicBool::new(false));

--- a/crates/rustnet-core/src/network/dns_attribution.rs
+++ b/crates/rustnet-core/src/network/dns_attribution.rs
@@ -38,16 +38,16 @@ const MAX_DOMAINS_PER_IP: usize = 4;
 /// it waits for matching DNS for at most this long. 10s matches Little
 /// Snitch's `MAX_QUERY_AGE` and is tight enough to keep CDN-IP
 /// collisions rare.
-pub const DEFAULT_FRESH_WINDOW: Duration = Duration::from_secs(10);
+pub(crate) const DEFAULT_FRESH_WINDOW: Duration = Duration::from_secs(10);
 
 /// Default retention window: entries past this are eligible for
 /// pruning. Kept longer than `fresh_window` so debug accessors / detail
 /// views can show recently-seen-but-not-fresh names if we ever want
 /// them; lookups won't return these for attribution.
-pub const DEFAULT_RETENTION: Duration = Duration::from_secs(600);
+pub(crate) const DEFAULT_RETENTION: Duration = Duration::from_secs(600);
 
 /// Default cap on tracked IPs.
-pub const DEFAULT_MAX_ENTRIES: usize = 8192;
+pub(crate) const DEFAULT_MAX_ENTRIES: usize = 8192;
 
 /// Cap on the number of connection keys that may wait on the same IP
 /// for attribution. Bounds memory if many simultaneous connections to a
@@ -56,7 +56,7 @@ const MAX_PENDING_PER_IP: usize = 256;
 
 /// One observed (domain, when, source) tuple for an IP.
 #[derive(Debug, Clone)]
-pub struct AttributedDomain {
+pub(crate) struct AttributedDomain {
     pub domain: String,
     pub observed_at: Instant,
     pub source: AttributionSource,
@@ -80,7 +80,7 @@ struct PendingEntry {
 ///
 /// All access is concurrent (DashMap), no outer lock required.
 #[derive(Debug)]
-pub struct DnsAttributionCache {
+pub(crate) struct DnsAttributionCache {
     map: DashMap<IpAddr, Vec<AttributedDomain>>,
     /// IP -> connection keys waiting on a DNS resolution for that IP.
     /// Entries are added by `attribute()` on a cache miss and drained
@@ -104,7 +104,7 @@ impl Default for DnsAttributionCache {
 }
 
 impl DnsAttributionCache {
-    pub fn new(max_entries: usize, fresh_window: Duration, retention: Duration) -> Self {
+    pub(crate) fn new(max_entries: usize, fresh_window: Duration, retention: Duration) -> Self {
         Self {
             map: DashMap::new(),
             pending: DashMap::new(),
@@ -121,7 +121,7 @@ impl DnsAttributionCache {
     /// in place: if the same domain is already present its timestamp is
     /// refreshed, otherwise the new entry is pushed and the per-IP list
     /// is trimmed to `MAX_DOMAINS_PER_IP` keeping the most recent.
-    pub fn record(&self, query_name: &str, ips: &[IpAddr], source: AttributionSource) {
+    pub(crate) fn record(&self, query_name: &str, ips: &[IpAddr], source: AttributionSource) {
         let domain = query_name.trim().trim_end_matches('.');
         if domain.is_empty() || ips.is_empty() {
             return;
@@ -178,7 +178,7 @@ impl DnsAttributionCache {
     /// older than `retention`. The boolean is `true` when the freshest
     /// entry is within `fresh_window` (and therefore trustworthy enough
     /// to attribute a new connection to).
-    pub fn lookup(&self, ip: IpAddr) -> Option<(AttributedDomain, bool)> {
+    pub(crate) fn lookup(&self, ip: IpAddr) -> Option<(AttributedDomain, bool)> {
         let entries = self.map.get(&ip)?;
         let now = Instant::now();
         let freshest = entries
@@ -214,7 +214,7 @@ impl DnsAttributionCache {
     ///   / local-discovery protocol (DNS, mDNS, LLMNR, DHCP, SSDP,
     ///   NetBIOS). Attribution is either nonsensical (the protocol
     ///   *is* the name lookup) or useless (broadcast / multicast).
-    pub fn attribute(&self, conn: &mut Connection, key: ConnectionKey) {
+    pub(crate) fn attribute(&self, conn: &mut Connection, key: ConnectionKey) {
         if conn.protocol == Protocol::Arp || conn.attributed_hostname.is_some() {
             return;
         }
@@ -274,7 +274,7 @@ impl DnsAttributionCache {
     /// Remove a connection key from the pending index. Called on
     /// connection cleanup so dead keys don't linger when the connection
     /// dies before any DNS response arrives.
-    pub fn forget_pending(&self, ip: IpAddr, conn_key: ConnectionKey) {
+    pub(crate) fn forget_pending(&self, ip: IpAddr, conn_key: ConnectionKey) {
         let now_empty = self.pending.get_mut(&ip).map(|mut entry| {
             entry.retain(|e| e.conn_key != conn_key);
             entry.is_empty()
@@ -289,7 +289,7 @@ impl DnsAttributionCache {
     /// waiting on any of those IPs. Stale enrollments are dropped on
     /// the floor so a brand-new DNS resolution can't retroactively
     /// label a long-running connection.
-    pub fn record_and_drain_pending(
+    pub(crate) fn record_and_drain_pending(
         &self,
         query_name: &str,
         ips: &[IpAddr],
@@ -316,7 +316,7 @@ impl DnsAttributionCache {
     /// Drop pending enrollments older than `fresh_window`. Intended to
     /// be called from a periodic cleanup tick so memory doesn't
     /// accumulate when DNS for an enrolled IP never arrives.
-    pub fn prune_pending(&self, now: Instant) {
+    pub(crate) fn prune_pending(&self, now: Instant) {
         self.pending.retain(|_ip, entries| {
             entries.retain(|e| now.saturating_duration_since(e.enrolled_at) <= self.fresh_window);
             !entries.is_empty()
@@ -326,7 +326,7 @@ impl DnsAttributionCache {
     /// Combined periodic maintenance: prune the IP -> domain map and the
     /// pending index. Cheap; intended to be called once per cleanup
     /// thread tick.
-    pub fn cleanup_tick(&self, now: Instant) {
+    pub(crate) fn cleanup_tick(&self, now: Instant) {
         self.prune(now);
         self.prune_pending(now);
     }
@@ -336,7 +336,7 @@ impl DnsAttributionCache {
     /// watermark below the cap, leaving headroom so the emergency prune
     /// in `record()` doesn't re-run the full-map pass on every
     /// subsequent insertion.
-    pub fn prune(&self, now: Instant) {
+    pub(crate) fn prune(&self, now: Instant) {
         // First, drop expired domains within each IP, and IPs that end up empty.
         self.map.retain(|_ip, entries| {
             entries.retain(|d| now.saturating_duration_since(d.observed_at) <= self.retention);
@@ -375,17 +375,10 @@ impl DnsAttributionCache {
     }
 
     /// Drop everything: the IP -> domain map and the pending index.
-    pub fn clear(&self) {
+    pub(crate) fn clear(&self) {
         self.map.clear();
         self.pending.clear();
         self.map_len.store(0, Ordering::Relaxed);
-    }
-
-    /// Number of IPs with waiting enrollments; test-only visibility for
-    /// the tracker's pending-lifecycle tests.
-    #[cfg(test)]
-    pub(crate) fn pending_len(&self) -> usize {
-        self.pending.len()
     }
 }
 
@@ -427,7 +420,8 @@ fn to_attributed_hostname(att: AttributedDomain) -> AttributedHostname {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::Ipv4Addr;
+    use crate::network::types::{Protocol, ProtocolState, TcpState};
+    use std::net::{Ipv4Addr, SocketAddr};
     use std::thread::sleep;
 
     fn ip(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
@@ -436,6 +430,15 @@ mod tests {
 
     fn key_of(conn: &Connection) -> ConnectionKey {
         ConnectionKey::new(conn.protocol, conn.local_addr, conn.remote_addr)
+    }
+
+    fn tcp_connection() -> Connection {
+        Connection::new(
+            Protocol::Tcp,
+            "192.168.1.10:54321".parse().unwrap(),
+            "1.2.3.4:443".parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Established),
+        )
     }
 
     #[test]
@@ -565,9 +568,6 @@ mod tests {
 
     #[test]
     fn attribute_tags_fresh_connection() {
-        use crate::network::types::{Protocol, ProtocolState};
-        use std::net::SocketAddr;
-
         let cache = DnsAttributionCache::default();
         cache.record(
             "youtube.com",
@@ -588,9 +588,6 @@ mod tests {
 
     #[test]
     fn attribute_stamps_dns_observation_time() {
-        use crate::network::types::{Protocol, ProtocolState};
-        use std::net::SocketAddr;
-
         let cache = DnsAttributionCache::default();
         cache.record("foo.com", &[ip(1, 2, 3, 4)], AttributionSource::CapturedDns);
         sleep(Duration::from_millis(50));
@@ -610,20 +607,10 @@ mod tests {
 
     #[test]
     fn attribute_first_write_wins() {
-        use crate::network::types::{Protocol, ProtocolState};
-        use std::net::SocketAddr;
-
         let cache = DnsAttributionCache::default();
         cache.record("a.com", &[ip(1, 2, 3, 4)], AttributionSource::CapturedDns);
 
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(crate::network::types::TcpState::Established),
-        );
+        let mut conn = tcp_connection();
 
         let key = key_of(&conn);
         cache.attribute(&mut conn, key);
@@ -636,11 +623,7 @@ mod tests {
 
     #[test]
     fn attribute_skips_dns_self_attribution() {
-        use crate::network::types::{
-            ApplicationProtocol, DnsInfo, DpiInfo, Protocol, ProtocolState,
-        };
-        use std::net::SocketAddr;
-        use std::time::Instant;
+        use crate::network::types::{ApplicationProtocol, DnsInfo, DpiInfo};
 
         let cache = DnsAttributionCache::default();
         cache.record(
@@ -662,7 +645,6 @@ mod tests {
                 rcode: None,
                 nodata: None,
             }),
-            last_update_time: Instant::now(),
         });
 
         let key = key_of(&conn);
@@ -677,11 +659,8 @@ mod tests {
     fn attribute_skips_local_discovery_protocols() {
         use crate::network::types::{
             ApplicationProtocol, DhcpInfo, DhcpMessageType, DpiInfo, LlmnrInfo, MdnsInfo,
-            NetBiosInfo, NetBiosOpcode, NetBiosService, Protocol, ProtocolState, SsdpInfo,
-            SsdpMethod,
+            NetBiosInfo, NetBiosOpcode, NetBiosService, SsdpInfo, SsdpMethod,
         };
-        use std::net::SocketAddr;
-        use std::time::Instant;
 
         let cache = DnsAttributionCache::default();
         cache.record(
@@ -694,10 +673,7 @@ mod tests {
         let remote: SocketAddr = "1.2.3.4:5353".parse().unwrap();
         let make_conn = |app: ApplicationProtocol| {
             let mut c = Connection::new(Protocol::Udp, local, remote, ProtocolState::Udp);
-            c.dpi_info = Some(DpiInfo {
-                application: app,
-                last_update_time: Instant::now(),
-            });
+            c.dpi_info = Some(DpiInfo { application: app });
             c
         };
 
@@ -763,11 +739,7 @@ mod tests {
 
     #[test]
     fn attribute_skips_when_sni_present() {
-        use crate::network::types::{
-            ApplicationProtocol, DpiInfo, HttpsInfo, Protocol, ProtocolState, TcpState, TlsInfo,
-        };
-        use std::net::SocketAddr;
-        use std::time::Instant;
+        use crate::network::types::{ApplicationProtocol, DpiInfo, HttpsInfo, TlsInfo};
 
         let cache = DnsAttributionCache::default();
         cache.record(
@@ -776,14 +748,7 @@ mod tests {
             AttributionSource::CapturedDns,
         );
 
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = tcp_connection();
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Https(HttpsInfo {
                 tls_info: Some(TlsInfo {
@@ -793,7 +758,6 @@ mod tests {
                     cipher_suite: None,
                 }),
             }),
-            last_update_time: Instant::now(),
         });
 
         let key = key_of(&conn);
@@ -806,11 +770,7 @@ mod tests {
 
     #[test]
     fn attribute_proceeds_when_sni_partial() {
-        use crate::network::types::{
-            ApplicationProtocol, DpiInfo, HttpsInfo, Protocol, ProtocolState, TcpState, TlsInfo,
-        };
-        use std::net::SocketAddr;
-        use std::time::Instant;
+        use crate::network::types::{ApplicationProtocol, DpiInfo, HttpsInfo, TlsInfo};
 
         let cache = DnsAttributionCache::default();
         cache.record(
@@ -819,14 +779,7 @@ mod tests {
             AttributionSource::CapturedDns,
         );
 
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = tcp_connection();
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Https(HttpsInfo {
                 tls_info: Some(TlsInfo {
@@ -836,7 +789,6 @@ mod tests {
                     cipher_suite: None,
                 }),
             }),
-            last_update_time: Instant::now(),
         });
 
         let key = key_of(&conn);
@@ -850,9 +802,6 @@ mod tests {
 
     #[test]
     fn attribute_skips_when_not_fresh() {
-        use crate::network::types::{Protocol, ProtocolState};
-        use std::net::SocketAddr;
-
         let cache = DnsAttributionCache::new(
             DEFAULT_MAX_ENTRIES,
             Duration::from_millis(10),
@@ -861,14 +810,7 @@ mod tests {
         cache.record("foo.com", &[ip(1, 2, 3, 4)], AttributionSource::CapturedDns);
         sleep(Duration::from_millis(40));
 
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(crate::network::types::TcpState::Established),
-        );
+        let mut conn = tcp_connection();
 
         let key = key_of(&conn);
         cache.attribute(&mut conn, key);
@@ -880,20 +822,10 @@ mod tests {
 
     #[test]
     fn attribute_enrolls_on_miss_then_drain_attributes() {
-        use crate::network::types::{Protocol, ProtocolState, TcpState};
-        use std::net::SocketAddr;
-
         let cache = DnsAttributionCache::default();
 
         // Connection happens first; cache is empty, so enroll in pending.
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = tcp_connection();
         let key = key_of(&conn);
         cache.attribute(&mut conn, key);
         assert!(conn.attributed_hostname.is_none());
@@ -923,18 +855,8 @@ mod tests {
 
     #[test]
     fn forget_pending_clears_dead_keys() {
-        use crate::network::types::{Protocol, ProtocolState, TcpState};
-        use std::net::SocketAddr;
-
         let cache = DnsAttributionCache::default();
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = tcp_connection();
         let key = key_of(&conn);
         cache.attribute(&mut conn, key);
         assert_eq!(cache.pending.len(), 1);
@@ -956,20 +878,10 @@ mod tests {
 
     #[test]
     fn pending_ttl_drops_expired_enrollments_on_drain() {
-        use crate::network::types::{Protocol, ProtocolState, TcpState};
-        use std::net::SocketAddr;
-
         // Backdate the enrollment via direct field surgery so we don't
         // have to actually sleep for `fresh_window`.
         let cache = DnsAttributionCache::default();
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = tcp_connection();
         let key = key_of(&conn);
         cache.attribute(&mut conn, key);
         // Backdate the enrollment past `fresh_window`.
@@ -989,18 +901,8 @@ mod tests {
 
     #[test]
     fn prune_pending_drops_expired_enrollments() {
-        use crate::network::types::{Protocol, ProtocolState, TcpState};
-        use std::net::SocketAddr;
-
         let cache = DnsAttributionCache::default();
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = tcp_connection();
         let key = key_of(&conn);
         cache.attribute(&mut conn, key);
         assert_eq!(cache.pending.len(), 1);
@@ -1016,18 +918,8 @@ mod tests {
 
     #[test]
     fn enroll_pending_dedupes_same_key() {
-        use crate::network::types::{Protocol, ProtocolState, TcpState};
-        use std::net::SocketAddr;
-
         let cache = DnsAttributionCache::default();
-        let local: SocketAddr = "192.168.1.10:54321".parse().unwrap();
-        let remote: SocketAddr = "1.2.3.4:443".parse().unwrap();
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            local,
-            remote,
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = tcp_connection();
         let key = key_of(&conn);
         for _ in 0..5 {
             cache.attribute(&mut conn, key);

--- a/crates/rustnet-core/src/network/dpi/bittorrent.rs
+++ b/crates/rustnet-core/src/network/dpi/bittorrent.rs
@@ -22,12 +22,12 @@ const MAX_DHT_METHOD_LEN: usize = 64;
 // --- TCP: Peer Handshake ---
 
 /// Check if the payload starts with a BitTorrent peer handshake.
-pub fn is_bittorrent_handshake(payload: &[u8]) -> bool {
+pub(super) fn is_bittorrent_handshake(payload: &[u8]) -> bool {
     payload.starts_with(BT_HANDSHAKE_PREFIX)
 }
 
 /// Analyze a BitTorrent TCP handshake payload and extract protocol details.
-pub fn analyze_bittorrent(payload: &[u8]) -> Option<BitTorrentInfo> {
+pub(super) fn analyze_bittorrent(payload: &[u8]) -> Option<BitTorrentInfo> {
     if !is_bittorrent_handshake(payload) {
         return None;
     }
@@ -71,7 +71,7 @@ pub fn analyze_bittorrent(payload: &[u8]) -> Option<BitTorrentInfo> {
 
 /// Analyze a UDP payload for BitTorrent DHT or uTP traffic.
 /// Tries DHT first (higher confidence), then uTP.
-pub fn analyze_udp_bittorrent(payload: &[u8]) -> Option<BitTorrentInfo> {
+pub(super) fn analyze_udp_bittorrent(payload: &[u8]) -> Option<BitTorrentInfo> {
     if let Some(info) = analyze_dht(payload) {
         return Some(info);
     }

--- a/crates/rustnet-core/src/network/dpi/cipher_suites.rs
+++ b/crates/rustnet-core/src/network/dpi/cipher_suites.rs
@@ -105,7 +105,7 @@ static CIPHER_SUITE_MAP: LazyLock<HashMap<u16, &'static str>> = LazyLock::new(||
 /// # Returns
 /// * Some(name) if the cipher suite is known
 /// * None if the cipher suite is not in our mapping
-pub fn get_cipher_suite_name(code: u16) -> Option<&'static str> {
+pub(super) fn get_cipher_suite_name(code: u16) -> Option<&'static str> {
     CIPHER_SUITE_MAP.get(&code).copied()
 }
 

--- a/crates/rustnet-core/src/network/dpi/dhcp.rs
+++ b/crates/rustnet-core/src/network/dpi/dhcp.rs
@@ -19,7 +19,7 @@ const DHCP_OPT_END: u8 = 255;
 /// Analyze a DHCP packet and extract key information.
 ///
 /// Returns `None` if the packet is too small or doesn't have the DHCP magic cookie.
-pub fn analyze_dhcp(payload: &[u8]) -> Option<DhcpInfo> {
+pub(super) fn analyze_dhcp(payload: &[u8]) -> Option<DhcpInfo> {
     // Early size check
     if payload.len() < MIN_DHCP_SIZE {
         return None;

--- a/crates/rustnet-core/src/network/dpi/dns.rs
+++ b/crates/rustnet-core/src/network/dpi/dns.rs
@@ -305,12 +305,11 @@ pub(super) fn parse_questions_starting_at_header(
     (query_name, query_type, offset)
 }
 
-pub fn analyze_dns(payload: &[u8]) -> Option<DnsInfo> {
+fn parse_dns_base(payload: &[u8]) -> Option<(DnsHeaderCounts, DnsInfo, usize)> {
     let header = dns_header_counts(payload)?;
-    let (query_name, query_type, mut offset) =
+    let (query_name, query_type, offset) =
         parse_questions_starting_at_header(payload, header.qdcount);
-
-    let mut info = DnsInfo {
+    let info = DnsInfo {
         query_name,
         query_type,
         response_ips: Vec::new(),
@@ -319,6 +318,11 @@ pub fn analyze_dns(payload: &[u8]) -> Option<DnsInfo> {
         rcode: header.is_response.then_some(header.rcode),
         nodata: None,
     };
+    Some((header, info, offset))
+}
+
+pub(super) fn analyze_dns(payload: &[u8]) -> Option<DnsInfo> {
+    let (header, mut info, mut offset) = parse_dns_base(payload)?;
 
     // Answer-section walk for A / AAAA records. Only runs on responses
     // (QR bit set), since `DnsInfo.response_ips` is only meaningful for
@@ -366,22 +370,11 @@ pub fn analyze_dns(payload: &[u8]) -> Option<DnsInfo> {
 /// answers / additionals, no questions). The DNS / LLMNR path keeps the
 /// stricter behaviour because their responses always echo the question.
 pub(super) fn analyze_dns_for_mdns(payload: &[u8]) -> Option<DnsInfo> {
-    let header = dns_header_counts(payload)?;
-    let (query_name, query_type, mut offset) =
-        parse_questions_starting_at_header(payload, header.qdcount);
+    let (header, mut info, mut offset) = parse_dns_base(payload)?;
 
-    let mut info = DnsInfo {
-        query_name,
-        query_type,
-        response_ips: Vec::new(),
-        is_response: header.is_response,
-        txid: header.txid,
-        rcode: header.is_response.then_some(header.rcode),
-        // NODATA is a unicast-DNS concept; mDNS negative responses use NSEC
-        // (RFC 6762 §6.1) and announcements carry no question to compare
-        // against, so the flag stays unset on this path.
-        nodata: None,
-    };
+    // NODATA is a unicast-DNS concept; mDNS negative responses use NSEC
+    // (RFC 6762 §6.1) and announcements carry no question to compare
+    // against, so the flag stays unset on this path.
 
     if header.is_response {
         let mut matched = 0;

--- a/crates/rustnet-core/src/network/dpi/ftp.rs
+++ b/crates/rustnet-core/src/network/dpi/ftp.rs
@@ -47,7 +47,7 @@ const FTP_DISTINCTIVE_COMMANDS: &[&str] = &[
 /// grammar is shared verbatim by SMTP, POP3-era protocols, and NNTP, so
 /// off port 21 a reply line carries no FTP signal. Replies are still parsed
 /// by [`analyze_ftp`] on the port-21 path.
-pub fn is_ftp(payload: &[u8]) -> bool {
+pub(super) fn is_ftp(payload: &[u8]) -> bool {
     let line = first_line(payload);
     if line.is_empty() {
         return false;
@@ -63,7 +63,7 @@ pub fn is_ftp(payload: &[u8]) -> bool {
 
 /// Parse an FTP control-channel payload. Returns `None` when the payload does
 /// not look like FTP.
-pub fn analyze_ftp(payload: &[u8]) -> Option<FtpInfo> {
+pub(super) fn analyze_ftp(payload: &[u8]) -> Option<FtpInfo> {
     let line = first_line(payload);
     if line.is_empty() {
         return None;

--- a/crates/rustnet-core/src/network/dpi/http.rs
+++ b/crates/rustnet-core/src/network/dpi/http.rs
@@ -1,7 +1,7 @@
 use crate::network::types::{HttpInfo, HttpVersion};
 
 /// Analyze payload for HTTP protocol
-pub fn analyze_http(payload: &[u8]) -> Option<HttpInfo> {
+pub(super) fn analyze_http(payload: &[u8]) -> Option<HttpInfo> {
     if !is_likely_http(payload) {
         return None;
     }

--- a/crates/rustnet-core/src/network/dpi/https.rs
+++ b/crates/rustnet-core/src/network/dpi/https.rs
@@ -2,7 +2,7 @@ use super::tls_common::{self, TlsParseOptions};
 use crate::network::types::{HttpsInfo, TlsInfo};
 use log::debug;
 
-pub fn is_tls_handshake(payload: &[u8]) -> bool {
+pub(super) fn is_tls_handshake(payload: &[u8]) -> bool {
     if payload.len() < 5 {
         return false;
     }
@@ -16,7 +16,7 @@ pub fn is_tls_handshake(payload: &[u8]) -> bool {
         (payload[2] >= 0x01 && payload[2] <= 0x04) // Minor version 1-4
 }
 
-pub fn analyze_https(payload: &[u8]) -> Option<HttpsInfo> {
+pub(super) fn analyze_https(payload: &[u8]) -> Option<HttpsInfo> {
     // Need at least 5 bytes for the TLS record header
     if payload.len() < 5 {
         return None;

--- a/crates/rustnet-core/src/network/dpi/llmnr.rs
+++ b/crates/rustnet-core/src/network/dpi/llmnr.rs
@@ -11,7 +11,7 @@ use super::dns;
 ///
 /// LLMNR uses the same packet format as DNS, so we reuse the DNS parser.
 /// Returns `None` if the packet cannot be parsed as DNS.
-pub fn analyze_llmnr(payload: &[u8]) -> Option<LlmnrInfo> {
+pub(super) fn analyze_llmnr(payload: &[u8]) -> Option<LlmnrInfo> {
     // Reuse DNS parser - LLMNR has the same wire format
     dns::analyze_dns(payload).map(LlmnrInfo::from)
 }

--- a/crates/rustnet-core/src/network/dpi/mdns.rs
+++ b/crates/rustnet-core/src/network/dpi/mdns.rs
@@ -15,7 +15,7 @@ use super::dns;
 /// ADDITIONAL records, where mDNS frequently carries A / AAAA rdata.
 ///
 /// Returns `None` if the packet cannot be parsed as DNS.
-pub fn analyze_mdns(payload: &[u8]) -> Option<MdnsInfo> {
+pub(super) fn analyze_mdns(payload: &[u8]) -> Option<MdnsInfo> {
     dns::analyze_dns_for_mdns(payload).map(MdnsInfo::from)
 }
 

--- a/crates/rustnet-core/src/network/dpi/mod.rs
+++ b/crates/rustnet-core/src/network/dpi/mod.rs
@@ -20,9 +20,9 @@ mod ssh;
 mod stun;
 mod tls_common;
 
-pub use cipher_suites::{format_cipher_suite, is_secure_cipher_suite};
-pub use quic::try_extract_tls_from_reassembler;
-pub use tls_common::is_partial_sni;
+pub(crate) use cipher_suites::{format_cipher_suite, is_secure_cipher_suite};
+pub(crate) use quic::try_extract_tls_from_reassembler;
+pub(crate) use tls_common::is_partial_sni;
 
 // Well-known port numbers used for DPI protocol detection.
 const PORT_SSH: u16 = 22;
@@ -50,7 +50,7 @@ pub struct DpiResult {
 }
 
 /// Analyze a TCP packet payload
-pub fn analyze_tcp_packet(
+pub(crate) fn analyze_tcp_packet(
     payload: &[u8],
     local_port: u16,
     remote_port: u16,
@@ -128,7 +128,7 @@ pub fn analyze_tcp_packet(
 }
 
 /// Analyze a UDP packet payload
-pub fn analyze_udp_packet(
+pub(crate) fn analyze_udp_packet(
     payload: &[u8],
     local_port: u16,
     remote_port: u16,

--- a/crates/rustnet-core/src/network/dpi/mqtt.rs
+++ b/crates/rustnet-core/src/network/dpi/mqtt.rs
@@ -2,7 +2,7 @@ use crate::network::types::{MqttInfo, MqttPacketType, MqttVersion};
 use log::debug;
 
 /// Quick check if payload looks like an MQTT packet.
-pub fn is_mqtt_packet(payload: &[u8]) -> bool {
+pub(super) fn is_mqtt_packet(payload: &[u8]) -> bool {
     if payload.len() < 2 {
         return false;
     }
@@ -51,7 +51,7 @@ pub fn is_mqtt_packet(payload: &[u8]) -> bool {
 }
 
 /// Full MQTT packet analysis.
-pub fn analyze_mqtt(payload: &[u8]) -> Option<MqttInfo> {
+pub(super) fn analyze_mqtt(payload: &[u8]) -> Option<MqttInfo> {
     if payload.len() < 2 {
         return None;
     }

--- a/crates/rustnet-core/src/network/dpi/netbios.rs
+++ b/crates/rustnet-core/src/network/dpi/netbios.rs
@@ -19,7 +19,7 @@ const NBDGM_ERROR_SIZE: usize = 11;
 /// Analyze a NetBIOS Name Service packet (UDP port 137).
 ///
 /// Returns `None` if the packet is too small or invalid.
-pub fn analyze_netbios_ns(payload: &[u8]) -> Option<NetBiosInfo> {
+pub(super) fn analyze_netbios_ns(payload: &[u8]) -> Option<NetBiosInfo> {
     if payload.len() < MIN_NBNS_SIZE {
         return None;
     }
@@ -60,7 +60,7 @@ pub fn analyze_netbios_ns(payload: &[u8]) -> Option<NetBiosInfo> {
 /// Analyze a NetBIOS Datagram Service packet (UDP port 138).
 ///
 /// Returns `None` if the packet is too small or invalid.
-pub fn analyze_netbios_dgm(payload: &[u8]) -> Option<NetBiosInfo> {
+pub(super) fn analyze_netbios_dgm(payload: &[u8]) -> Option<NetBiosInfo> {
     // Message type at byte 0
     let msg_type = *payload.first()?;
 

--- a/crates/rustnet-core/src/network/dpi/ntp.rs
+++ b/crates/rustnet-core/src/network/dpi/ntp.rs
@@ -11,7 +11,7 @@ const MIN_NTP_PACKET_SIZE: usize = 48;
 /// Analyze an NTP packet and extract key information.
 ///
 /// Returns `None` if the packet is too small or has invalid version.
-pub fn analyze_ntp(payload: &[u8]) -> Option<NtpInfo> {
+pub(super) fn analyze_ntp(payload: &[u8]) -> Option<NtpInfo> {
     // Early size check - NTP packets are at least 48 bytes
     if payload.len() < MIN_NTP_PACKET_SIZE {
         return None;

--- a/crates/rustnet-core/src/network/dpi/quic/mod.rs
+++ b/crates/rustnet-core/src/network/dpi/quic/mod.rs
@@ -6,5 +6,5 @@ mod tls;
 #[cfg(test)]
 mod tests;
 
-pub use packet::{is_quic_packet, parse_quic_packet};
+pub(super) use packet::{is_quic_packet, parse_quic_packet};
 pub use tls::try_extract_tls_from_reassembler;

--- a/crates/rustnet-core/src/network/dpi/quic/packet.rs
+++ b/crates/rustnet-core/src/network/dpi/quic/packet.rs
@@ -46,7 +46,7 @@ pub(super) fn initial_salt_for_version(version: u32) -> &'static [u8] {
 
 /// Main entry point for QUIC packet parsing
 /// Handles coalesced packets - multiple QUIC packets in a single UDP datagram
-pub fn parse_quic_packet(payload: &[u8]) -> Option<QuicInfo> {
+pub(in crate::network::dpi) fn parse_quic_packet(payload: &[u8]) -> Option<QuicInfo> {
     if payload.is_empty() {
         debug!("QUIC: Empty payload");
         return None;
@@ -818,7 +818,7 @@ pub(super) fn is_quic_v2(version: u32) -> bool {
 }
 
 /// Check if a packet is likely a QUIC packet
-pub fn is_quic_packet(payload: &[u8]) -> bool {
+pub(in crate::network::dpi) fn is_quic_packet(payload: &[u8]) -> bool {
     if payload.len() < 5 {
         return false;
     }

--- a/crates/rustnet-core/src/network/dpi/quic/tls.rs
+++ b/crates/rustnet-core/src/network/dpi/quic/tls.rs
@@ -327,31 +327,7 @@ pub(super) fn scan_for_sni_extension(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Build a minimal SNI extension structure
-    fn build_sni_extension(hostname: &str) -> Vec<u8> {
-        let name_bytes = hostname.as_bytes();
-        let name_len = name_bytes.len() as u16;
-        let list_len = name_len + 3; // name_type (1) + name_len (2)
-        let ext_len = list_len + 2; // list_len (2)
-
-        let mut data = Vec::new();
-        // Extension type: SNI (0x0000)
-        data.push(0x00);
-        data.push(0x00);
-        // Extension length
-        data.extend_from_slice(&ext_len.to_be_bytes());
-        // Server name list length
-        data.extend_from_slice(&list_len.to_be_bytes());
-        // Name type: hostname (0x00)
-        data.push(0x00);
-        // Name length
-        data.extend_from_slice(&name_len.to_be_bytes());
-        // Hostname
-        data.extend_from_slice(name_bytes);
-
-        data
-    }
+    use crate::network::dpi::tls_common::test_fixtures::build_sni_extension;
 
     #[test]
     fn test_greedy_sni_extraction_complete() {

--- a/crates/rustnet-core/src/network/dpi/snmp.rs
+++ b/crates/rustnet-core/src/network/dpi/snmp.rs
@@ -27,7 +27,7 @@ const PDU_REPORT: u8 = 0xA8;
 /// Analyze an SNMP packet and extract key information.
 ///
 /// Returns `None` if the packet is not valid SNMP.
-pub fn analyze_snmp(payload: &[u8]) -> Option<SnmpInfo> {
+pub(super) fn analyze_snmp(payload: &[u8]) -> Option<SnmpInfo> {
     if payload.len() < MIN_SNMP_SIZE {
         return None;
     }

--- a/crates/rustnet-core/src/network/dpi/ssdp.rs
+++ b/crates/rustnet-core/src/network/dpi/ssdp.rs
@@ -12,7 +12,7 @@ const MIN_SSDP_SIZE: usize = 10;
 ///
 /// SSDP uses HTTP-like text format with methods like M-SEARCH and NOTIFY.
 /// Returns `None` if the packet is not valid SSDP.
-pub fn analyze_ssdp(payload: &[u8]) -> Option<SsdpInfo> {
+pub(super) fn analyze_ssdp(payload: &[u8]) -> Option<SsdpInfo> {
     if payload.len() < MIN_SSDP_SIZE {
         return None;
     }

--- a/crates/rustnet-core/src/network/dpi/ssh.rs
+++ b/crates/rustnet-core/src/network/dpi/ssh.rs
@@ -3,7 +3,7 @@ use log::debug;
 
 /// Analyze payload for SSH protocol
 /// is_outgoing: true if this packet is from client to server
-pub fn analyze_ssh(payload: &[u8], is_outgoing: bool) -> Option<SshInfo> {
+pub(super) fn analyze_ssh(payload: &[u8], is_outgoing: bool) -> Option<SshInfo> {
     if !is_likely_ssh(payload) {
         return None;
     }
@@ -121,7 +121,7 @@ pub fn analyze_ssh(payload: &[u8], is_outgoing: bool) -> Option<SshInfo> {
 }
 
 /// Check if payload might be SSH
-pub fn is_likely_ssh(payload: &[u8]) -> bool {
+pub(super) fn is_likely_ssh(payload: &[u8]) -> bool {
     if payload.len() < 4 {
         return false;
     }

--- a/crates/rustnet-core/src/network/dpi/stun.rs
+++ b/crates/rustnet-core/src/network/dpi/stun.rs
@@ -21,7 +21,7 @@ const MAX_SOFTWARE_LEN: usize = 128;
 ///
 /// Returns `None` if the packet is too small, lacks the magic cookie,
 /// or has invalid structural properties.
-pub fn analyze_stun(payload: &[u8]) -> Option<StunInfo> {
+pub(super) fn analyze_stun(payload: &[u8]) -> Option<StunInfo> {
     if payload.len() < STUN_HEADER_SIZE {
         return None;
     }
@@ -94,7 +94,7 @@ pub fn analyze_stun(payload: &[u8]) -> Option<StunInfo> {
 
 /// Check if a packet looks like STUN without full parsing.
 /// Used for non-standard port detection where we want a quick probe.
-pub fn is_likely_stun(payload: &[u8]) -> bool {
+pub(super) fn is_likely_stun(payload: &[u8]) -> bool {
     if payload.len() < STUN_HEADER_SIZE {
         return false;
     }

--- a/crates/rustnet-core/src/network/dpi/tls_common.rs
+++ b/crates/rustnet-core/src/network/dpi/tls_common.rs
@@ -46,14 +46,14 @@ pub(in crate::network::dpi) struct TlsParseOptions {
 }
 
 impl TlsParseOptions {
-    pub fn tcp() -> Self {
+    pub(super) fn tcp() -> Self {
         Self {
             transport: TlsTransport::Tcp,
             allow_partial: true,
         }
     }
 
-    pub fn quic(allow_partial: bool) -> Self {
+    pub(super) fn quic(allow_partial: bool) -> Self {
         Self {
             transport: TlsTransport::Quic,
             allow_partial,
@@ -584,8 +584,28 @@ fn parse_supported_versions(data: &[u8], is_client: bool) -> Option<TlsVersion> 
     }
 }
 
+/// TLS wire-format builders shared by the TLS-family DPI tests: the QUIC
+/// parser reuses the SNI extension layout, so its tests encode it here.
+#[cfg(test)]
+pub(crate) mod test_fixtures {
+    /// Build a minimal SNI extension structure for `hostname`.
+    pub(crate) fn build_sni_extension(hostname: &str) -> Vec<u8> {
+        let name_len = hostname.len() as u16;
+        let list_len = name_len + 3;
+        let mut ext = Vec::new();
+        ext.extend_from_slice(&0x0000u16.to_be_bytes()); // type: SNI
+        ext.extend_from_slice(&(list_len + 2).to_be_bytes()); // extension length
+        ext.extend_from_slice(&list_len.to_be_bytes());
+        ext.push(0x00); // name type
+        ext.extend_from_slice(&name_len.to_be_bytes());
+        ext.extend_from_slice(hostname.as_bytes());
+        ext
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::test_fixtures::build_sni_extension;
     use super::*;
 
     #[test]
@@ -727,19 +747,6 @@ mod tests {
         msg.extend_from_slice(&(body.len() as u32).to_be_bytes()[1..]);
         msg.extend_from_slice(&body);
         msg
-    }
-
-    fn build_sni_extension(hostname: &str) -> Vec<u8> {
-        let name_len = hostname.len() as u16;
-        let list_len = name_len + 3;
-        let mut ext = Vec::new();
-        ext.extend_from_slice(&0x0000u16.to_be_bytes()); // type: SNI
-        ext.extend_from_slice(&(list_len + 2).to_be_bytes()); // extension length
-        ext.extend_from_slice(&list_len.to_be_bytes());
-        ext.push(0x00); // name type
-        ext.extend_from_slice(&name_len.to_be_bytes());
-        ext.extend_from_slice(hostname.as_bytes());
-        ext
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/interface_stats/mod.rs
+++ b/crates/rustnet-core/src/network/interface_stats/mod.rs
@@ -9,13 +9,13 @@ mod linux;
 mod windows;
 
 #[cfg(target_os = "freebsd")]
-pub use bsd::FreeBSDStatsProvider;
+use bsd::FreeBSDStatsProvider;
 #[cfg(target_os = "macos")]
-pub use bsd::MacOSStatsProvider;
+use bsd::MacOSStatsProvider;
 #[cfg(target_os = "linux")]
-pub use linux::LinuxStatsProvider;
+use linux::LinuxStatsProvider;
 #[cfg(target_os = "windows")]
-pub use windows::WindowsStatsProvider;
+use windows::WindowsStatsProvider;
 
 /// Statistics for a network interface
 #[derive(Debug, Clone)]
@@ -126,38 +126,36 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
+    /// Snapshot with the given counters and timestamp, error fields zeroed.
+    fn stats(
+        rx_bytes: u64,
+        tx_bytes: u64,
+        rx_packets: u64,
+        tx_packets: u64,
+        timestamp: SystemTime,
+    ) -> InterfaceStats {
+        InterfaceStats {
+            interface_name: "test".to_string(),
+            rx_bytes,
+            tx_bytes,
+            rx_packets,
+            tx_packets,
+            rx_errors: 0,
+            tx_errors: 0,
+            rx_dropped: 0,
+            tx_dropped: 0,
+            collisions: 0,
+            timestamp,
+        }
+    }
+
     #[test]
     fn test_rate_calculation() {
         let t1 = SystemTime::now();
         let t2 = t1 + Duration::from_secs(1);
 
-        let stats1 = InterfaceStats {
-            interface_name: "test".to_string(),
-            rx_bytes: 1000,
-            tx_bytes: 500,
-            rx_packets: 10,
-            tx_packets: 5,
-            rx_errors: 0,
-            tx_errors: 0,
-            rx_dropped: 0,
-            tx_dropped: 0,
-            collisions: 0,
-            timestamp: t1,
-        };
-
-        let stats2 = InterfaceStats {
-            interface_name: "test".to_string(),
-            rx_bytes: 2000,
-            tx_bytes: 1000,
-            rx_packets: 20,
-            tx_packets: 10,
-            rx_errors: 0,
-            tx_errors: 0,
-            rx_dropped: 0,
-            tx_dropped: 0,
-            collisions: 0,
-            timestamp: t2,
-        };
+        let stats1 = stats(1000, 500, 10, 5, t1);
+        let stats2 = stats(2000, 1000, 20, 10, t2);
 
         let rates = stats2.calculate_rates(&stats1);
         assert_eq!(rates.rx_bytes_per_sec, 1000);
@@ -168,20 +166,7 @@ mod tests {
     fn test_rate_calculation_zero_duration() {
         let t = SystemTime::now();
 
-        let stats1 = InterfaceStats {
-            interface_name: "test".to_string(),
-            rx_bytes: 1000,
-            tx_bytes: 500,
-            rx_packets: 10,
-            tx_packets: 5,
-            rx_errors: 0,
-            tx_errors: 0,
-            rx_dropped: 0,
-            tx_dropped: 0,
-            collisions: 0,
-            timestamp: t,
-        };
-
+        let stats1 = stats(1000, 500, 10, 5, t);
         let stats2 = stats1.clone();
 
         let rates = stats2.calculate_rates(&stats1);
@@ -194,34 +179,11 @@ mod tests {
         let t1 = SystemTime::now();
         let t2 = t1 + Duration::from_secs(1);
 
-        let stats1 = InterfaceStats {
-            interface_name: "test".to_string(),
-            rx_bytes: 1000,
-            tx_bytes: 500,
-            rx_packets: 10,
-            tx_packets: 5,
-            rx_errors: 0,
-            tx_errors: 0,
-            rx_dropped: 0,
-            tx_dropped: 0,
-            collisions: 0,
-            timestamp: t1,
-        };
+        let stats1 = stats(1000, 500, 10, 5, t1);
 
-        // Simulate counter reset (should use saturating_sub to avoid panic)
-        let stats2 = InterfaceStats {
-            interface_name: "test".to_string(),
-            rx_bytes: 500, // Less than previous
-            tx_bytes: 250,
-            rx_packets: 5,
-            tx_packets: 2,
-            rx_errors: 0,
-            tx_errors: 0,
-            rx_dropped: 0,
-            tx_dropped: 0,
-            collisions: 0,
-            timestamp: t2,
-        };
+        // Simulate counter reset (should use saturating_sub to avoid panic):
+        // counters lower than the previous snapshot's.
+        let stats2 = stats(500, 250, 5, 2, t2);
 
         let rates = stats2.calculate_rates(&stats1);
         // Should result in 0 due to saturating_sub
@@ -233,19 +195,7 @@ mod tests {
     fn test_traffic_since() {
         let t1 = SystemTime::now();
         let t2 = t1 + Duration::from_secs(60);
-        let first = InterfaceStats {
-            interface_name: "test".to_string(),
-            rx_bytes: 1_000,
-            tx_bytes: 500,
-            rx_packets: 0,
-            tx_packets: 0,
-            rx_errors: 0,
-            tx_errors: 0,
-            rx_dropped: 0,
-            tx_dropped: 0,
-            collisions: 0,
-            timestamp: t1,
-        };
+        let first = stats(1_000, 500, 0, 0, t1);
         let second = InterfaceStats {
             rx_bytes: 9_000,
             tx_bytes: 2_500,

--- a/crates/rustnet-core/src/network/link_layer/mod.rs
+++ b/crates/rustnet-core/src/network/link_layer/mod.rs
@@ -7,16 +7,16 @@
 //! - TUN/TAP interfaces
 //! - PKTAP (macOS process metadata)
 
-pub mod ethernet;
-pub mod linux_sll;
+pub(crate) mod ethernet;
+pub(crate) mod linux_sll;
 #[cfg(target_os = "macos")]
 pub mod pktap;
-pub mod raw_ip;
-pub mod tun_tap;
+pub(crate) mod raw_ip;
+pub(crate) mod tun_tap;
 
 /// Data Link Type (DLT) constants
 /// These match the values from libpcap
-pub mod dlt {
+pub(crate) mod dlt {
     pub const EN10MB: i32 = 1; // Ethernet
     pub const RAW: i32 = 12; // Raw IP (no link layer)
     pub const NULL: i32 = 0; // BSD loopback (sometimes used by TUN)

--- a/crates/rustnet-core/src/network/link_layer/pktap.rs
+++ b/crates/rustnet-core/src/network/link_layer/pktap.rs
@@ -11,7 +11,7 @@ const DARWIN_PID_MAX: u32 = 99_999;
 /// Based on the LINKTYPE_PKTAP specification and Apple's pktap.h
 #[repr(C)]
 #[derive(Debug, Clone)]
-pub struct PktapHeader {
+pub(crate) struct PktapHeader {
     pub pth_length: u32,            // Total header length (minimum 108 bytes)
     pub pth_type_next: u32,         // Type of next header
     pub pth_dlt: u32,               // DLT type of actual packet (e.g., DLT_EN10MB)
@@ -34,7 +34,7 @@ pub struct PktapHeader {
 
 impl PktapHeader {
     /// Parse PKTAP header from raw packet data
-    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+    pub(crate) fn from_bytes(data: &[u8]) -> Option<Self> {
         // Check minimum size
         if data.len() < mem::size_of::<PktapHeader>() {
             debug!("Packet too small for PKTAP header: {} bytes", data.len());
@@ -68,7 +68,7 @@ impl PktapHeader {
 
     /// Extract process information from the header using the correct offsets
     /// Based on our successful test: process name at offset 56, PID at offset 52
-    pub fn get_process_info(&self) -> (Option<String>, Option<u32>) {
+    pub(crate) fn get_process_info(&self) -> (Option<String>, Option<u32>) {
         // Extract process name from pth_comm (offset 56, length 20)
         let process_name = extract_process_name_from_bytes(&self.pth_comm);
 
@@ -102,7 +102,7 @@ impl PktapHeader {
     }
 
     /// Get the interface name
-    pub fn get_interface(&self) -> String {
+    pub(crate) fn get_interface(&self) -> String {
         std::str::from_utf8(&self.pth_ifname)
             .unwrap_or("")
             .trim_end_matches('\0')
@@ -111,23 +111,42 @@ impl PktapHeader {
     }
 
     /// Get the offset where the actual packet data starts
-    pub fn payload_offset(&self) -> usize {
+    pub(crate) fn payload_offset(&self) -> usize {
         self.pth_length as usize
     }
 
     /// Get the DLT type of the inner packet
-    pub fn inner_dlt(&self) -> u32 {
+    pub(crate) fn inner_dlt(&self) -> u32 {
         self.pth_dlt
     }
 
     /// Check if this PKTAP header looks valid
-    pub fn is_valid(&self) -> bool {
+    pub(crate) fn is_valid(&self) -> bool {
         // Basic sanity checks
         self.pth_length >= 108 &&
         self.pth_length <= 4096 && // Reasonable upper bound
         self.pth_dlt > 0 &&
         self.pth_dlt < 1000 // Reasonable DLT range
     }
+}
+
+/// Normalize a process name by collapsing whitespace and control characters
+/// into single spaces. Used for PKTAP-extracted names and by the macOS lsof
+/// lookup in rustnet-host; the two sides must normalize identically or
+/// attribution matching by name breaks.
+pub fn normalize_process_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_whitespace() || c.is_control() {
+                ' ' // Convert whitespace and control characters to space
+            } else {
+                c
+            }
+        })
+        .collect::<String>()
+        .split_whitespace() // Split on any whitespace
+        .collect::<Vec<&str>>()
+        .join(" ") // Join with single spaces
 }
 
 /// Extract and normalize process name from raw PKTAP bytes
@@ -146,19 +165,7 @@ fn extract_process_name_from_bytes(bytes: &[u8; 20]) -> Option<String> {
     let raw_str = std::str::from_utf8(&bytes[..end_pos]).ok()?;
 
     // Apply aggressive normalization
-    let normalized = raw_str
-        .chars()
-        .map(|c| {
-            if c.is_whitespace() || c.is_control() {
-                ' ' // Convert whitespace and control characters to space
-            } else {
-                c
-            }
-        })
-        .collect::<String>()
-        .split_whitespace() // Split on any whitespace
-        .collect::<Vec<&str>>()
-        .join(" "); // Join with single spaces
+    let normalized = normalize_process_name(raw_str);
 
     if normalized.is_empty() || !normalized.chars().all(|c| c.is_ascii_graphic() || c == ' ') {
         debug!(
@@ -185,7 +192,7 @@ pub fn is_pktap_linktype(linktype: i32) -> bool {
 }
 
 /// Try to extract PKTAP metadata and payload from a packet
-pub fn parse_pktap_packet(data: &[u8]) -> Option<(PktapHeader, &[u8])> {
+pub(crate) fn parse_pktap_packet(data: &[u8]) -> Option<(PktapHeader, &[u8])> {
     let header = PktapHeader::from_bytes(data)?;
 
     if !header.is_valid() {

--- a/crates/rustnet-core/src/network/local_addresses.rs
+++ b/crates/rustnet-core/src/network/local_addresses.rs
@@ -6,32 +6,13 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 /// broadcast address of every assigned network (e.g. 192.168.0.255 for a /24).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct LocalAddresses {
-    pub ips: HashSet<IpAddr>,
+    pub(crate) ips: HashSet<IpAddr>,
     /// Subnet-directed broadcasts only; the limited broadcast
     /// (255.255.255.255) needs no prefix knowledge and is handled statelessly.
-    pub v4_broadcasts: HashSet<Ipv4Addr>,
+    pub(crate) v4_broadcasts: HashSet<Ipv4Addr>,
     /// Next-hop addresses of the host's default routes, refreshed together
     /// with the interface addresses.
-    pub gateways: HashSet<IpAddr>,
-}
-
-#[cfg(test)]
-impl LocalAddresses {
-    /// Test helper: a snapshot with the given addresses and no broadcast or
-    /// gateway sets.
-    pub(crate) fn from_ips(ips: impl IntoIterator<Item = IpAddr>) -> Self {
-        Self {
-            ips: ips.into_iter().collect(),
-            v4_broadcasts: HashSet::new(),
-            gateways: HashSet::new(),
-        }
-    }
-
-    /// Test helper: the snapshot with the given default-gateway addresses.
-    pub(crate) fn with_gateways(mut self, gateways: impl IntoIterator<Item = IpAddr>) -> Self {
-        self.gateways = gateways.into_iter().collect();
-        self
-    }
+    pub(crate) gateways: HashSet<IpAddr>,
 }
 
 /// Directed-broadcast address of `ip`'s subnet, or `None` when the prefix has

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -1,7 +1,7 @@
 // src/network/merge.rs - Connection merging and update utilities
 
 use log::{debug, info, warn};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
 use crate::network::dpi::{DpiResult, is_partial_sni, try_extract_tls_from_reassembler};
 use crate::network::parser::{ParsedPacket, TcpFlags};
@@ -176,13 +176,11 @@ fn analyze_tcp_segment(
             // Err means the ACK's capture time precedes the send: clocks or
             // packet order went backwards, so no sample either way.
             if let Ok(rtt) = at.duration_since(sent_at) {
-                analytics.last_rtt = Some(rtt);
                 analytics.smoothed_rtt = Some(match analytics.smoothed_rtt {
                     // RFC 6298 smoothing: 7/8 previous + 1/8 new sample.
                     Some(srtt) => (srtt * 7 + rtt) / 8,
                     None => rtt,
                 });
-                analytics.rtt_samples += 1;
                 events.rtt_sample = Some(rtt);
             }
             analytics.rtt_probe = None;
@@ -447,7 +445,7 @@ fn icmp_echo_direction(parsed: &ParsedPacket) -> Option<bool> {
 }
 
 /// Create a new connection from a parsed packet
-pub fn create_connection_from_packet(parsed: &ParsedPacket, now: SystemTime) -> Connection {
+pub(crate) fn create_connection_from_packet(parsed: &ParsedPacket, now: SystemTime) -> Connection {
     let mut conn = Connection::new(
         parsed.protocol,
         parsed.local_addr,
@@ -514,7 +512,6 @@ pub fn create_connection_from_packet(parsed: &ParsedPacket, now: SystemTime) -> 
     if let Some(dpi_result) = &parsed.dpi_result {
         conn.dpi_info = Some(DpiInfo {
             application: dpi_result.application.clone(),
-            last_update_time: Instant::now(),
         });
 
         debug!(
@@ -561,7 +558,6 @@ fn merge_dpi_info(conn: &mut Connection, dpi_result: &DpiResult) {
             // No existing DPI info, use the new one
             conn.dpi_info = Some(DpiInfo {
                 application: dpi_result.application.clone(),
-                last_update_time: Instant::now(),
             });
 
             debug!(
@@ -571,9 +567,6 @@ fn merge_dpi_info(conn: &mut Connection, dpi_result: &DpiResult) {
             );
         }
         Some(dpi_info) => {
-            // Update the last update time
-            dpi_info.last_update_time = Instant::now();
-
             // Match on both the existing and new application protocols
             match (&mut dpi_info.application, &dpi_result.application) {
                 // HTTP merging
@@ -1475,8 +1468,6 @@ mod tests {
 
         assert_eq!(events.rtt_sample, Some(Duration::from_millis(40)));
         assert_eq!(a.smoothed_rtt, Some(Duration::from_millis(40)));
-        assert_eq!(a.last_rtt, Some(Duration::from_millis(40)));
-        assert_eq!(a.rtt_samples, 1);
         assert_eq!(a.rtt_probe, None, "a completed probe must not re-fire");
     }
 
@@ -1506,7 +1497,6 @@ mod tests {
 
         let events = recv_at(&mut a, 0, 100, 0, t0() + Duration::from_millis(50));
         assert_eq!(events.rtt_sample, None);
-        assert_eq!(a.rtt_samples, 0);
     }
 
     #[test]
@@ -1522,8 +1512,6 @@ mod tests {
         send_at(&mut a, 100, 100, sent);
         recv_at(&mut a, 0, 200, 0, sent + Duration::from_millis(16));
         assert_eq!(a.smoothed_rtt, Some(Duration::from_millis(72)));
-        assert_eq!(a.last_rtt, Some(Duration::from_millis(16)));
-        assert_eq!(a.rtt_samples, 2);
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/neighbors.rs
+++ b/crates/rustnet-core/src/network/neighbors.rs
@@ -44,7 +44,7 @@ const SWEEP_MIN_INTERVAL: Duration = Duration::from_secs(60);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NeighborEntry {
     /// Colon-separated lowercase MAC, as produced by
-    /// [`crate::network::oui::format_mac`].
+    /// `crate::network::oui::format_mac`.
     pub mac: String,
     /// OUI vendor, resolved by the parse path when the database is loaded.
     pub vendor: Option<String>,
@@ -56,7 +56,7 @@ pub struct NeighborEntry {
 /// IP -> [`NeighborEntry`] table with interior mutability, safe to share
 /// behind an `Arc` between packet-processor threads and UI readers.
 #[derive(Debug, Default)]
-pub struct NeighborCache {
+pub(crate) struct NeighborCache {
     entries: DashMap<IpAddr, NeighborEntry, FxBuildHasher>,
     /// Unix-epoch seconds of the last stale sweep; `0` means never swept.
     last_sweep_epoch_secs: AtomicU64,
@@ -70,7 +70,7 @@ impl NeighborCache {
     /// reply the sender is the answering host. A reply's target additionally
     /// echoes the original requester, so it is learned too; a request's
     /// target MAC is unspecified and ignored.
-    pub fn learn_from_arp(&self, arp: &ArpInfo, now: SystemTime) {
+    pub(crate) fn learn_from_arp(&self, arp: &ArpInfo, now: SystemTime) {
         self.learn(arp.sender_ip, &arp.sender_mac, &arp.sender_vendor, now);
         if arp.operation == ArpOperation::Reply {
             self.learn(arp.target_ip, &arp.target_mac, &arp.target_vendor, now);
@@ -80,18 +80,18 @@ impl NeighborCache {
     /// Fold one NDP-carried mapping into the table. The parser extracts these
     /// only from messages that passed the hop-limit-255 check (RFC 4861), the
     /// IPv6 equivalent of ARP's on-link guarantee.
-    pub fn learn_from_ndp(&self, neighbor: &NdpNeighbor, now: SystemTime) {
+    pub(crate) fn learn_from_ndp(&self, neighbor: &NdpNeighbor, now: SystemTime) {
         self.learn(neighbor.ip, &neighbor.mac, &neighbor.vendor, now);
     }
 
     /// The learned entry for `ip`, if any.
-    pub fn get(&self, ip: &IpAddr) -> Option<NeighborEntry> {
+    pub(crate) fn get(&self, ip: &IpAddr) -> Option<NeighborEntry> {
         self.entries.get(ip).map(|entry| entry.clone())
     }
 
     /// Forget every learned neighbor. Part of the tracker-wide clear, so the
     /// user-facing reset also recovers from a poisoned or flood-filled table.
-    pub fn clear(&self) {
+    pub(crate) fn clear(&self) {
         self.entries.clear();
     }
 

--- a/crates/rustnet-core/src/network/oui.rs
+++ b/crates/rustnet-core/src/network/oui.rs
@@ -72,13 +72,13 @@ impl OuiLookup {
 /// # Panics
 ///
 /// Panics if `bytes` is shorter than 6 bytes.
-pub fn format_mac(bytes: &[u8]) -> String {
+pub(crate) fn format_mac(bytes: &[u8]) -> String {
     crate::network::util::hex_encode(&bytes[..6], ":")
 }
 
 /// Parse the first octet of a MAC address string.
 /// Supports the same formats as [`parse_mac_prefix`].
-pub fn mac_first_octet(mac: &str) -> Option<u8> {
+pub(crate) fn mac_first_octet(mac: &str) -> Option<u8> {
     parse_mac_prefix(mac).map(|prefix| prefix[0])
 }
 

--- a/crates/rustnet-core/src/network/parser.rs
+++ b/crates/rustnet-core/src/network/parser.rs
@@ -42,6 +42,39 @@ pub struct ParsedPacket {
 }
 
 impl ParsedPacket {
+    /// Packet with the given flow fields and process attribution. The address
+    /// kinds and gateway flag start at their unicast/false defaults (they are
+    /// overwritten centrally in `PacketParser::parse_packet`), and
+    /// `tcp_header`/`dpi_result` start as `None` for the caller to fill in
+    /// where applicable.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        protocol: Protocol,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        protocol_state: ProtocolState,
+        is_outgoing: bool,
+        packet_len: usize,
+        process_name: Option<String>,
+        process_id: Option<u32>,
+    ) -> Self {
+        Self {
+            protocol,
+            local_addr,
+            remote_addr,
+            local_addr_kind: AddrKind::Unicast,
+            remote_addr_kind: AddrKind::Unicast,
+            remote_is_gateway: false,
+            tcp_header: None,
+            protocol_state,
+            is_outgoing,
+            packet_len,
+            dpi_result: None,
+            process_name,
+            process_id,
+        }
+    }
+
     /// The flow identity this packet belongs to, derived from protocol and
     /// addresses. `ConnectionKey` is `Copy`, so this costs nothing on the
     /// per-packet path (no allocation, unlike the former `String` key field).
@@ -63,21 +96,16 @@ impl ParsedPacket {
         remote_addr: SocketAddr,
         protocol_state: ProtocolState,
     ) -> Self {
-        Self {
+        Self::new(
             protocol,
             local_addr,
             remote_addr,
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            tcp_header: None,
             protocol_state,
-            is_outgoing: false,
-            packet_len: 0,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
-        }
+            false,
+            0,
+            None,
+            None,
+        )
     }
 
     /// TCP test packet carrying the given header.
@@ -746,22 +774,16 @@ impl PacketParser {
             (SocketAddr::new(target_ip, 0), SocketAddr::new(sender_ip, 0))
         };
 
-        Some(ParsedPacket {
-            protocol: Protocol::Arp,
+        Some(ParsedPacket::new(
+            Protocol::Arp,
             local_addr,
             remote_addr,
-            // Overwritten centrally in PacketParser::parse_packet
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            tcp_header: None,
-            protocol_state: ProtocolState::Arp(arp_info),
+            ProtocolState::Arp(arp_info),
             is_outgoing,
-            packet_len: data.len(),
-            dpi_result: None,
+            data.len(),
             process_name,
             process_id,
-        })
+        ))
     }
 
     /// Parse a raw IPv4 packet (no link-layer header)
@@ -859,6 +881,23 @@ impl PacketParser {
 mod tests {
     use super::*;
     use std::net::IpAddr;
+
+    fn local_addresses(ips: impl IntoIterator<Item = IpAddr>) -> LocalAddresses {
+        LocalAddresses {
+            ips: ips.into_iter().collect(),
+            ..LocalAddresses::default()
+        }
+    }
+
+    fn local_addresses_with_gateways(
+        ips: impl IntoIterator<Item = IpAddr>,
+        gateways: impl IntoIterator<Item = IpAddr>,
+    ) -> LocalAddresses {
+        LocalAddresses {
+            gateways: gateways.into_iter().collect(),
+            ..local_addresses(ips)
+        }
+    }
 
     /// Helper to create a parser with a specific linktype and controlled local IPs
     /// This adds 192.168.1.100 to the local_ips set so test packets are correctly identified
@@ -1296,7 +1335,7 @@ mod tests {
         parser.gateways.clear();
         let gateway = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
         let collector =
-            || LocalAddresses::from_ips([IpAddr::V4(Ipv4Addr::LOCALHOST)]).with_gateways([gateway]);
+            || local_addresses_with_gateways([IpAddr::V4(Ipv4Addr::LOCALHOST)], [gateway]);
 
         assert!(
             parser.refresh_local_ips_with(collector),
@@ -1324,7 +1363,7 @@ mod tests {
         let new_local = IpAddr::V6("2001:db8::1".parse().expect("valid fixture address"));
         let corrected = parser
             .parse_packet_with_local_ip_collector(&packet, || {
-                LocalAddresses::from_ips([
+                local_addresses([
                     IpAddr::V4(Ipv4Addr::LOCALHOST),
                     IpAddr::V6(Ipv6Addr::LOCALHOST),
                     new_local,
@@ -1345,7 +1384,7 @@ mod tests {
         let new = IpAddr::V6("2001:db8::2".parse().expect("valid new address"));
         parser.local_ips = [old].into_iter().collect();
 
-        assert!(parser.refresh_local_ips_with(|| LocalAddresses::from_ips([new])));
+        assert!(parser.refresh_local_ips_with(|| local_addresses([new])));
         assert!(!parser.local_ips.contains(&old));
         assert!(parser.local_ips.contains(&new));
     }
@@ -1361,7 +1400,7 @@ mod tests {
         let collector_calls = Cell::new(0u32);
         let unchanged_collector = || {
             collector_calls.set(collector_calls.get() + 1);
-            LocalAddresses::from_ips([IpAddr::V4(Ipv4Addr::LOCALHOST)])
+            local_addresses([IpAddr::V4(Ipv4Addr::LOCALHOST)])
         };
 
         parser
@@ -1393,7 +1432,7 @@ mod tests {
         );
 
         let new = IpAddr::V6("2001:db8::99".parse().expect("valid address"));
-        assert!(parser.refresh_local_ips_with(|| LocalAddresses::from_ips([new])));
+        assert!(parser.refresh_local_ips_with(|| local_addresses([new])));
         assert_eq!(
             parser.unchanged_ambiguous_refreshes, 0,
             "a refresh that observes a change must reset the backoff"

--- a/crates/rustnet-core/src/network/process_activity.rs
+++ b/crates/rustnet-core/src/network/process_activity.rs
@@ -16,7 +16,7 @@ const OTHER_NAME: &str = "Other";
 
 /// Bounds for retained process accounting.
 #[derive(Debug, Clone)]
-pub struct ProcessActivityConfig {
+pub(crate) struct ProcessActivityConfig {
     /// Maximum number of historic process buckets represented in one sample.
     /// Additional identities are folded into attributed/unattributed `Other`
     /// buckets. Active identities are always represented individually.
@@ -446,7 +446,7 @@ impl ProcessActivityTracker {
         Self::with_config(ProcessActivityConfig::default())
     }
 
-    pub fn with_config(config: ProcessActivityConfig) -> Self {
+    pub(crate) fn with_config(config: ProcessActivityConfig) -> Self {
         Self {
             config,
             sample: HashMap::new(),
@@ -455,25 +455,6 @@ impl ProcessActivityTracker {
             histories: HashMap::new(),
             snapshot: ProcessActivitySnapshot::default(),
         }
-    }
-
-    /// Aggregate one complete active-plus-historic connection view.
-    /// Repeated observations are idempotent because compact per-flow counters
-    /// contribute only newly observed bytes.
-    pub fn observe_connections(&mut self, connections: &[Connection], now: SystemTime) {
-        self.observe_sources(
-            now,
-            |observe| {
-                for connection in connections.iter().filter(|conn| !conn.is_historic) {
-                    observe(connection);
-                }
-            },
-            |observe| {
-                for connection in connections.iter().filter(|conn| conn.is_historic) {
-                    observe(connection);
-                }
-            },
-        );
     }
 
     /// Stream active and historic sources into one sample without cloning
@@ -721,6 +702,26 @@ mod tests {
     use super::*;
     use crate::network::types::{Protocol, ProtocolState, TcpState};
     use std::net::{IpAddr, Ipv4Addr};
+
+    impl ProcessActivityTracker {
+        /// Test shorthand: feed one complete active-plus-historic connection
+        /// slice through [`observe_sources`](Self::observe_sources).
+        fn observe_connections(&mut self, connections: &[Connection], now: SystemTime) {
+            self.observe_sources(
+                now,
+                |observe| {
+                    for connection in connections.iter().filter(|conn| !conn.is_historic) {
+                        observe(connection);
+                    }
+                },
+                |observe| {
+                    for connection in connections.iter().filter(|conn| conn.is_historic) {
+                        observe(connection);
+                    }
+                },
+            );
+        }
+    }
 
     fn connection(pid: Option<u32>, name: Option<&str>, remote_port: u16) -> Connection {
         let mut conn = Connection::new(

--- a/crates/rustnet-core/src/network/protocol/icmp.rs
+++ b/crates/rustnet-core/src/network/protocol/icmp.rs
@@ -2,9 +2,8 @@
 //! Handles both ICMPv4 and ICMPv6
 
 use crate::network::parser::ParsedPacket;
-use crate::network::protocol::TransportParams;
-use crate::network::types::{AddrKind, Protocol, ProtocolState};
-use std::net::SocketAddr;
+use crate::network::protocol::{TransportParams, orient_endpoints};
+use crate::network::types::{Protocol, ProtocolState};
 
 /// Parse an ICMP (IPv4) packet
 pub fn parse(
@@ -51,31 +50,13 @@ fn parse_icmp(
             (None, None)
         };
 
-    // Determine direction based on local IPs
-    let is_outgoing = local_ips.contains(&params.src_ip);
+    let (local_addr, remote_addr, is_outgoing) = orient_endpoints(&params, 0, 0, local_ips);
 
-    let (local_addr, remote_addr) = if is_outgoing {
-        (
-            SocketAddr::new(params.src_ip, 0),
-            SocketAddr::new(params.dst_ip, 0),
-        )
-    } else {
-        (
-            SocketAddr::new(params.dst_ip, 0),
-            SocketAddr::new(params.src_ip, 0),
-        )
-    };
-
-    Some(ParsedPacket {
-        protocol: Protocol::Icmp,
+    Some(ParsedPacket::new(
+        Protocol::Icmp,
         local_addr,
         remote_addr,
-        // Overwritten centrally in PacketParser::parse_packet
-        local_addr_kind: AddrKind::Unicast,
-        remote_addr_kind: AddrKind::Unicast,
-        remote_is_gateway: false,
-        tcp_header: None,
-        protocol_state: ProtocolState::Icmp {
+        ProtocolState::Icmp {
             icmp_type,
             icmp_id,
             icmp_sequence,
@@ -84,11 +65,10 @@ fn parse_icmp(
             ndp_neighbor: None,
         },
         is_outgoing,
-        packet_len: params.packet_len,
-        dpi_result: None,
-        process_name: params.process_name,
-        process_id: params.process_id,
-    })
+        params.packet_len,
+        params.process_name,
+        params.process_id,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/rustnet-core/src/network/protocol/igmp.rs
+++ b/crates/rustnet-core/src/network/protocol/igmp.rs
@@ -1,9 +1,9 @@
 //! IGMP (Internet Group Management Protocol) parsing
 
 use crate::network::parser::ParsedPacket;
-use crate::network::protocol::TransportParams;
-use crate::network::types::{AddrKind, Protocol, ProtocolState};
-use std::net::{Ipv4Addr, SocketAddr};
+use crate::network::protocol::{TransportParams, orient_endpoints};
+use crate::network::types::{Protocol, ProtocolState};
+use std::net::Ipv4Addr;
 
 /// Parse an IGMP packet
 ///
@@ -44,39 +44,21 @@ pub fn parse(
         None
     };
 
-    let is_outgoing = local_ips.contains(&params.src_ip);
+    let (local_addr, remote_addr, is_outgoing) = orient_endpoints(&params, 0, 0, local_ips);
 
-    let (local_addr, remote_addr) = if is_outgoing {
-        (
-            SocketAddr::new(params.src_ip, 0),
-            SocketAddr::new(params.dst_ip, 0),
-        )
-    } else {
-        (
-            SocketAddr::new(params.dst_ip, 0),
-            SocketAddr::new(params.src_ip, 0),
-        )
-    };
-
-    Some(ParsedPacket {
-        protocol: Protocol::Igmp,
+    Some(ParsedPacket::new(
+        Protocol::Igmp,
         local_addr,
         remote_addr,
-        // Overwritten centrally in PacketParser::parse_packet
-        local_addr_kind: AddrKind::Unicast,
-        remote_addr_kind: AddrKind::Unicast,
-        remote_is_gateway: false,
-        tcp_header: None,
-        protocol_state: ProtocolState::Igmp {
+        ProtocolState::Igmp {
             igmp_type,
             group_addr,
         },
         is_outgoing,
-        packet_len: params.packet_len,
-        dpi_result: None,
-        process_name: params.process_name,
-        process_id: params.process_id,
-    })
+        params.packet_len,
+        params.process_name,
+        params.process_id,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/rustnet-core/src/network/protocol/mod.rs
+++ b/crates/rustnet-core/src/network/protocol/mod.rs
@@ -8,19 +8,20 @@
 //! - IGMP (Internet Group Management Protocol)
 //! - NDP (Neighbor Discovery Protocol, link-layer address extraction only)
 
-pub mod icmp;
-pub mod igmp;
-pub mod ndp;
+pub(crate) mod icmp;
+pub(crate) mod igmp;
+pub(crate) mod ndp;
 pub mod tcp;
-pub mod udp;
+pub(crate) mod udp;
 
-use std::net::IpAddr;
+use std::collections::HashSet;
+use std::net::{IpAddr, SocketAddr};
 
 /// Common parameters for transport layer parsing
 /// Note: Direction (is_outgoing) is determined by the protocol parsers
 /// based on local_ips, not passed as a parameter
 #[derive(Clone)]
-pub struct TransportParams {
+pub(crate) struct TransportParams {
     pub src_ip: IpAddr,
     pub dst_ip: IpAddr,
     pub packet_len: usize,
@@ -29,7 +30,7 @@ pub struct TransportParams {
 }
 
 impl TransportParams {
-    pub fn new(
+    pub(crate) fn new(
         src_ip: IpAddr,
         dst_ip: IpAddr,
         packet_len: usize,
@@ -43,5 +44,21 @@ impl TransportParams {
             process_name,
             process_id,
         }
+    }
+}
+
+pub(super) fn orient_endpoints(
+    params: &TransportParams,
+    src_port: u16,
+    dst_port: u16,
+    local_ips: &HashSet<IpAddr>,
+) -> (SocketAddr, SocketAddr, bool) {
+    let is_outgoing = local_ips.contains(&params.src_ip);
+    let source = SocketAddr::new(params.src_ip, src_port);
+    let destination = SocketAddr::new(params.dst_ip, dst_port);
+    if is_outgoing {
+        (source, destination, true)
+    } else {
+        (destination, source, false)
     }
 }

--- a/crates/rustnet-core/src/network/protocol/tcp.rs
+++ b/crates/rustnet-core/src/network/protocol/tcp.rs
@@ -2,9 +2,8 @@
 
 use crate::network::dpi;
 use crate::network::parser::{ParsedPacket, ParserConfig};
-use crate::network::protocol::TransportParams;
-use crate::network::types::{AddrKind, Protocol, ProtocolState, TcpState};
-use std::net::SocketAddr;
+use crate::network::protocol::{TransportParams, orient_endpoints};
+use crate::network::types::{Protocol, ProtocolState, TcpState};
 
 // Define TCP flags as bit masks
 const TCP_FIN: u8 = 0x01;
@@ -32,7 +31,7 @@ pub struct TcpHeaderInfo {
 }
 
 /// Parse TCP flags from the flags byte
-pub fn parse_tcp_flags(flags: u8) -> TcpFlags {
+pub(crate) fn parse_tcp_flags(flags: u8) -> TcpFlags {
     TcpFlags {
         fin: (flags & TCP_FIN) != 0,
         syn: (flags & TCP_SYN) != 0,
@@ -42,7 +41,7 @@ pub fn parse_tcp_flags(flags: u8) -> TcpFlags {
 }
 
 /// Parse a TCP packet
-pub fn parse(
+pub(crate) fn parse(
     transport_data: &[u8],
     params: TransportParams,
     config: &ParserConfig,
@@ -99,20 +98,8 @@ pub fn parse(
         tcp_flags.ack
     );
 
-    // Determine direction based on local IPs
-    let is_outgoing = local_ips.contains(&params.src_ip);
-
-    let (local_addr, remote_addr) = if is_outgoing {
-        (
-            SocketAddr::new(params.src_ip, src_port),
-            SocketAddr::new(params.dst_ip, dst_port),
-        )
-    } else {
-        (
-            SocketAddr::new(params.dst_ip, dst_port),
-            SocketAddr::new(params.src_ip, src_port),
-        )
-    };
+    let (local_addr, remote_addr, is_outgoing) =
+        orient_endpoints(&params, src_port, dst_port, local_ips);
 
     // Perform DPI if enabled and there's payload
     let dpi_result = if config.enable_dpi {
@@ -126,22 +113,19 @@ pub fn parse(
         None
     };
 
-    Some(ParsedPacket {
-        protocol: Protocol::Tcp,
+    let mut packet = ParsedPacket::new(
+        Protocol::Tcp,
         local_addr,
         remote_addr,
-        // Overwritten centrally in PacketParser::parse_packet
-        local_addr_kind: AddrKind::Unicast,
-        remote_addr_kind: AddrKind::Unicast,
-        remote_is_gateway: false,
-        tcp_header: Some(tcp_header),
-        protocol_state: ProtocolState::Tcp(TcpState::Unknown),
+        ProtocolState::Tcp(TcpState::Unknown),
         is_outgoing,
-        packet_len: params.packet_len,
-        dpi_result,
-        process_name: params.process_name,
-        process_id: params.process_id,
-    })
+        params.packet_len,
+        params.process_name,
+        params.process_id,
+    );
+    packet.tcp_header = Some(tcp_header);
+    packet.dpi_result = dpi_result;
+    Some(packet)
 }
 
 #[cfg(test)]

--- a/crates/rustnet-core/src/network/protocol/udp.rs
+++ b/crates/rustnet-core/src/network/protocol/udp.rs
@@ -2,9 +2,8 @@
 
 use crate::network::dpi;
 use crate::network::parser::{ParsedPacket, ParserConfig};
-use crate::network::protocol::TransportParams;
-use crate::network::types::{AddrKind, Protocol, ProtocolState};
-use std::net::SocketAddr;
+use crate::network::protocol::{TransportParams, orient_endpoints};
+use crate::network::types::{Protocol, ProtocolState};
 
 /// Parse a UDP packet
 pub fn parse(
@@ -20,20 +19,8 @@ pub fn parse(
     let src_port = u16::from_be_bytes([transport_data[0], transport_data[1]]);
     let dst_port = u16::from_be_bytes([transport_data[2], transport_data[3]]);
 
-    // Determine direction based on local IPs
-    let is_outgoing = local_ips.contains(&params.src_ip);
-
-    let (local_addr, remote_addr) = if is_outgoing {
-        (
-            SocketAddr::new(params.src_ip, src_port),
-            SocketAddr::new(params.dst_ip, dst_port),
-        )
-    } else {
-        (
-            SocketAddr::new(params.dst_ip, dst_port),
-            SocketAddr::new(params.src_ip, src_port),
-        )
-    };
+    let (local_addr, remote_addr, is_outgoing) =
+        orient_endpoints(&params, src_port, dst_port, local_ips);
 
     // Perform DPI if enabled and there's payload
     let dpi_result = if config.enable_dpi && transport_data.len() > 8 {
@@ -43,20 +30,16 @@ pub fn parse(
         None
     };
 
-    Some(ParsedPacket {
-        protocol: Protocol::Udp,
+    let mut packet = ParsedPacket::new(
+        Protocol::Udp,
         local_addr,
         remote_addr,
-        // Overwritten centrally in PacketParser::parse_packet
-        local_addr_kind: AddrKind::Unicast,
-        remote_addr_kind: AddrKind::Unicast,
-        remote_is_gateway: false,
-        tcp_header: None,
-        protocol_state: ProtocolState::Udp,
+        ProtocolState::Udp,
         is_outgoing,
-        packet_len: params.packet_len,
-        dpi_result,
-        process_name: params.process_name,
-        process_id: params.process_id,
-    })
+        params.packet_len,
+        params.process_name,
+        params.process_id,
+    );
+    packet.dpi_result = dpi_result;
+    Some(packet)
 }

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -10,13 +10,12 @@
 //! dependency.
 //!
 //! This is the piece that makes headless tools easy: pair a capture source with
-//! a parser, then feed each parsed packet to [`ConnectionTracker::ingest`] and
-//! periodically call [`ConnectionTracker::cleanup`]. A Prometheus exporter, a
-//! pcap post-processor, or a test harness can all reuse the exact connection
+//! a parser, then feed each parsed packet to [`ConnectionTracker::ingest_at`]
+//! and periodically call [`ConnectionTracker::cleanup`]. A Prometheus exporter,
+//! a pcap post-processor, or a test harness can all reuse the exact connection
 //! semantics of the main application. Offline consumers replaying a saved trace
-//! should use [`ConnectionTracker::ingest_at`] with each packet's capture
-//! timestamp so connection lifetimes and timeouts follow trace time rather than
-//! the replay wall clock.
+//! should pass each packet's capture timestamp so connection lifetimes and
+//! timeouts follow trace time rather than the replay wall clock.
 //!
 //! ```no_run
 //! use rustnet_core::network::parser::PacketParser;
@@ -28,7 +27,7 @@
 //! # let frames: Vec<Vec<u8>> = Vec::new();
 //! for frame in frames {
 //!     if let Some(parsed) = parser.parse_packet(&frame) {
-//!         tracker.ingest(&parsed);
+//!         tracker.ingest_at(&parsed, SystemTime::now());
 //!     }
 //! }
 //! tracker.cleanup(SystemTime::now()); // expire idle/closed connections
@@ -130,7 +129,7 @@ impl std::fmt::Display for HistoricKey {
 
 /// Tuning knobs for a [`ConnectionTracker`].
 #[derive(Debug, Clone)]
-pub struct TrackerConfig {
+pub(crate) struct TrackerConfig {
     /// Maximum number of concurrent active connections. New connections beyond
     /// this limit are dropped (existing ones still update) to bound memory
     /// under port scans or connection floods.
@@ -164,7 +163,8 @@ impl Default for TrackerConfig {
     }
 }
 
-/// What happened when a packet was [`ingest`](ConnectionTracker::ingest)ed.
+/// What happened when a packet was ingested via
+/// [`ingest_at`](ConnectionTracker::ingest_at).
 ///
 /// Returned so callers can layer their own concerns — global statistics,
 /// structured logging, DNS enrichment — on top of the core table update without
@@ -312,13 +312,13 @@ pub struct ConnectionTracker {
 }
 
 impl ConnectionTracker {
-    /// Create a tracker with [default](TrackerConfig::default) configuration.
+    /// Create a tracker with default configuration.
     pub fn new() -> Self {
         Self::with_config(TrackerConfig::default())
     }
 
     /// Create a tracker with custom [`TrackerConfig`].
-    pub fn with_config(config: TrackerConfig) -> Self {
+    pub(crate) fn with_config(config: TrackerConfig) -> Self {
         Self {
             connections: ConnectionMap::with_hasher(FxBuildHasher),
             historic: HistoricMap::with_hasher(FxBuildHasher),
@@ -334,27 +334,16 @@ impl ConnectionTracker {
     }
 
     /// Fold a parsed packet into the connection table, creating or updating the
-    /// matching connection, timestamping the update with the current wall clock.
+    /// matching connection, stamping the update with the supplied `now`.
     ///
-    /// This is the right call for live capture. Offline consumers replaying a
-    /// pcap should use [`ingest_at`](Self::ingest_at) and pass the packet's own
-    /// capture time so connection lifetimes and [`cleanup`](Self::cleanup)
-    /// timeouts reflect the trace rather than the replay wall clock.
-    pub fn ingest(&self, parsed: &ParsedPacket) -> IngestOutcome {
-        self.ingest_at(parsed, SystemTime::now())
-    }
-
-    /// Like [`ingest`](Self::ingest), but stamps the connection update with the
-    /// supplied `now` instead of the wall clock.
-    ///
-    /// Use this for deterministic offline processing (pcap replay, tests): pass
-    /// the packet's capture timestamp so `created_at`/`last_activity` and the
-    /// `cleanup` timeout sweep operate on trace time, not real time.
-    ///
-    /// Live callers should pass each packet's own capture timestamp too, not one
-    /// clock read shared across a batch of packets. Handshake RTT is the
-    /// difference between two packets' `now` values, so a shared timestamp
-    /// collapses every round trip that completes within one batch to zero.
+    /// Pass the packet's own capture timestamp: for offline processing (pcap
+    /// replay, tests) this keeps `created_at`/`last_activity` and the
+    /// [`cleanup`](Self::cleanup) timeout sweep on trace time rather than the
+    /// replay wall clock. Live callers should also pass each packet's own
+    /// capture timestamp, not one clock read shared across a batch of packets.
+    /// Handshake RTT is the difference between two packets' `now` values, so a
+    /// shared timestamp collapses every round trip that completes within one
+    /// batch to zero.
     pub fn ingest_at(&self, parsed: &ParsedPacket, now: SystemTime) -> IngestOutcome {
         // Harvest IP -> MAC mappings from ARP and NDP packets; only they pay
         // this cost.
@@ -887,8 +876,8 @@ impl ConnectionTracker {
     /// Remove connections whose protocol-aware timeout has elapsed as of `now`.
     ///
     /// Removed connections are archived into the historic table (when
-    /// [`keep_historic`](TrackerConfig::keep_historic) is set, subject to
-    /// [`max_historic`](TrackerConfig::max_historic) eviction) and their QUIC
+    /// `keep_historic` is set, subject to `max_historic` eviction) and their
+    /// QUIC
     /// mappings are dropped. Returns the removed connections (in their original,
     /// pre-archive form) so callers can emit close events or export them.
     pub fn cleanup(&self, now: SystemTime) -> Vec<Connection> {
@@ -983,14 +972,6 @@ impl ConnectionTracker {
             .collect()
     }
 
-    /// A point-in-time copy of the historic (recently-closed) connections.
-    pub fn historic_snapshot(&self) -> Vec<Connection> {
-        self.historic
-            .iter()
-            .map(|entry| entry.value().clone())
-            .collect()
-    }
-
     /// Inspect the active and historic maps as one consistent retained view.
     ///
     /// Cleanup cannot move a connection between the maps while `inspect` is
@@ -1050,7 +1031,7 @@ impl ConnectionTracker {
     ///
     /// Use this for in-place enrichment (e.g. attaching process, DNS, or GeoIP
     /// information via `iter_mut`) or custom reads. Lifecycle changes should go
-    /// through [`ingest`](Self::ingest) and [`cleanup`](Self::cleanup) so the
+    /// through [`ingest_at`](Self::ingest_at) and [`cleanup`](Self::cleanup) so the
     /// connection-count limit, RTT, and QUIC coalescing stay consistent —
     /// inserting or removing entries directly desyncs the internal counter
     /// backing the `max_connections` check.
@@ -1091,6 +1072,14 @@ mod tests {
     use super::*;
     use crate::network::parser::PacketParser;
     use crate::network::types::NetBiosOpcode;
+
+    impl ConnectionTracker {
+        /// Wall-clock `ingest_at` shorthand for tests that don't exercise
+        /// packet timing.
+        fn ingest(&self, parsed: &ParsedPacket) -> IngestOutcome {
+            self.ingest_at(parsed, SystemTime::now())
+        }
+    }
 
     /// A minimal Ethernet+IPv4+UDP frame, parsed into a `ParsedPacket` so we can
     /// exercise the tracker with a realistic input.
@@ -2312,10 +2301,10 @@ mod tests {
         tracker.ingest_at(&packet, started);
         tracker.cleanup(started + Duration::from_secs(61));
 
-        let historic_before = tracker.historic_snapshot().pop().unwrap();
+        let historic_before = tracker.historic.iter().next().unwrap().value().clone();
         tracker.ingest_at(&packet, started + Duration::from_secs(62));
         tracker.ingest_at(&packet, started + Duration::from_secs(63));
-        let historic_after = tracker.historic_snapshot().pop().unwrap();
+        let historic_after = tracker.historic.iter().next().unwrap().value().clone();
 
         assert_eq!(historic_after.bytes_sent, historic_before.bytes_sent);
         assert_eq!(
@@ -2520,21 +2509,14 @@ mod tests {
     fn cleanup_forgets_pending_attribution_enrollments() {
         let tracker = ConnectionTracker::new();
         tracker.ingest(&plain_udp_packet());
-        assert_eq!(tracker.dns_attribution.pending_len(), 1);
-
         let removed = tracker.cleanup(SystemTime::now() + Duration::from_secs(86_400));
         assert_eq!(removed.len(), 1);
-        assert_eq!(
-            tracker.dns_attribution.pending_len(),
-            0,
-            "cleanup must forget the dead connection's enrollment"
-        );
 
         let answered_ip: std::net::IpAddr = "203.0.113.80".parse().unwrap();
         tracker.ingest(&dns_answer_packet(1, "posthumous.example", &[answered_ip]));
         assert!(
             tracker
-                .historic_snapshot()
+                .historic
                 .iter()
                 .all(|conn| conn.attributed_hostname.is_none()),
             "a response after death must not label the archived record"

--- a/crates/rustnet-core/src/network/types/connection.rs
+++ b/crates/rustnet-core/src/network/types/connection.rs
@@ -412,22 +412,7 @@ impl Connection {
     /// Get display state with enhanced UDP/QUIC visibility
     pub fn state(&self) -> Cow<'_, str> {
         match &self.protocol_state {
-            ProtocolState::Tcp(tcp_state) => {
-                let name = match tcp_state {
-                    TcpState::SynSent => "SYN_SENT",
-                    TcpState::SynReceived => "SYN_RECV",
-                    TcpState::Established => "ESTABLISHED",
-                    TcpState::FinWait1 => "FIN_WAIT1",
-                    TcpState::FinWait2 => "FIN_WAIT2",
-                    TcpState::CloseWait => "CLOSE_WAIT",
-                    TcpState::LastAck => "LAST_ACK",
-                    TcpState::TimeWait => "TIME_WAIT",
-                    TcpState::Closing => "CLOSING",
-                    TcpState::Closed => "CLOSED",
-                    TcpState::Unknown => "TCP_UNKNOWN",
-                };
-                Cow::Borrowed(name)
-            }
+            ProtocolState::Tcp(tcp_state) => Cow::Borrowed(tcp_state.as_str()),
             ProtocolState::Udp => {
                 // Check if it's a DPI-identified protocol
                 if let Some(dpi_info) = &self.dpi_info {
@@ -733,7 +718,6 @@ mod tests {
     };
     use std::net::{IpAddr, Ipv4Addr};
     use std::path::PathBuf;
-    use std::time::Instant;
 
     fn create_test_connection() -> Connection {
         Connection::new(
@@ -842,97 +826,6 @@ mod tests {
     }
 
     #[test]
-    fn test_connection_rate_integration() {
-        let mut conn = create_test_connection();
-        let start = Instant::now();
-
-        // Simulate receiving packets - use internal rate_tracker directly for deterministic timing
-        conn.bytes_sent = 1000;
-        conn.bytes_received = 500;
-        conn.rate_tracker
-            .update_at_time(start, conn.bytes_sent, conn.bytes_received);
-
-        conn.bytes_sent = 3000;
-        conn.bytes_received = 1500;
-        conn.rate_tracker.update_at_time(
-            start + Duration::from_secs(1),
-            conn.bytes_sent,
-            conn.bytes_received,
-        );
-
-        // Update cached rate values
-        conn.current_outgoing_rate_bps = conn
-            .rate_tracker
-            .get_outgoing_rate_at(start + Duration::from_secs(1));
-        conn.current_incoming_rate_bps = conn
-            .rate_tracker
-            .get_incoming_rate_at(start + Duration::from_secs(1));
-
-        // Verify backward compatibility fields are updated
-        assert!(conn.current_outgoing_rate_bps >= 0.0);
-        assert!(conn.current_incoming_rate_bps >= 0.0);
-    }
-
-    #[test]
-    fn test_connection_refresh_rates() {
-        // Test that refresh_rates() properly updates cached rate values
-        let mut conn = create_test_connection();
-        let start = Instant::now();
-
-        // Initialize the rate tracker properly
-        conn.rate_tracker.initialize_with_counts(0, 0);
-
-        // Simulate first packet
-        conn.bytes_sent = 50_000;
-        conn.bytes_received = 25_000;
-        conn.rate_tracker
-            .update_at_time(start, conn.bytes_sent, conn.bytes_received);
-
-        // Simulate more traffic after 1 second
-        conn.bytes_sent = 100_000;
-        conn.bytes_received = 50_000;
-        conn.rate_tracker.update_at_time(
-            start + Duration::from_secs(1),
-            conn.bytes_sent,
-            conn.bytes_received,
-        );
-
-        // Update cached rates at the 1-second mark
-        let check_time = start + Duration::from_secs(1);
-        conn.current_outgoing_rate_bps = conn.rate_tracker.get_outgoing_rate_at(check_time);
-        conn.current_incoming_rate_bps = conn.rate_tracker.get_incoming_rate_at(check_time);
-
-        // Should have non-zero rates after recent traffic (>= 1 second of data)
-        assert!(
-            conn.current_outgoing_rate_bps > 0.0,
-            "Should have outgoing rate: {}",
-            conn.current_outgoing_rate_bps
-        );
-        assert!(
-            conn.current_incoming_rate_bps > 0.0,
-            "Should have incoming rate: {}",
-            conn.current_incoming_rate_bps
-        );
-
-        // Check rates at a time after samples become stale
-        // Newest sample is at start+1s, window is 10s, threshold is 1.1x
-        // So need to check at > start + 1s + 11s = start + 12.1s
-        let idle_time = start + Duration::from_millis(12200);
-        conn.current_outgoing_rate_bps = conn.rate_tracker.get_outgoing_rate_at(idle_time);
-        conn.current_incoming_rate_bps = conn.rate_tracker.get_incoming_rate_at(idle_time);
-
-        // Rates should be zero after long idle
-        assert_eq!(
-            conn.current_outgoing_rate_bps, 0.0,
-            "Should be zero after 10+ seconds idle"
-        );
-        assert_eq!(
-            conn.current_incoming_rate_bps, 0.0,
-            "Should be zero after 10+ seconds idle"
-        );
-    }
-
-    #[test]
     fn test_enhanced_state_display_tcp() {
         let mut conn = create_test_connection();
 
@@ -966,7 +859,6 @@ mod tests {
 
         let dpi_info = DpiInfo {
             application: ApplicationProtocol::Quic(Box::new(quic_info.clone())),
-            last_update_time: Instant::now(),
         };
         conn.dpi_info = Some(dpi_info);
 
@@ -977,7 +869,6 @@ mod tests {
         quic_connected.connection_state = QuicConnectionState::Connected;
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Quic(Box::new(quic_connected)),
-            last_update_time: Instant::now(),
         });
         assert_eq!(conn.state(), "QUIC_CONNECTED");
 
@@ -986,7 +877,6 @@ mod tests {
         quic_draining.connection_state = QuicConnectionState::Draining;
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Quic(Box::new(quic_draining)),
-            last_update_time: Instant::now(),
         });
         assert_eq!(conn.state(), "QUIC_DRAINING");
     }
@@ -1013,7 +903,6 @@ mod tests {
 
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Dns(dns_query),
-            last_update_time: Instant::now(),
         });
         assert_eq!(conn.state(), "DNS_QUERY");
 
@@ -1030,7 +919,6 @@ mod tests {
 
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Dns(dns_response),
-            last_update_time: Instant::now(),
         });
         assert_eq!(conn.state(), "DNS_RESPONSE");
     }
@@ -1094,7 +982,6 @@ mod tests {
 
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Quic(Box::new(quic_info)),
-            last_update_time: Instant::now(),
         });
 
         assert_eq!(conn.get_timeout(), Duration::from_secs(15));
@@ -1108,7 +995,6 @@ mod tests {
 
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Quic(Box::new(quic_app_close)),
-            last_update_time: Instant::now(),
         });
 
         assert_eq!(conn.get_timeout(), Duration::from_secs(15));
@@ -1135,7 +1021,6 @@ mod tests {
 
         conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Dns(dns_info),
-            last_update_time: Instant::now(),
         });
 
         assert_eq!(conn.get_timeout(), Duration::from_secs(30)); // Short timeout for DNS

--- a/crates/rustnet-core/src/network/types/graph.rs
+++ b/crates/rustnet-core/src/network/types/graph.rs
@@ -147,29 +147,6 @@ impl TrafficHistory {
         }
     }
 
-    /// Add a new sample
-    pub fn add_sample(
-        &mut self,
-        rx_bytes_per_sec: u64,
-        tx_bytes_per_sec: u64,
-        connection_count: usize,
-        packets_per_sec: u64,
-        retransmits_per_sec: u64,
-        avg_rtt_ms: Option<f64>,
-    ) {
-        self.add_sample_with_lifecycle(
-            rx_bytes_per_sec,
-            tx_bytes_per_sec,
-            ConnectionLifecycleSample {
-                active: connection_count,
-                ..ConnectionLifecycleSample::default()
-            },
-            packets_per_sec,
-            retransmits_per_sec,
-            avg_rtt_ms,
-        );
-    }
-
     /// Add a traffic sample with connection lifecycle activity.
     pub fn add_sample_with_lifecycle(
         &mut self,
@@ -334,11 +311,6 @@ impl TrafficHistory {
         self.sparkline(count, |s| s.smoothed_tx_bytes_per_sec)
     }
 
-    /// Get active connection count values for sparkline (newest last)
-    pub fn get_connection_sparkline_data(&self, count: usize) -> Vec<u64> {
-        self.sparkline(count, |s| s.connection_count as u64)
-    }
-
     pub fn get_opened_sparkline_data(&self, count: usize) -> Vec<u64> {
         self.sparkline(count, |s| s.smoothed_opened_connections_per_sec_tenths)
     }
@@ -457,35 +429,55 @@ impl Default for TrafficHistory {
 mod tests {
     use super::*;
 
+    fn add_sample(
+        history: &mut TrafficHistory,
+        rx_bytes_per_sec: u64,
+        tx_bytes_per_sec: u64,
+        connection_count: usize,
+        packets_per_sec: u64,
+        retransmits_per_sec: u64,
+        avg_rtt_ms: Option<f64>,
+    ) {
+        history.add_sample_with_lifecycle(
+            rx_bytes_per_sec,
+            tx_bytes_per_sec,
+            ConnectionLifecycleSample {
+                active: connection_count,
+                ..ConnectionLifecycleSample::default()
+            },
+            packets_per_sec,
+            retransmits_per_sec,
+            avg_rtt_ms,
+        );
+    }
+
     #[test]
-    fn sparkline_getters_return_last_count_oldest_first() {
+    fn rate_sparklines_return_last_count_oldest_first() {
         // Distinct rx/tx/conn values per sample so ordering bugs are visible.
         let mut hist = TrafficHistory::new(100);
         for i in 1u64..=5 {
-            hist.add_sample(i * 10, i * 100, i as usize, 0, 0, None);
+            add_sample(&mut hist, i * 10, i * 100, i as usize, 0, 0, None);
         }
 
         // Fewer than available: keep the N newest stored samples in order.
         assert_eq!(hist.get_rx_sparkline_data(2), vec![30, 40]);
         assert_eq!(hist.get_tx_sparkline_data(2), vec![300, 400]);
-        assert_eq!(hist.get_connection_sparkline_data(3), vec![3, 4, 5]);
-
-        // count exceeds sample count: return everything, oldest→newest.
-        assert_eq!(hist.get_connection_sparkline_data(99), vec![1, 2, 3, 4, 5]);
+        // count exceeds sample count: return everything, oldest to newest.
+        assert_eq!(hist.get_rx_sparkline_data(99), vec![10, 15, 20, 30, 40]);
 
         // count == 0: empty.
-        assert!(hist.get_connection_sparkline_data(0).is_empty());
+        assert!(hist.get_rx_sparkline_data(0).is_empty());
 
         // Empty history: empty out, no panic.
         let empty = TrafficHistory::new(10);
-        assert!(empty.get_connection_sparkline_data(5).is_empty());
+        assert!(empty.get_rx_sparkline_data(5).is_empty());
     }
 
     #[test]
     fn sparkline_smoothing_preserves_the_full_history_window() {
         let mut history = TrafficHistory::new(5);
         for i in 1u64..=5 {
-            history.add_sample(i * 10, i * 100, 1, 0, 0, None);
+            add_sample(&mut history, i * 10, i * 100, 1, 0, 0, None);
         }
 
         let rx = history.get_rx_sparkline_data(usize::MAX);
@@ -539,11 +531,11 @@ mod tests {
     fn trimming_history_does_not_resmooth_the_left_edge() {
         let mut history = TrafficHistory::new(3);
         for value in [100, 200, 300] {
-            history.add_sample(value, value, 1, 0, 0, None);
+            add_sample(&mut history, value, value, 1, 0, 0, None);
         }
         assert_eq!(history.get_rx_sparkline_data(usize::MAX), [100, 150, 200]);
 
-        history.add_sample(400, 400, 1, 0, 0, None);
+        add_sample(&mut history, 400, 400, 1, 0, 0, None);
 
         assert_eq!(history.get_rx_sparkline_data(usize::MAX), [150, 200, 300]);
     }
@@ -586,11 +578,11 @@ mod tests {
     #[test]
     fn traffic_scale_forgets_peaks_after_they_leave_the_window() {
         let mut history = TrafficHistory::new(3);
-        history.add_sample(10_000, 10_000, 1, 0, 0, None);
+        add_sample(&mut history, 10_000, 10_000, 1, 0, 0, None);
         assert_eq!(history.rx_scale.target, 16_384);
 
         for _ in 0..5 {
-            history.add_sample(1_000, 1_000, 1, 0, 0, None);
+            add_sample(&mut history, 1_000, 1_000, 1, 0, 0, None);
         }
 
         assert_eq!(history.get_rx_sparkline_data(usize::MAX), [1_000; 3]);
@@ -607,7 +599,7 @@ mod tests {
         let mut history = TrafficHistory::new(60);
 
         // Add sample with 100 packets and 5 retransmits (5% loss)
-        history.add_sample(1000, 500, 10, 100, 5, Some(25.0));
+        add_sample(&mut history, 1000, 500, 10, 100, 5, Some(25.0));
 
         let (loss_data, rtt_data) = history.get_health_chart_data();
 
@@ -627,7 +619,7 @@ mod tests {
         let mut history = TrafficHistory::new(60);
 
         // Add sample with 0 packets (no loss calculation possible)
-        history.add_sample(1000, 500, 10, 0, 0, None);
+        add_sample(&mut history, 1000, 500, 10, 0, 0, None);
 
         let (loss_data, rtt_data) = history.get_health_chart_data();
 
@@ -645,7 +637,15 @@ mod tests {
 
         // Add multiple samples
         for i in 0..5 {
-            history.add_sample(1000, 500, 10, 100, i * 2, Some((i * 10) as f64));
+            add_sample(
+                &mut history,
+                1000,
+                500,
+                10,
+                100,
+                i * 2,
+                Some((i * 10) as f64),
+            );
             std::thread::sleep(Duration::from_millis(10));
         }
 

--- a/crates/rustnet-core/src/network/types/identity.rs
+++ b/crates/rustnet-core/src/network/types/identity.rs
@@ -12,7 +12,6 @@ use std::path::PathBuf;
 /// Defined here rather than in `rustnet-host` because
 /// [`Connection`](crate::network::types::Connection) carries it
 /// and `rustnet-host` depends on this crate, not the other way round.
-/// `rustnet-host` re-exports it.
 ///
 /// Marked `#[non_exhaustive]` so new relaxation shapes can be added without
 /// breaking downstream `match` arms.
@@ -31,9 +30,7 @@ pub enum MatchQuality {
     ProcfsExact,
     /// procfs match that needed a relaxed key.
     ProcfsRelaxed,
-    /// The backend reported an owner but not how it matched. Produced by the
-    /// compatibility bridge for platforms that still only implement the
-    /// `(pid, name)` tuple API.
+    /// The backend reported an owner but could not report match provenance.
     Unspecified,
 }
 
@@ -149,22 +146,27 @@ pub enum TcpState {
     Unknown,
 }
 
+impl TcpState {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::SynSent => "SYN_SENT",
+            Self::SynReceived => "SYN_RECV",
+            Self::Established => "ESTABLISHED",
+            Self::FinWait1 => "FIN_WAIT1",
+            Self::FinWait2 => "FIN_WAIT2",
+            Self::CloseWait => "CLOSE_WAIT",
+            Self::LastAck => "LAST_ACK",
+            Self::TimeWait => "TIME_WAIT",
+            Self::Closing => "CLOSING",
+            Self::Closed => "CLOSED",
+            Self::Unknown => "TCP_UNKNOWN",
+        }
+    }
+}
+
 impl fmt::Display for TcpState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = match self {
-            TcpState::SynSent => "SYN_SENT",
-            TcpState::SynReceived => "SYN_RECV",
-            TcpState::Established => "ESTABLISHED",
-            TcpState::FinWait1 => "FIN_WAIT1",
-            TcpState::FinWait2 => "FIN_WAIT2",
-            TcpState::CloseWait => "CLOSE_WAIT",
-            TcpState::LastAck => "LAST_ACK",
-            TcpState::TimeWait => "TIME_WAIT",
-            TcpState::Closing => "CLOSING",
-            TcpState::Closed => "CLOSED",
-            TcpState::Unknown => "TCP_UNKNOWN",
-        };
-        write!(f, "{}", name)
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/rustnet-core/src/network/types/protocol_info.rs
+++ b/crates/rustnet-core/src/network/types/protocol_info.rs
@@ -1267,7 +1267,6 @@ impl CryptoFrameReassembler {
 #[derive(Debug, Clone)]
 pub struct DpiInfo {
     pub application: ApplicationProtocol,
-    pub last_update_time: Instant,
 }
 
 #[cfg(test)]

--- a/crates/rustnet-core/src/network/types/rates.rs
+++ b/crates/rustnet-core/src/network/types/rates.rs
@@ -48,7 +48,7 @@ impl RateTracker {
         Self::with_window_duration(Duration::from_secs(10))
     }
 
-    pub fn with_window_duration(window_duration: Duration) -> Self {
+    fn with_window_duration(window_duration: Duration) -> Self {
         Self {
             samples: Arc::new(VecDeque::new()),
             window_duration,
@@ -235,22 +235,6 @@ impl RateTracker {
             window_received_total: 0,
         }
     }
-
-    // Test-only methods for deterministic testing with controlled timestamps
-    #[cfg(test)]
-    pub fn update_at_time(&mut self, now: Instant, bytes_sent: u64, bytes_received: u64) {
-        self.update_at(now, bytes_sent, bytes_received);
-    }
-
-    #[cfg(test)]
-    pub fn get_outgoing_rate_at(&self, now: Instant) -> f64 {
-        self.get_outgoing_rate_bps_at(now)
-    }
-
-    #[cfg(test)]
-    pub fn get_incoming_rate_at(&self, now: Instant) -> f64 {
-        self.get_incoming_rate_bps_at(now)
-    }
 }
 
 impl Default for RateTracker {
@@ -295,9 +279,6 @@ pub struct TcpAnalytics {
     pub rtt_probe: Option<(u32, SystemTime)>,
     /// EWMA of data round trips (RFC 6298 style: 7/8 old + 1/8 sample).
     pub smoothed_rtt: Option<Duration>,
-    /// Most recent raw sample, before smoothing.
-    pub last_rtt: Option<Duration>,
-    pub rtt_samples: u64,
 }
 
 impl TcpAnalytics {
@@ -317,8 +298,6 @@ impl TcpAnalytics {
             last_window_size: 0,
             rtt_probe: None,
             smoothed_rtt: None,
-            last_rtt: None,
-            rtt_samples: 0,
         }
     }
 }
@@ -384,18 +363,18 @@ mod tests {
         let start = Instant::now();
 
         // Initialize with 0 bytes
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
 
         // Simulate steady traffic: 10,000 bytes/sec for 2 seconds
         // 1000 bytes every 100ms = 10KB/s out, 5KB/s in
         for i in 1..=20_u64 {
             let t = start + Duration::from_millis(i * 100);
-            tracker.update_at_time(t, i * 1000, i * 500);
+            tracker.update_at(t, i * 1000, i * 500);
         }
 
         let final_time = start + Duration::from_millis(2000);
-        let outgoing_rate = tracker.get_outgoing_rate_at(final_time);
-        let incoming_rate = tracker.get_incoming_rate_at(final_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(final_time);
+        let incoming_rate = tracker.get_incoming_rate_bps_at(final_time);
 
         // Should converge to actual sustained rate
         // 1000 bytes / 0.1s = 10,000 bytes/sec outgoing
@@ -417,19 +396,19 @@ mod tests {
         let mut tracker = RateTracker::new();
         let start = Instant::now();
 
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
 
         // Large burst: 1MB in one shot at 500ms
-        tracker.update_at_time(start + Duration::from_millis(500), 1_000_000, 500_000);
+        tracker.update_at(start + Duration::from_millis(500), 1_000_000, 500_000);
 
         // Then slow traffic: 10KB every 100ms
         for i in 1..=10_u64 {
             let t = start + Duration::from_millis(500 + 100 + i * 100);
-            tracker.update_at_time(t, 1_000_000 + i * 10_000, 500_000 + i * 5_000);
+            tracker.update_at(t, 1_000_000 + i * 10_000, 500_000 + i * 5_000);
         }
 
         let final_time = start + Duration::from_millis(1600);
-        let outgoing_rate = tracker.get_outgoing_rate_at(final_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(final_time);
 
         // Rate should be averaged over the whole window
         // Total bytes sent: 1MB burst + 100KB slow = 1.1MB over 1.6s = ~687.5 KB/s
@@ -445,18 +424,18 @@ mod tests {
         let mut tracker = RateTracker::new();
         let start = Instant::now();
 
-        tracker.update_at_time(start, 0, 0);
-        tracker.update_at_time(start + Duration::from_millis(100), 10_000, 5_000);
+        tracker.update_at(start, 0, 0);
+        tracker.update_at(start + Duration::from_millis(100), 10_000, 5_000);
 
         // With only 100ms of data (< 1 second minimum), should return 0
         let check_time = start + Duration::from_millis(100);
         assert_eq!(
-            tracker.get_outgoing_rate_at(check_time),
+            tracker.get_outgoing_rate_bps_at(check_time),
             0.0,
             "Should return 0 when time_span < 1 second"
         );
         assert_eq!(
-            tracker.get_incoming_rate_at(check_time),
+            tracker.get_incoming_rate_bps_at(check_time),
             0.0,
             "Should return 0 when time_span < 1 second"
         );
@@ -467,18 +446,18 @@ mod tests {
         let mut tracker = RateTracker::new();
         let start = Instant::now();
 
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
 
         // Simulate high packet rate: 100 packets/sec for 2 seconds = 200 packets
         // Each packet is 1500 bytes, 10ms intervals
         for i in 1..=200_u64 {
             let t = start + Duration::from_millis(i * 10);
-            tracker.update_at_time(t, i * 1500, i * 750);
+            tracker.update_at(t, i * 1500, i * 750);
         }
 
         let final_time = start + Duration::from_millis(2000);
-        let outgoing_rate = tracker.get_outgoing_rate_at(final_time);
-        let incoming_rate = tracker.get_incoming_rate_at(final_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(final_time);
+        let incoming_rate = tracker.get_incoming_rate_bps_at(final_time);
 
         // Expected: 1500 bytes / 0.01s = 150,000 bytes/sec = ~150 KB/s outgoing
         // 750 bytes / 0.01s = 75,000 bytes/sec = ~75 KB/s incoming
@@ -499,16 +478,16 @@ mod tests {
         let mut tracker = RateTracker::new();
         let start = Instant::now();
 
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
 
         // Add exactly one more sample after 1 second
-        tracker.update_at_time(start + Duration::from_secs(1), 10_000, 5_000);
+        tracker.update_at(start + Duration::from_secs(1), 10_000, 5_000);
 
         // Now we have 2 samples spanning 1 second with 10,000 bytes transferred
         // This should give us 10,000 bytes/sec
         // If we were .skip(1), we'd get 0 because we'd skip the only data sample!
         let check_time = start + Duration::from_secs(1);
-        let outgoing_rate = tracker.get_outgoing_rate_at(check_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(check_time);
 
         assert!(
             (outgoing_rate - 10_000.0).abs() < 1.0,
@@ -523,15 +502,15 @@ mod tests {
         let start = Instant::now();
 
         // Establish some traffic
-        tracker.update_at_time(start, 0, 0);
-        tracker.update_at_time(start + Duration::from_millis(500), 100_000, 50_000);
+        tracker.update_at(start, 0, 0);
+        tracker.update_at(start + Duration::from_millis(500), 100_000, 50_000);
 
         // Check at a time beyond the 10-second window (samples become stale)
         let check_time = start + Duration::from_secs(12);
 
         // Should return 0 as all samples are outside the window
         assert_eq!(
-            tracker.get_outgoing_rate_at(check_time),
+            tracker.get_outgoing_rate_bps_at(check_time),
             0.0,
             "Should return 0 when window has slid past all traffic"
         );
@@ -553,7 +532,7 @@ mod tests {
         let mut tracker = RateTracker::new();
         let start = Instant::now();
         for i in 0..10_u64 {
-            tracker.update_at_time(start + Duration::from_millis(i * 100), i * 1000, i * 500);
+            tracker.update_at(start + Duration::from_millis(i * 100), i * 1000, i * 500);
         }
 
         let detached = tracker.clone_without_samples();
@@ -580,7 +559,7 @@ mod tests {
         for i in 0..50u64 {
             bytes_sent += 100 + i;
             bytes_recv += 50 + i;
-            tracker.update_at_time(
+            tracker.update_at(
                 start + Duration::from_millis(i * 40),
                 bytes_sent,
                 bytes_recv,
@@ -608,7 +587,7 @@ mod tests {
         for i in 0..20u64 {
             sent += 10 * (i + 1);
             recv += 5 * (i + 1);
-            tracker.update_at_time(start + Duration::from_millis(i * 100), sent, recv);
+            tracker.update_at(start + Duration::from_millis(i * 100), sent, recv);
         }
 
         assert!(tracker.samples.len() <= 8, "cap must be enforced");
@@ -622,8 +601,8 @@ mod tests {
     fn test_rate_tracker_prune_noop_avoids_cow() {
         let mut tracker = RateTracker::new();
         let start = Instant::now();
-        tracker.update_at_time(start, 100, 50);
-        tracker.update_at_time(start + Duration::from_millis(100), 200, 100);
+        tracker.update_at(start, 100, 50);
+        tracker.update_at(start + Duration::from_millis(100), 200, 100);
 
         // Share the buffer (as a full clone would), then prune with nothing
         // prunable: the fast path must not deep-copy via Arc::make_mut.
@@ -643,14 +622,14 @@ mod tests {
         let start = Instant::now();
 
         // Add initial sample
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
 
         // Add second sample - 5000 bytes sent, 2500 received over 1 second
-        tracker.update_at_time(start + Duration::from_secs(1), 5000, 2500);
+        tracker.update_at(start + Duration::from_secs(1), 5000, 2500);
 
         let check_time = start + Duration::from_secs(1);
-        let outgoing_rate = tracker.get_outgoing_rate_at(check_time);
-        let incoming_rate = tracker.get_incoming_rate_at(check_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(check_time);
+        let incoming_rate = tracker.get_incoming_rate_bps_at(check_time);
 
         // Should be exactly 5000 bytes/sec outgoing, 2500 bytes/sec incoming
         assert!(
@@ -671,18 +650,18 @@ mod tests {
         let start = Instant::now();
 
         // Simulate steady transfer over time
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
 
         // Add samples every 100ms for 1.5 seconds (15 samples)
         // 1000 bytes/100ms = 10KB/s, 500 bytes/100ms = 5KB/s
         for i in 1..=15_u64 {
             let t = start + Duration::from_millis(i * 100);
-            tracker.update_at_time(t, i * 1000, i * 500);
+            tracker.update_at(t, i * 1000, i * 500);
         }
 
         let final_time = start + Duration::from_millis(1500);
-        let outgoing_rate = tracker.get_outgoing_rate_at(final_time);
-        let incoming_rate = tracker.get_incoming_rate_at(final_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(final_time);
+        let incoming_rate = tracker.get_incoming_rate_bps_at(final_time);
 
         // Should be exactly 10000 bytes/sec outgoing, 5000 bytes/sec incoming
         assert!(
@@ -704,15 +683,15 @@ mod tests {
         let start = Instant::now();
 
         // Add samples that will be pruned
-        tracker.update_at_time(start, 0, 0);
-        tracker.update_at_time(start + Duration::from_millis(100), 1000, 500);
+        tracker.update_at(start, 0, 0);
+        tracker.update_at(start + Duration::from_millis(100), 1000, 500);
 
         // Add a sample after the window has slid past the first samples
-        tracker.update_at_time(start + Duration::from_millis(500), 2000, 1000);
+        tracker.update_at(start + Duration::from_millis(500), 2000, 1000);
 
         // Check rate - the first samples should be pruned
         let check_time = start + Duration::from_millis(500);
-        let rate = tracker.get_outgoing_rate_at(check_time);
+        let rate = tracker.get_outgoing_rate_bps_at(check_time);
         // After pruning, should have limited data - just verify it works
         assert!(rate >= 0.0);
     }
@@ -723,10 +702,10 @@ mod tests {
         let start = Instant::now();
 
         // Add more samples than we need, ensuring we span > 1 second
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
         for i in 1..=150_u64 {
             let t = start + Duration::from_millis(i * 10); // 10ms intervals = 1.5 seconds total
-            tracker.update_at_time(t, i * 100, i * 50);
+            tracker.update_at(t, i * 100, i * 50);
         }
 
         // Should have pruned to max_samples limit (20,000)
@@ -734,8 +713,8 @@ mod tests {
 
         // Should still calculate rates (we have > 1 second of data)
         let check_time = start + Duration::from_millis(1500);
-        let outgoing_rate = tracker.get_outgoing_rate_at(check_time);
-        let incoming_rate = tracker.get_incoming_rate_at(check_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(check_time);
+        let incoming_rate = tracker.get_incoming_rate_bps_at(check_time);
         assert!(outgoing_rate >= 0.0);
         assert!(incoming_rate >= 0.0);
     }
@@ -746,20 +725,20 @@ mod tests {
         let start = Instant::now();
 
         // Initial state
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
 
         // Burst of traffic at 500ms
-        tracker.update_at_time(start + Duration::from_millis(500), 10000, 5000);
+        tracker.update_at(start + Duration::from_millis(500), 10000, 5000);
 
         // No more traffic (same byte counts) - keep updating to span > 1 second
-        tracker.update_at_time(start + Duration::from_millis(1000), 10000, 5000);
-        tracker.update_at_time(start + Duration::from_millis(1500), 10000, 5000);
+        tracker.update_at(start + Duration::from_millis(1000), 10000, 5000);
+        tracker.update_at(start + Duration::from_millis(1500), 10000, 5000);
 
         // Rate should be averaged over the entire window (1.5 seconds)
         // 10,000 bytes over 1.5 seconds ≈ 6,666 bytes/sec
         let check_time = start + Duration::from_millis(1500);
-        let outgoing_rate = tracker.get_outgoing_rate_at(check_time);
-        let incoming_rate = tracker.get_incoming_rate_at(check_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(check_time);
+        let incoming_rate = tracker.get_incoming_rate_bps_at(check_time);
 
         // Should be smoothed average: 10000 / 1.5 = 6666.67 bytes/sec
         assert!(
@@ -796,16 +775,16 @@ mod tests {
         // Simulate a connection that has been running for a while with cumulative byte counts
         // Initialize tracker to simulate connection with existing traffic
         tracker.initialize_with_counts(1_000_000, 500_000);
-        tracker.update_at_time(start, 1_000_000, 500_000); // No change yet (establishing baseline)
+        tracker.update_at(start, 1_000_000, 500_000); // No change yet (establishing baseline)
 
-        tracker.update_at_time(start + Duration::from_millis(500), 1_500_000, 750_000); // 500KB more sent, 250KB more received
-        tracker.update_at_time(start + Duration::from_millis(1000), 2_000_000, 1_000_000); // 500KB more sent, 250KB more received
+        tracker.update_at(start + Duration::from_millis(500), 1_500_000, 750_000); // 500KB more sent, 250KB more received
+        tracker.update_at(start + Duration::from_millis(1000), 2_000_000, 1_000_000); // 500KB more sent, 250KB more received
 
         // The rate should be based on the deltas, not the cumulative values
         // We sent 1MB in deltas over 1 second = 1MB/s
         let check_time = start + Duration::from_millis(1000);
-        let outgoing_rate = tracker.get_outgoing_rate_at(check_time);
-        let incoming_rate = tracker.get_incoming_rate_at(check_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(check_time);
+        let incoming_rate = tracker.get_incoming_rate_bps_at(check_time);
 
         // Should be exactly 1MB/s outgoing (1_000_000 bytes/sec)
         assert!(
@@ -830,10 +809,10 @@ mod tests {
         let start = Instant::now();
 
         // Add initial samples - 1MB/s for first second (100KB every 100ms = 11 samples total)
-        tracker.update_at_time(start, 0, 0);
+        tracker.update_at(start, 0, 0);
         for i in 1..=10_u64 {
             let t = start + Duration::from_millis(i * 100);
-            tracker.update_at_time(t, i * 100_000, i * 50_000);
+            tracker.update_at(t, i * 100_000, i * 50_000);
         }
 
         // After window slides past first samples (at 3 seconds), add new samples
@@ -841,14 +820,14 @@ mod tests {
         // Need >= 1 second span, so 11 samples at 100ms intervals = 1.0s span
         for i in 0..=10_u64 {
             let t = start + Duration::from_millis(3000 + i * 100);
-            tracker.update_at_time(t, 1_000_000 + i * 100_000, 500_000 + i * 50_000);
+            tracker.update_at(t, 1_000_000 + i * 100_000, 500_000 + i * 50_000);
         }
 
         // Rate should be consistent: 10 deltas of 100KB over 1 second = 1MB/s
         let check_time = start + Duration::from_millis(4000);
         tracker.prune();
-        let outgoing_rate = tracker.get_outgoing_rate_at(check_time);
-        let incoming_rate = tracker.get_incoming_rate_at(check_time);
+        let outgoing_rate = tracker.get_outgoing_rate_bps_at(check_time);
+        let incoming_rate = tracker.get_incoming_rate_bps_at(check_time);
 
         // We're sending at 1MB/s and receiving at 500KB/s
         assert!(
@@ -870,13 +849,13 @@ mod tests {
         let start = Instant::now();
 
         // Simulate active traffic
-        tracker.update_at_time(start, 0, 0);
-        tracker.update_at_time(start + Duration::from_secs(1), 100_000, 50_000); // 100KB sent, 50KB received over 1 second
+        tracker.update_at(start, 0, 0);
+        tracker.update_at(start + Duration::from_secs(1), 100_000, 50_000); // 100KB sent, 50KB received over 1 second
 
         // Should have non-zero rate with >= 1 second of data
         let check_time_active = start + Duration::from_secs(1);
-        let initial_out = tracker.get_outgoing_rate_at(check_time_active);
-        let initial_in = tracker.get_incoming_rate_at(check_time_active);
+        let initial_out = tracker.get_outgoing_rate_bps_at(check_time_active);
+        let initial_in = tracker.get_incoming_rate_bps_at(check_time_active);
         assert!(
             (initial_out - 100_000.0).abs() < 1.0,
             "Should have outgoing traffic: {}",
@@ -893,8 +872,8 @@ mod tests {
         // So need to check at > start + 1s + 11s = start + 12.1s
         let check_time_idle = start + Duration::from_millis(12200);
 
-        let final_out = tracker.get_outgoing_rate_at(check_time_idle);
-        let final_in = tracker.get_incoming_rate_at(check_time_idle);
+        let final_out = tracker.get_outgoing_rate_bps_at(check_time_idle);
+        let final_in = tracker.get_incoming_rate_bps_at(check_time_idle);
 
         // After window slides past all samples, should be zero
         assert_eq!(

--- a/crates/rustnet-core/src/network/types/rtt.rs
+++ b/crates/rustnet-core/src/network/types/rtt.rs
@@ -74,21 +74,6 @@ impl<K: Eq + std::hash::Hash, V: PendingStamp> PendingTable<K, V> {
     fn clear(&mut self) {
         self.map.clear();
     }
-
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.map.len()
-    }
-
-    #[cfg(test)]
-    fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
-
-    #[cfg(test)]
-    fn contains_key(&self, key: &K) -> bool {
-        self.map.contains_key(key)
-    }
 }
 
 impl<K: Eq + std::hash::Hash> PendingTable<K, (SystemTime, ConnectionKey)> {
@@ -527,7 +512,7 @@ mod tests {
     #[test]
     fn test_rtt_tracker_new() {
         let tracker = RttTracker::new();
-        assert!(tracker.pending_syns.is_empty());
+        assert!(tracker.pending_syns.map.is_empty());
         assert!(tracker.recent_rtts.is_empty());
     }
 
@@ -541,8 +526,8 @@ mod tests {
         );
 
         tracker.record_syn(key, rtt_capture_time(0));
-        assert_eq!(tracker.pending_syns.len(), 1);
-        assert!(tracker.pending_syns.contains_key(&key));
+        assert_eq!(tracker.pending_syns.map.len(), 1);
+        assert!(tracker.pending_syns.map.contains_key(&key));
     }
 
     #[test]
@@ -575,7 +560,7 @@ mod tests {
         let rtt = tracker.record_syn_ack(&syn_ack_key, rtt_capture_time(10));
 
         assert_eq!(rtt, Some(Duration::from_millis(10)));
-        assert!(tracker.pending_syns.is_empty());
+        assert!(tracker.pending_syns.map.is_empty());
         assert_eq!(tracker.recent_rtts.len(), 1);
     }
 
@@ -595,7 +580,7 @@ mod tests {
             );
             tracker.record_syn(key, rtt_capture_time(0));
         }
-        assert_eq!(tracker.pending_syns.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_syns.map.len(), MAX_PENDING);
 
         // One more distinct SYN is rejected...
         let overflow_key = ConnectionKey::new(
@@ -604,7 +589,7 @@ mod tests {
             remote,
         );
         tracker.record_syn(overflow_key, rtt_capture_time(1));
-        assert_eq!(tracker.pending_syns.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_syns.map.len(), MAX_PENDING);
         let rtt = tracker.record_syn_ack(&overflow_key, rtt_capture_time(20));
         assert!(rtt.is_none(), "a rejected SYN has no pending timestamp");
 
@@ -632,7 +617,7 @@ mod tests {
             );
             tracker.record_quic_handshake(key, true, rtt_capture_time(0));
         }
-        assert_eq!(tracker.pending_quic_handshakes.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_quic_handshakes.map.len(), MAX_PENDING);
 
         let overflow_key = ConnectionKey::new(
             Protocol::Udp,
@@ -640,7 +625,7 @@ mod tests {
             remote,
         );
         tracker.record_quic_handshake(overflow_key, true, rtt_capture_time(1));
-        assert_eq!(tracker.pending_quic_handshakes.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_quic_handshakes.map.len(), MAX_PENDING);
         let rtt = tracker.record_quic_handshake(overflow_key, false, rtt_capture_time(20));
         assert!(
             rtt.is_none(),
@@ -693,7 +678,7 @@ mod tests {
         tracker.record_dns_packet(key, 0x1234, true, false, rtt_capture_time(0));
         let rtt = tracker.record_dns_packet(key, 0x1234, false, true, rtt_capture_time(11_000));
         assert!(rtt.is_none(), "the pending query expired after 10s");
-        assert!(tracker.pending_dns.is_empty());
+        assert!(tracker.pending_dns.map.is_empty());
     }
 
     /// At the hard cap, new pending queries are dropped (losing samples under
@@ -709,13 +694,13 @@ mod tests {
         for txid in 0..MAX_PENDING as u16 {
             tracker.record_dns_packet(key, txid, true, false, rtt_capture_time(0));
         }
-        assert_eq!(tracker.pending_dns.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_dns.map.len(), MAX_PENDING);
 
         // One more distinct query is rejected...
         let overflow_key =
             ConnectionKey::new(Protocol::Udp, SocketAddr::new(local.ip(), 40_001), remote);
         tracker.record_dns_packet(overflow_key, 7, true, false, rtt_capture_time(1));
-        assert_eq!(tracker.pending_dns.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_dns.map.len(), MAX_PENDING);
         let rtt = tracker.record_dns_packet(overflow_key, 7, false, true, rtt_capture_time(20));
         assert!(rtt.is_none(), "a rejected query has no pending timestamp");
 
@@ -762,7 +747,7 @@ mod tests {
             second.is_none(),
             "only the first response completes the query"
         );
-        assert!(tracker.pending_dns.is_empty());
+        assert!(tracker.pending_dns.map.is_empty());
     }
 
     #[test]
@@ -793,7 +778,7 @@ mod tests {
             rtt_capture_time(11_000),
         );
         assert!(rtt.is_none(), "the pending query expired after 10s");
-        assert!(tracker.pending_dns.is_empty());
+        assert!(tracker.pending_dns.map.is_empty());
     }
 
     #[test]
@@ -810,7 +795,7 @@ mod tests {
         tracker.record_netbios_packet(key, &request, true, rtt_capture_time(0));
         let rtt = tracker.record_netbios_packet(key, &response, false, rtt_capture_time(11_000));
         assert!(rtt.is_none(), "the pending request expired after 10s");
-        assert!(tracker.pending_netbios.is_empty());
+        assert!(tracker.pending_netbios.map.is_empty());
     }
 
     #[test]
@@ -824,7 +809,7 @@ mod tests {
             let request = netbios_test_info(NetBiosService::NameService, transaction_id, false);
             tracker.record_netbios_packet(key, &request, true, rtt_capture_time(0));
         }
-        assert_eq!(tracker.pending_netbios.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_netbios.map.len(), MAX_PENDING);
 
         let overflow_key = ConnectionKey::new(
             Protocol::Udp,
@@ -834,7 +819,7 @@ mod tests {
         let overflow_request = netbios_test_info(NetBiosService::DatagramService, 7, false);
         let overflow_response = netbios_test_info(NetBiosService::DatagramService, 7, true);
         tracker.record_netbios_packet(overflow_key, &overflow_request, true, rtt_capture_time(1));
-        assert_eq!(tracker.pending_netbios.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_netbios.map.len(), MAX_PENDING);
         let rtt = tracker.record_netbios_packet(
             overflow_key,
             &overflow_response,
@@ -866,7 +851,7 @@ mod tests {
         tracker.record_icmp_echo(key, (7, 1), true, false, rtt_capture_time(0));
         let rtt = tracker.record_icmp_echo(key, (7, 1), false, true, rtt_capture_time(11_000));
         assert!(rtt.is_none(), "the pending echo expired after 10s");
-        assert!(tracker.pending_icmp_echoes.is_empty());
+        assert!(tracker.pending_icmp_echoes.map.is_empty());
     }
 
     #[test]
@@ -881,7 +866,7 @@ mod tests {
         for sequence in 0..MAX_PENDING as u16 {
             tracker.record_icmp_echo(key, (7, sequence), true, false, rtt_capture_time(0));
         }
-        assert_eq!(tracker.pending_icmp_echoes.len(), MAX_PENDING);
+        assert_eq!(tracker.pending_icmp_echoes.map.len(), MAX_PENDING);
 
         let rejected_sequence = MAX_PENDING as u16;
         tracker.record_icmp_echo(
@@ -939,7 +924,7 @@ mod tests {
             StunMessageClass::Indication,
             rtt_capture_time(100),
         );
-        assert!(tracker.pending_stun.is_empty());
+        assert!(tracker.pending_stun.map.is_empty());
     }
 
     #[test]
@@ -967,7 +952,7 @@ mod tests {
             rtt_capture_time(11_000),
         );
         assert!(rtt.is_none(), "the pending request expired after 10s");
-        assert!(tracker.pending_stun.is_empty());
+        assert!(tracker.pending_stun.map.is_empty());
     }
 
     fn ntp_info(mode: NtpMode, origin_timestamp: u64, transmit_timestamp: u64) -> NtpInfo {
@@ -1036,6 +1021,6 @@ mod tests {
             rtt_capture_time(11_000),
         );
         assert!(rtt.is_none(), "the pending request expired after 10s");
-        assert!(tracker.pending_ntp.is_empty());
+        assert!(tracker.pending_ntp.map.is_empty());
     }
 }

--- a/crates/rustnet-host/Cargo.toml
+++ b/crates/rustnet-host/Cargo.toml
@@ -19,13 +19,13 @@ path = "src/lib.rs"
 
 [features]
 # eBPF-based process attribution on Linux (libbpf). No effect on other platforms.
-ebpf = ["dep:libbpf-rs", "dep:libbpf-cargo"]
+ebpf = ["dep:bitflags", "dep:libbpf-rs", "dep:libbpf-cargo"]
 
 [dependencies]
 rustnet-core.workspace = true
 anyhow.workspace = true
 log.workspace = true
-bitflags = "2"
+bitflags = { version = "2", optional = true }
 # Used by the Linux eBPF loader (geteuid etc.), macOS lsof path, and FreeBSD.
 libc = "0.2"
 

--- a/crates/rustnet-host/README.md
+++ b/crates/rustnet-host/README.md
@@ -19,25 +19,15 @@ best strategy each platform offers, with graceful fallbacks:
 use rustnet_host::create_process_lookup;
 
 let lookup = create_process_lookup(/* use_pktap = */ false)?;
-if let Some((pid, name)) = lookup.get_process_for_connection(&conn) {
-    println!("{conn:?} owned by {name} ({pid})");
-}
-```
-
-Callers that want more than a pid and a name ask for a `ProcessAttribution`
-instead:
-
-```rust
 if let Some(attribution) = lookup.get_process_attribution(&conn) {
     println!(
-        "{} ({}) ppid={:?} uid={:?} exe={:?} lineage={:?} via {} ({} match)",
+        "{} ({}) ppid={:?} uid={:?} exe={:?} lineage={:?} ({} match)",
         attribution.name,
         attribution.tgid,
         attribution.ppid,
         attribution.uid,
         attribution.executable,
         attribution.lineage,
-        attribution.backend,
         attribution.quality,
     );
 }
@@ -59,9 +49,8 @@ truncation flag marks chains capped before another known parent.
 On macOS, PKTAP supplies an exact PID and process name with each packet. Libproc
 adds the PPID, executable path, and effective UID/GID. The fallback parses
 numeric UIDs from `lsof -l` and uses libproc for the other process details.
-PKTAP reports
-`AttributionBackend::Pktap` with `MatchQuality::ExactTuple`; lsof reports whether
-its socket-table match was exact, wildcard-bound, or a listener.
+PKTAP reports `MatchQuality::ExactTuple`; lsof reports whether its socket-table
+match was exact, wildcard-bound, or a listener.
 
 On FreeBSD, `sockstat` supplies the socket owner and native `sysctl` queries add
 the PPID, effective UID/GID, and executable path. Process details are cached by
@@ -74,9 +63,6 @@ creation times. Connection match quality remains `MatchQuality::Unspecified`.
 When a platform can't use its optimal method, `ProcessLookup::get_degradation_reason`
 reports why (e.g. missing `CAP_BPF`, no root for PKTAP) via `DegradationReason`,
 which front-ends can surface to the user.
-
-Linux callers can inspect `ProcessLookup::get_attribution_backend()` to
-distinguish fentry/fexit, legacy kprobes, and procfs.
 
 Both Linux BPF objects use CO-RE for safe socket field access and therefore
 require usable target BTF. A compatible target-BTF kernel tries fentry/fexit

--- a/crates/rustnet-host/src/freebsd/mod.rs
+++ b/crates/rustnet-host/src/freebsd/mod.rs
@@ -2,7 +2,7 @@
 
 mod process;
 
-pub use process::FreeBSDProcessLookup;
+use process::FreeBSDProcessLookup;
 
 use crate::ProcessLookup;
 use anyhow::Result;

--- a/crates/rustnet-host/src/freebsd/process.rs
+++ b/crates/rustnet-host/src/freebsd/process.rs
@@ -1,9 +1,9 @@
 // network/platform/freebsd/process.rs - FreeBSD sockstat-based process lookup
 
 use crate::{
-    AttributionBackend, ConnectionKey, MatchQuality, ProcessAncestor, ProcessAttribution,
-    ProcessLineage, ProcessLookup, ancestor_display_name, collect_process_lineage,
-    decode_process_name, memoized, parse_socket_addr_text, relaxed_lookup,
+    ConnectionKey, MatchQuality, ProcessAncestor, ProcessAttribution, ProcessLineage,
+    ProcessLookup, ancestor_display_name, collect_process_lineage, decode_process_name, memoized,
+    parse_socket_addr_text, relaxed_lookup,
 };
 use anyhow::{Context, Result};
 use rustnet_core::network::types::{Connection, Protocol};
@@ -14,21 +14,15 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::ptr;
 use std::sync::RwLock;
-use std::time::{Duration, Instant};
 
 const SOCKSTAT_PATH: &str = "/usr/bin/sockstat";
 
-pub struct FreeBSDProcessLookup {
+pub(super) struct FreeBSDProcessLookup {
     // Cache: ConnectionKey -> socket owner
-    cache: RwLock<ProcessCache>,
+    cache: RwLock<HashMap<ConnectionKey, FreeBsdProcessInfo>>,
     // A process may own many sockets. Resolve its metadata through sysctl once
     // per refresh generation rather than once per connection.
     process_details: RwLock<HashMap<u32, Option<FreeBsdProcessDetails>>>,
-}
-
-struct ProcessCache {
-    lookup: HashMap<ConnectionKey, FreeBsdProcessInfo>,
-    last_refresh: Instant,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,12 +43,9 @@ struct FreeBsdProcessDetails {
 }
 
 impl FreeBSDProcessLookup {
-    pub fn new() -> Result<Self> {
+    pub(super) fn new() -> Result<Self> {
         Ok(Self {
-            cache: RwLock::new(ProcessCache {
-                lookup: HashMap::new(),
-                last_refresh: Instant::now() - Duration::from_secs(3600),
-            }),
+            cache: RwLock::new(HashMap::new()),
             process_details: RwLock::new(HashMap::new()),
         })
     }
@@ -63,11 +54,11 @@ impl FreeBSDProcessLookup {
         let key = ConnectionKey::from_connection(conn);
         let cache = self.cache.read().expect("process cache lock poisoned");
 
-        if let Some(process) = cache.lookup.get(&key) {
+        if let Some(process) = cache.get(&key) {
             return Some((process.clone(), MatchQuality::ExactTuple));
         }
 
-        relaxed_lookup(&cache.lookup, &key).map(|(process, quality)| (process.clone(), quality))
+        relaxed_lookup(&cache, &key).map(|(process, quality)| (process.clone(), quality))
     }
 
     fn resolve_executable(pid: libc::pid_t) -> Option<PathBuf> {
@@ -316,19 +307,9 @@ impl FreeBSDProcessLookup {
 }
 
 impl ProcessLookup for FreeBSDProcessLookup {
-    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
-        self.lookup_match(conn)
-            .map(|(process, _quality)| (process.pid, process.name))
-    }
-
     fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
         let (process, quality) = self.lookup_match(conn)?;
-        let mut attribution = ProcessAttribution::new(
-            process.pid,
-            process.name,
-            AttributionBackend::PlatformNative,
-            quality,
-        );
+        let mut attribution = ProcessAttribution::new(process.pid, process.name, quality);
         attribution.uid = Some(process.uid);
         if let Some(details) = self.process_details(process.pid) {
             let lineage = self.process_lineage(process.pid, details.ppid);
@@ -345,9 +326,7 @@ impl ProcessLookup for FreeBSDProcessLookup {
     fn refresh(&self) -> Result<()> {
         let process_map = Self::build_process_map()?;
 
-        let mut cache = self.cache.write().expect("cache lock poisoned");
-        cache.lookup = process_map;
-        cache.last_refresh = Instant::now();
+        *self.cache.write().expect("cache lock poisoned") = process_map;
         self.process_details
             .write()
             .expect("process details cache lock poisoned")
@@ -382,10 +361,10 @@ USER COMMAND PID FD PROTO LOCAL ADDRESS FOREIGN ADDRESS
 1001 curl 4294967295 3 tcp4 127.0.0.1:5000 1.1.1.1:443
 ";
         let lookup = FreeBSDProcessLookup {
-            cache: RwLock::new(ProcessCache {
-                lookup: FreeBSDProcessLookup::parse_sockstat_rows(output, Protocol::Tcp),
-                last_refresh: Instant::now(),
-            }),
+            cache: RwLock::new(FreeBSDProcessLookup::parse_sockstat_rows(
+                output,
+                Protocol::Tcp,
+            )),
             process_details: RwLock::new(HashMap::new()),
         };
         let conn = tcp_connection("127.0.0.1:5000", "1.1.1.1:443");
@@ -397,10 +376,6 @@ USER COMMAND PID FD PROTO LOCAL ADDRESS FOREIGN ADDRESS
         assert_eq!(attribution.uid, Some(1001));
         assert_eq!(attribution.gid, None);
         assert_eq!(attribution.quality, MatchQuality::ExactTuple);
-        assert_eq!(
-            lookup.get_process_for_connection(&conn),
-            Some((u32::MAX, "curl".to_string()))
-        );
     }
 
     #[test]

--- a/crates/rustnet-host/src/lib.rs
+++ b/crates/rustnet-host/src/lib.rs
@@ -16,10 +16,8 @@
 //!
 //! [`ProcessLookup::get_process_attribution`] returns the richer
 //! [`ProcessAttribution`]: parent process id, effective UID/GID, executable
-//! path, process lineage, the producing [`AttributionBackend`], and a
-//! [`MatchQuality`] saying how the connection was matched. Platforms that only
-//! implement the tuple API are bridged automatically, so
-//! `get_process_for_connection` keeps working everywhere.
+//! path, process lineage, and a [`MatchQuality`] saying how the connection was
+//! matched.
 //!
 //! When a platform can't use its optimal method, [`ProcessLookup::get_degradation_reason`]
 //! reports why via [`DegradationReason`] (e.g. missing `CAP_BPF`, no root for
@@ -32,44 +30,36 @@
 //! tools can attribute processes the same way the `rustnet` TUI does.
 
 use anyhow::Result;
-use rustnet_core::network::types::{Connection, Protocol};
+use rustnet_core::network::types::{
+    Connection, MAX_PROCESS_ANCESTORS, MatchQuality, ProcessAncestor, ProcessLineage, Protocol,
+};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 
 /// Active process-attribution backend.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum AttributionBackend {
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttributionBackend {
     /// Linux BPF trampoline programs using fentry and fexit.
     EbpfFentry,
     /// Linux legacy kprobe and kretprobe programs.
     EbpfKprobe,
-    /// Linux procfs socket-table scanning.
-    Procfs,
-    /// macOS PKTAP packet metadata.
-    Pktap,
-    /// macOS `lsof` socket-table scanning.
-    Lsof,
-    /// A platform-native backend outside the Linux eBPF stack.
-    #[default]
-    PlatformNative,
 }
 
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
 impl std::fmt::Display for AttributionBackend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
             Self::EbpfFentry => "eBPF fentry/fexit",
             Self::EbpfKprobe => "eBPF kprobe",
-            Self::Procfs => "procfs",
-            Self::Pktap => "PKTAP",
-            Self::Lsof => "lsof",
-            Self::PlatformNative => "platform native",
         };
         f.write_str(name)
     }
 }
 
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
 bitflags::bitflags! {
     /// Connection operations covered by the active Linux eBPF backend.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -84,20 +74,6 @@ bitflags::bitflags! {
     }
 }
 
-/// How closely an attribution result matched the connection it was asked about.
-///
-/// Backends record sockets under the tuple they saw at creation time, which is
-/// not always the tuple the capture side observes on the wire. A lookup may
-/// therefore have to relax the key, and the caller deserves to know that it
-/// did: a relaxed hit is a plausible owner, not a proven one.
-///
-/// Defined in `rustnet-core` because [`Connection`] carries it and this crate
-/// depends on core, not the other way round. Re-exported here so attribution
-/// callers only need one import.
-pub use rustnet_core::network::types::{
-    MAX_PROCESS_ANCESTORS, MatchQuality, ProcessAncestor, ProcessLineage,
-};
-
 /// A rich process-attribution result.
 ///
 /// Everything past `tgid`/`name` is best effort: a backend fills in what it
@@ -106,8 +82,7 @@ pub use rustnet_core::network::types::{
 /// capped parent chain. Linux, macOS, and FreeBSD can report credentials.
 ///
 /// Marked `#[non_exhaustive]` because cgroup and container fields are expected
-/// to land here later. Build values with [`ProcessAttribution::new`] plus the
-/// `with_*` methods instead of a struct literal.
+/// to land here later.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ProcessAttribution {
@@ -124,8 +99,6 @@ pub struct ProcessAttribution {
     /// Absolute executable path, resolved once at attribution time. `None` when
     /// the process already exited or the path is unreadable.
     pub executable: Option<PathBuf>,
-    /// Backend that produced this result.
-    pub backend: AttributionBackend,
     /// How the connection key matched the backend's records.
     pub quality: MatchQuality,
     /// Best-effort parent chain, ordered oldest retained ancestor first.
@@ -134,12 +107,7 @@ pub struct ProcessAttribution {
 
 impl ProcessAttribution {
     /// Create an attribution with only the fields every backend can supply.
-    pub fn new(
-        tgid: u32,
-        name: impl Into<String>,
-        backend: AttributionBackend,
-        quality: MatchQuality,
-    ) -> Self {
+    pub(crate) fn new(tgid: u32, name: impl Into<String>, quality: MatchQuality) -> Self {
         Self {
             tgid,
             ppid: None,
@@ -147,20 +115,21 @@ impl ProcessAttribution {
             uid: None,
             gid: None,
             executable: None,
-            backend,
             quality,
             lineage: None,
         }
     }
 
     /// Attach the parent process id.
-    pub fn with_parent_pid(mut self, ppid: u32) -> Self {
+    #[cfg(any(test, target_os = "linux"))]
+    pub(crate) fn with_parent_pid(mut self, ppid: u32) -> Self {
         self.ppid = Some(ppid);
         self
     }
 
     /// Attach the effective user and group id.
-    pub fn with_credentials(mut self, uid: u32, gid: u32) -> Self {
+    #[cfg(any(test, target_os = "linux"))]
+    pub(crate) fn with_credentials(mut self, uid: u32, gid: u32) -> Self {
         self.uid = Some(uid);
         self.gid = Some(gid);
         self
@@ -168,13 +137,15 @@ impl ProcessAttribution {
 
     /// Attach the resolved executable path. `None` is a valid outcome and is
     /// stored as such: failing to read the path never fails the attribution.
-    pub fn with_executable(mut self, executable: Option<PathBuf>) -> Self {
+    #[cfg(any(test, target_os = "linux", target_os = "macos"))]
+    pub(crate) fn with_executable(mut self, executable: Option<PathBuf>) -> Self {
         self.executable = executable;
         self
     }
 
     /// Attach the owning process's best-effort parent chain.
-    pub fn with_lineage(mut self, lineage: Option<ProcessLineage>) -> Self {
+    #[cfg(target_os = "linux")]
+    pub(crate) fn with_lineage(mut self, lineage: Option<ProcessLineage>) -> Self {
         self.lineage = lineage;
         self
     }
@@ -183,7 +154,13 @@ impl ProcessAttribution {
     /// one step: parent pid, credentials, executable path, and lineage.
     /// Credentials and executable are left untouched when the lookup does not
     /// resolve them.
-    pub fn with_details(
+    #[cfg(any(
+        test,
+        target_os = "freebsd",
+        target_os = "macos",
+        target_os = "windows"
+    ))]
+    pub(crate) fn with_details(
         mut self,
         ppid: u32,
         credentials: Option<(u32, u32)>,
@@ -306,7 +283,8 @@ where
 /// Parse a socket address as printed by OS socket-table tools (`sockstat`,
 /// `lsof`): `ip:port`, `*:port` (wildcard), `[ipv6]:port`, or bracketless
 /// IPv6 like `::1:8080` (the last colon splits off the port).
-pub fn parse_socket_addr_text(addr_str: &str) -> Option<SocketAddr> {
+#[cfg(any(test, target_os = "freebsd", target_os = "macos"))]
+pub(crate) fn parse_socket_addr_text(addr_str: &str) -> Option<SocketAddr> {
     // Handle wildcard addresses
     if addr_str.starts_with("*:") {
         let port = addr_str.strip_prefix("*:")?.parse::<u16>().ok()?;
@@ -489,32 +467,9 @@ pub use windows::create_process_lookup;
 
 /// Trait for platform-specific process lookup
 pub trait ProcessLookup: Send + Sync {
-    /// Look up process information for a connection
-    /// Returns (pid, process_name) if found
-    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)>;
-
     /// Rich attribution for a connection: identity, credentials, executable
     /// path, and the provenance of the match.
-    ///
-    /// The default implementation bridges the legacy tuple returned by
-    /// [`ProcessLookup::get_process_for_connection`], so platforms that have
-    /// not been ported keep working unchanged. It reports
-    /// [`MatchQuality::Unspecified`] because the tuple API carries no
-    /// provenance, and never claims an exact match it cannot prove.
-    ///
-    /// Overriding is only half the contract: an implementation whose
-    /// `get_process_for_connection` delegates *to this method* **must** also
-    /// override this method, otherwise the two default paths call each other
-    /// forever.
-    fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
-        let (tgid, name) = self.get_process_for_connection(conn)?;
-        Some(ProcessAttribution::new(
-            tgid,
-            name,
-            self.get_attribution_backend(),
-            MatchQuality::Unspecified,
-        ))
-    }
+    fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution>;
 
     /// Refresh internal caches if any (best-effort)
     fn refresh(&self) -> Result<()> {
@@ -528,26 +483,6 @@ pub trait ProcessLookup: Send + Sync {
     /// Returns DegradationReason::None if using optimal detection method
     fn get_degradation_reason(&self) -> DegradationReason {
         DegradationReason::None // Default: no degradation
-    }
-
-    /// Return the active attribution backend.
-    fn get_attribution_backend(&self) -> AttributionBackend {
-        AttributionBackend::PlatformNative
-    }
-
-    /// Fallback lookup that relaxes the connection key to handle sockets stored
-    /// with wildcard addresses in OS-level tables.
-    ///
-    /// Thin wrapper over [`relaxed_lookup`] for callers that only want the
-    /// owner and not the match provenance.
-    fn fallback_lookup(
-        map: &HashMap<ConnectionKey, (u32, String)>,
-        key: &ConnectionKey,
-    ) -> Option<(u32, String)>
-    where
-        Self: Sized,
-    {
-        relaxed_lookup(map, key).map(|(entry, _quality)| entry.clone())
     }
 }
 
@@ -565,7 +500,7 @@ pub trait ProcessLookup: Send + Sync {
 /// Every candidate is still probed even after a hit: if two candidates resolve
 /// to *different* owners the answer is ambiguous and `None` is returned rather
 /// than a coin flip. Candidates that agree are not a conflict.
-pub fn relaxed_lookup<'map, V: PartialEq>(
+pub(crate) fn relaxed_lookup<'map, V: PartialEq>(
     map: &'map HashMap<ConnectionKey, V>,
     key: &ConnectionKey,
 ) -> Option<(&'map V, MatchQuality)> {
@@ -618,14 +553,14 @@ pub fn relaxed_lookup<'map, V: PartialEq>(
 
 /// Connection identifier for lookups
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct ConnectionKey {
-    pub protocol: Protocol,
-    pub local_addr: SocketAddr,
-    pub remote_addr: SocketAddr,
+pub(crate) struct ConnectionKey {
+    pub(crate) protocol: Protocol,
+    pub(crate) local_addr: SocketAddr,
+    pub(crate) remote_addr: SocketAddr,
 }
 
 impl ConnectionKey {
-    pub fn from_connection(conn: &Connection) -> Self {
+    pub(crate) fn from_connection(conn: &Connection) -> Self {
         Self {
             protocol: conn.protocol,
             local_addr: conn.local_addr,
@@ -637,17 +572,7 @@ impl ConnectionKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustnet_core::network::types::{ProtocolState, TcpState};
     use std::path::Path;
-
-    fn connection(local: &str, remote: &str) -> Connection {
-        Connection::new(
-            Protocol::Tcp,
-            local.parse().unwrap(),
-            remote.parse().unwrap(),
-            ProtocolState::Tcp(TcpState::Established),
-        )
-    }
 
     fn key(protocol: Protocol, local: &str, remote: &str) -> ConnectionKey {
         ConnectionKey {
@@ -661,33 +586,12 @@ mod tests {
         (pid, name.to_string())
     }
 
-    /// A platform that only implements the legacy tuple API, standing in for
-    /// the macOS/Windows/FreeBSD lookups.
-    struct LegacyOnlyLookup {
-        result: Option<(u32, String)>,
-    }
-
-    impl ProcessLookup for LegacyOnlyLookup {
-        fn get_process_for_connection(&self, _conn: &Connection) -> Option<(u32, String)> {
-            self.result.clone()
-        }
-
-        fn get_detection_method(&self) -> &str {
-            "legacy"
-        }
-    }
-
     #[test]
-    fn attribution_reduces_to_the_legacy_pid_and_name_pair() {
-        let attribution = ProcessAttribution::new(
-            42,
-            "curl",
-            AttributionBackend::EbpfFentry,
-            MatchQuality::ExactTuple,
-        )
-        .with_parent_pid(1)
-        .with_credentials(1000, 100)
-        .with_executable(Some(PathBuf::from("/usr/bin/curl")));
+    fn attribution_builders_preserve_rich_fields() {
+        let attribution = ProcessAttribution::new(42, "curl", MatchQuality::ExactTuple)
+            .with_parent_pid(1)
+            .with_credentials(1000, 100)
+            .with_executable(Some(PathBuf::from("/usr/bin/curl")));
 
         assert_eq!(attribution.ppid, Some(1));
         assert_eq!(attribution.uid, Some(1000));
@@ -701,13 +605,8 @@ mod tests {
 
     #[test]
     fn attribution_leaves_unobserved_fields_empty() {
-        let attribution = ProcessAttribution::new(
-            7,
-            "sshd",
-            AttributionBackend::Procfs,
-            MatchQuality::ProcfsExact,
-        )
-        .with_executable(None);
+        let attribution =
+            ProcessAttribution::new(7, "sshd", MatchQuality::ProcfsExact).with_executable(None);
 
         assert_eq!(attribution.ppid, None);
         assert_eq!(attribution.uid, None);
@@ -718,14 +617,7 @@ mod tests {
 
     #[test]
     fn with_details_leaves_unresolved_credentials_and_executable_untouched() {
-        let base = || {
-            ProcessAttribution::new(
-                7,
-                "sshd",
-                AttributionBackend::PlatformNative,
-                MatchQuality::Unspecified,
-            )
-        };
+        let base = || ProcessAttribution::new(7, "sshd", MatchQuality::Unspecified);
 
         let full = base().with_details(
             1,
@@ -799,36 +691,6 @@ mod tests {
         assert!(!MatchQuality::ListenerSocket.is_exact());
         assert!(!MatchQuality::ProcfsRelaxed.is_exact());
         assert!(!MatchQuality::Unspecified.is_exact());
-    }
-
-    #[test]
-    fn default_rich_lookup_bridges_the_legacy_tuple_without_claiming_an_exact_match() {
-        let lookup = LegacyOnlyLookup {
-            result: Some(owner(99, "Safari")),
-        };
-
-        let attribution = lookup
-            .get_process_attribution(&connection("192.168.1.10:5000", "1.1.1.1:443"))
-            .expect("legacy tuple must bridge to an attribution");
-
-        assert_eq!(attribution.tgid, 99);
-        assert_eq!(attribution.name, "Safari");
-        assert_eq!(attribution.backend, AttributionBackend::PlatformNative);
-        // The tuple API carries no provenance, so the bridge must not pretend
-        // the exact 4-tuple was proven.
-        assert_eq!(attribution.quality, MatchQuality::Unspecified);
-        assert!(!attribution.quality.is_exact());
-        assert_eq!(attribution.executable, None);
-    }
-
-    #[test]
-    fn default_rich_lookup_propagates_a_legacy_miss() {
-        let lookup = LegacyOnlyLookup { result: None };
-        assert!(
-            lookup
-                .get_process_attribution(&connection("192.168.1.10:5000", "1.1.1.1:443"))
-                .is_none()
-        );
     }
 
     #[test]
@@ -1025,22 +887,5 @@ mod tests {
         // Port out of range
         assert_eq!(parse_socket_addr_text("192.168.1.1:99999"), None);
         assert_eq!(parse_socket_addr_text(""), None);
-    }
-
-    #[test]
-    fn fallback_lookup_still_returns_the_plain_tuple() {
-        let mut map = HashMap::new();
-        map.insert(
-            key(Protocol::Tcp, "0.0.0.0:22", "0.0.0.0:0"),
-            owner(17, "sshd"),
-        );
-
-        assert_eq!(
-            LegacyOnlyLookup::fallback_lookup(
-                &map,
-                &key(Protocol::Tcp, "192.168.1.10:22", "203.0.113.5:51000")
-            ),
-            Some(owner(17, "sshd"))
-        );
     }
 }

--- a/crates/rustnet-host/src/linux/ebpf/loader.rs
+++ b/crates/rustnet-host/src/linux/ebpf/loader.rs
@@ -39,7 +39,7 @@ enum BackendSelection<T, E> {
 }
 
 /// Loaded eBPF backend. Each object owns a private socket map.
-pub enum EbpfLoader {
+pub(super) enum EbpfLoader {
     Fentry(FentryLoader),
     Kprobe(KprobeLoader),
 }
@@ -51,7 +51,7 @@ impl EbpfLoader {
     /// CO-RE socket field reads, so missing target BTF falls safely to procfs.
     /// With BTF available, backend support is determined from actual program
     /// load and attachment results rather than uname.
-    pub fn try_load() -> Result<(Option<Self>, DegradationReason)> {
+    pub(super) fn try_load() -> Result<(Option<Self>, DegradationReason)> {
         let cap_result = check_capabilities_detailed();
         if cap_result != DegradationReason::None {
             if matches!(
@@ -133,21 +133,21 @@ impl EbpfLoader {
         }
     }
 
-    pub fn socket_map(&self) -> &libbpf_rs::Map<'_> {
+    pub(super) fn socket_map(&self) -> &libbpf_rs::Map<'_> {
         match self {
             Self::Fentry(loader) => loader.socket_map(),
             Self::Kprobe(loader) => loader.socket_map(),
         }
     }
 
-    pub fn backend(&self) -> AttributionBackend {
+    pub(super) fn backend(&self) -> AttributionBackend {
         match self {
             Self::Fentry(_) => AttributionBackend::EbpfFentry,
             Self::Kprobe(_) => AttributionBackend::EbpfKprobe,
         }
     }
 
-    pub fn capabilities(&self) -> AttributionCapabilities {
+    pub(super) fn capabilities(&self) -> AttributionCapabilities {
         match self {
             Self::Fentry(loader) => loader.capabilities,
             Self::Kprobe(loader) => loader.capabilities,
@@ -163,12 +163,11 @@ impl EbpfLoader {
                 FentryLoader::load_program(&kernel_btf).map(Self::Fentry)
             }
             AttributionBackend::EbpfKprobe => KprobeLoader::load_program().map(Self::Kprobe),
-            other => Err(anyhow::anyhow!("{other} is not an eBPF backend")),
         }
     }
 }
 
-pub struct FentryLoader {
+pub(super) struct FentryLoader {
     skel: Box<SocketTrackerFentrySkel<'static>>,
     _open_object: Box<std::mem::MaybeUninit<libbpf_rs::OpenObject>>,
     _links: Vec<libbpf_rs::Link>,
@@ -304,7 +303,7 @@ impl FentryLoader {
     }
 }
 
-pub struct KprobeLoader {
+pub(super) struct KprobeLoader {
     skel: Box<SocketTrackerKprobeSkel<'static>>,
     _open_object: Box<std::mem::MaybeUninit<libbpf_rs::OpenObject>>,
     _links: Vec<libbpf_rs::Link>,

--- a/crates/rustnet-host/src/linux/ebpf/maps_libbpf.rs
+++ b/crates/rustnet-host/src/linux/ebpf/maps_libbpf.rs
@@ -6,13 +6,13 @@ use libbpf_rs::MapCore;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 const TASK_COMM_LEN: usize = 16;
-pub const CONN_KEY_SIZE: usize = 40;
-pub const CONN_INFO_SIZE: usize = 40;
+pub(super) const CONN_KEY_SIZE: usize = 40;
+pub(super) const CONN_INFO_SIZE: usize = 40;
 
 /// Connection key matching `socket_tracker_types.h`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ConnKey {
+pub(super) struct ConnKey {
     pub saddr: [u32; 4],
     pub daddr: [u32; 4],
     pub sport: u16,
@@ -25,7 +25,7 @@ pub struct ConnKey {
 /// Raw process identity matching `socket_tracker_types.h`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ConnInfo {
+struct ConnInfo {
     pub tgid: u32,
     pub tid: u32,
     pub uid: u32,
@@ -85,7 +85,7 @@ impl ConnKey {
         }
     }
 
-    pub fn new_v4(
+    pub(super) fn new_v4(
         src_ip: Ipv4Addr,
         dst_ip: Ipv4Addr,
         src_port: u16,
@@ -98,7 +98,7 @@ impl ConnKey {
         key
     }
 
-    pub(crate) fn new_v6(
+    pub(super) fn new_v6(
         src_ip: Ipv6Addr,
         dst_ip: Ipv6Addr,
         src_port: u16,
@@ -111,20 +111,20 @@ impl ConnKey {
         key
     }
 
-    pub fn new_icmp_v4(src_ip: Ipv4Addr, dst_ip: Ipv4Addr, icmp_id: u16) -> Self {
+    pub(super) fn new_icmp_v4(src_ip: Ipv4Addr, dst_ip: Ipv4Addr, icmp_id: u16) -> Self {
         let mut key = Self::empty_v4(icmp_id, 0, IPPROTO_ICMP);
         key.fill_v4(src_ip, dst_ip);
         key
     }
 
-    pub fn new_icmp_v6(src_ip: Ipv6Addr, dst_ip: Ipv6Addr, icmp_id: u16) -> Self {
+    pub(super) fn new_icmp_v6(src_ip: Ipv6Addr, dst_ip: Ipv6Addr, icmp_id: u16) -> Self {
         let mut key = Self::empty_v6(icmp_id, 0, IPPROTO_ICMPV6);
         key.fill_v6(src_ip, dst_ip);
         key
     }
 
     /// Return the exact C ABI bytes used as the BPF map key.
-    pub fn as_bytes(&self) -> [u8; CONN_KEY_SIZE] {
+    pub(super) fn as_bytes(&self) -> [u8; CONN_KEY_SIZE] {
         let mut bytes = [0; CONN_KEY_SIZE];
         // SAFETY: ConnKey has a compile-time checked size, contains explicit
         // initialized padding, and bytes accepts every bit pattern.
@@ -191,10 +191,13 @@ fn monotonic_time_ns() -> Result<u64> {
     Ok(timestamp.tv_sec as u64 * 1_000_000_000 + timestamp.tv_nsec as u64)
 }
 
-pub struct MapReader;
+pub(super) struct MapReader;
 
 impl MapReader {
-    pub fn lookup_connection(map: &libbpf_rs::Map, key: ConnKey) -> Result<Option<ProcessInfo>> {
+    pub(super) fn lookup_connection(
+        map: &libbpf_rs::Map,
+        key: ConnKey,
+    ) -> Result<Option<ProcessInfo>> {
         let key_bytes = key.as_bytes();
 
         match map.lookup(&key_bytes, libbpf_rs::MapFlags::empty()) {
@@ -210,7 +213,10 @@ impl MapReader {
         }
     }
 
-    pub fn cleanup_stale_entries(map: &libbpf_rs::Map, stale_threshold_ns: u64) -> Result<u32> {
+    pub(super) fn cleanup_stale_entries(
+        map: &libbpf_rs::Map,
+        stale_threshold_ns: u64,
+    ) -> Result<u32> {
         let current_time_ns = monotonic_time_ns()?;
         let mut keys_to_delete = Vec::new();
 
@@ -245,7 +251,7 @@ impl MapReader {
         Ok(cleanup_count)
     }
 
-    pub fn debug_lookup_miss(map: &libbpf_rs::Map, lookup_key: &ConnKey) -> Result<()> {
+    pub(super) fn debug_lookup_miss(map: &libbpf_rs::Map, lookup_key: &ConnKey) -> Result<()> {
         log::debug!(
             "eBPF map miss: key={:02x?}, source={:08x}, destination={:08x}, sport={}, dport={}, proto={}, family={}",
             lookup_key.as_bytes(),

--- a/crates/rustnet-host/src/linux/ebpf/mod.rs
+++ b/crates/rustnet-host/src/linux/ebpf/mod.rs
@@ -3,30 +3,30 @@
 //! This module provides enhanced process lookup using eBPF for TCP/UDP connections.
 //! It maintains compatibility with the existing procfs approach as a fallback.
 
-pub mod loader;
-pub mod maps_libbpf;
-pub mod tracker_libbpf;
+mod loader;
+mod maps_libbpf;
+mod tracker_libbpf;
 
-pub use tracker_libbpf::LibbpfSocketTracker as EbpfSocketTracker;
+pub(super) use tracker_libbpf::LibbpfSocketTracker as EbpfSocketTracker;
 
 use crate::MatchQuality;
 
 /// Process information from eBPF
 #[derive(Debug, Clone)]
-pub struct ProcessInfo {
+pub(super) struct ProcessInfo {
     /// Thread group id (the PID as user space understands it).
-    pub pid: u32,
+    pub(super) pid: u32,
     /// Kernel thread id that created the socket.
-    pub tid: u32,
+    pub(super) tid: u32,
     /// Effective user id at socket creation.
-    pub uid: u32,
+    pub(super) uid: u32,
     /// Effective group id at socket creation.
-    pub gid: u32,
+    pub(super) gid: u32,
     /// Short `comm` of the task, as recorded by the BPF program.
-    pub comm: String,
+    pub(super) comm: String,
     /// `bpf_ktime_get_ns` reading: nanoseconds on a **monotonic** clock, not
     /// wall-clock time.
-    pub timestamp: u64,
+    pub(super) timestamp: u64,
 }
 
 /// A socket-map hit together with how the lookup key matched it.
@@ -34,9 +34,9 @@ pub struct ProcessInfo {
 /// The tracker retries a miss with a zeroed source address, so the caller can
 /// no longer assume a hit means the exact tuple was recorded.
 #[derive(Debug, Clone)]
-pub struct SocketMatch {
-    pub info: ProcessInfo,
-    pub quality: MatchQuality,
+pub(super) struct SocketMatch {
+    pub(super) info: ProcessInfo,
+    pub(super) quality: MatchQuality,
 }
 
 impl SocketMatch {

--- a/crates/rustnet-host/src/linux/ebpf/tracker_libbpf.rs
+++ b/crates/rustnet-host/src/linux/ebpf/tracker_libbpf.rs
@@ -9,7 +9,7 @@ use crate::{AttributionBackend, AttributionCapabilities, DegradationReason, Matc
 use anyhow::Result;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-pub struct LibbpfSocketTracker {
+pub(crate) struct LibbpfSocketTracker {
     loader: EbpfLoader,
 }
 
@@ -19,7 +19,7 @@ unsafe impl Sync for LibbpfSocketTracker {}
 impl LibbpfSocketTracker {
     /// Create a new eBPF socket tracker
     /// Returns (Option<Self>, DegradationReason) - the reason explains why eBPF is unavailable
-    pub fn new() -> Result<(Option<Self>, DegradationReason)> {
+    pub(crate) fn new() -> Result<(Option<Self>, DegradationReason)> {
         let (loader_opt, reason) = EbpfLoader::try_load()?;
         match loader_opt {
             Some(loader) => Ok((Some(Self { loader }), reason)),
@@ -27,11 +27,11 @@ impl LibbpfSocketTracker {
         }
     }
 
-    pub fn backend(&self) -> AttributionBackend {
+    pub(crate) fn backend(&self) -> AttributionBackend {
         self.loader.backend()
     }
 
-    pub fn capabilities(&self) -> AttributionCapabilities {
+    fn capabilities(&self) -> AttributionCapabilities {
         self.loader.capabilities()
     }
 
@@ -43,7 +43,7 @@ impl LibbpfSocketTracker {
     }
 
     /// Look up process information for a connection (IPv4)
-    pub fn lookup_v4(
+    fn lookup_v4(
         &mut self,
         src_ip: Ipv4Addr,
         dst_ip: Ipv4Addr,
@@ -114,7 +114,7 @@ impl LibbpfSocketTracker {
     }
 
     /// Look up process information for a connection (IPv6)
-    pub fn lookup_v6(
+    fn lookup_v6(
         &mut self,
         src_ip: Ipv6Addr,
         dst_ip: Ipv6Addr,
@@ -165,7 +165,7 @@ impl LibbpfSocketTracker {
     }
 
     /// Look up process information for a connection (generic)
-    pub fn lookup(
+    pub(crate) fn lookup(
         &mut self,
         src_ip: IpAddr,
         dst_ip: IpAddr,
@@ -188,7 +188,7 @@ impl LibbpfSocketTracker {
     }
 
     /// Look up process information for an ICMP connection
-    pub fn lookup_icmp(
+    pub(crate) fn lookup_icmp(
         &mut self,
         src_ip: IpAddr,
         dst_ip: IpAddr,
@@ -200,14 +200,22 @@ impl LibbpfSocketTracker {
                     .capabilities()
                     .contains(AttributionCapabilities::ICMP_V4_SEND) =>
             {
-                self.lookup_icmp_v4(src, dst, icmp_id)
+                self.lookup_icmp_keys(
+                    ConnKey::new_icmp_v4(src, dst, icmp_id),
+                    ConnKey::new_icmp_v4(Ipv4Addr::UNSPECIFIED, dst, icmp_id),
+                    icmp_id,
+                )
             }
             (IpAddr::V6(src), IpAddr::V6(dst))
                 if self
                     .capabilities()
                     .contains(AttributionCapabilities::ICMP_V6_SEND) =>
             {
-                self.lookup_icmp_v6(src, dst, icmp_id)
+                self.lookup_icmp_keys(
+                    ConnKey::new_icmp_v6(src, dst, icmp_id),
+                    ConnKey::new_icmp_v6(Ipv6Addr::UNSPECIFIED, dst, icmp_id),
+                    icmp_id,
+                )
             }
             (IpAddr::V4(_), IpAddr::V4(_)) | (IpAddr::V6(_), IpAddr::V6(_)) => None,
             _ => {
@@ -217,17 +225,16 @@ impl LibbpfSocketTracker {
         }
     }
 
-    fn lookup_icmp_v4(
-        &mut self,
-        src_ip: Ipv4Addr,
-        dst_ip: Ipv4Addr,
+    fn lookup_icmp_keys(
+        &self,
+        exact_key: ConnKey,
+        zero_src_key: ConnKey,
         icmp_id: u16,
     ) -> Option<SocketMatch> {
         let socket_map = self.loader.socket_map();
 
         // Try exact match first
-        let key = ConnKey::new_icmp_v4(src_ip, dst_ip, icmp_id);
-        match MapReader::lookup_connection(socket_map, key) {
+        match MapReader::lookup_connection(socket_map, exact_key) {
             Ok(Some(result)) => return Some(SocketMatch::new(result, MatchQuality::ExactTuple)),
             Ok(None) => {
                 log::debug!("eBPF ICMP exact lookup miss, trying with zero source address");
@@ -237,52 +244,8 @@ impl LibbpfSocketTracker {
             }
         }
 
-        // Try with zero source address (common for ICMP - socket not bound to specific IP)
-        let zero_src_key = ConnKey::new_icmp_v4(Ipv4Addr::new(0, 0, 0, 0), dst_ip, icmp_id);
-
-        match MapReader::lookup_connection(socket_map, zero_src_key) {
-            Ok(Some(result)) => {
-                log::debug!(
-                    "eBPF ICMP lookup succeeded with zero source address! PID: {}, comm: {}",
-                    result.pid,
-                    result.comm
-                );
-                Some(SocketMatch::new(result, MatchQuality::WildcardLocalAddress))
-            }
-            Ok(None) => {
-                log::debug!("eBPF ICMP lookup miss for ID: {}", icmp_id);
-                None
-            }
-            Err(e) => {
-                log::debug!("eBPF ICMP zero-source lookup failed: {}", e);
-                None
-            }
-        }
-    }
-
-    fn lookup_icmp_v6(
-        &mut self,
-        src_ip: Ipv6Addr,
-        dst_ip: Ipv6Addr,
-        icmp_id: u16,
-    ) -> Option<SocketMatch> {
-        let socket_map = self.loader.socket_map();
-
-        // Try exact match first
-        let key = ConnKey::new_icmp_v6(src_ip, dst_ip, icmp_id);
-        match MapReader::lookup_connection(socket_map, key) {
-            Ok(Some(result)) => return Some(SocketMatch::new(result, MatchQuality::ExactTuple)),
-            Ok(None) => {
-                log::debug!("eBPF ICMP exact lookup miss, trying with zero source address");
-            }
-            Err(e) => {
-                log::debug!("eBPF ICMP lookup failed: {}", e);
-            }
-        }
-
-        // Try with zero source address (common for ICMP - socket not bound to specific IP)
-        let zero_src_key = ConnKey::new_icmp_v6(Ipv6Addr::UNSPECIFIED, dst_ip, icmp_id);
-
+        // Try with a zero source address, as unbound ICMP sockets commonly
+        // appear in the map this way.
         match MapReader::lookup_connection(socket_map, zero_src_key) {
             Ok(Some(result)) => {
                 log::debug!(
@@ -305,7 +268,7 @@ impl LibbpfSocketTracker {
 
     /// Clean up stale entries from the eBPF map
     /// Returns the number of entries cleaned up
-    pub fn cleanup_stale_entries(&mut self, stale_threshold_secs: u64) -> u32 {
+    pub(crate) fn cleanup_stale_entries(&mut self, stale_threshold_secs: u64) -> u32 {
         let socket_map = self.loader.socket_map();
         let stale_threshold_ns = stale_threshold_secs * 1_000_000_000;
 
@@ -409,8 +372,8 @@ mod integration_tests {
         );
     }
 
-    fn test_tcp_v4(tracker: &mut LibbpfSocketTracker) {
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    fn test_tcp(tracker: &mut LibbpfSocketTracker, loopback: IpAddr, check_accept_tid: bool) {
+        let listener = TcpListener::bind((loopback, 0)).unwrap();
         let server = listener.local_addr().unwrap();
         let client = TcpStream::connect(server).unwrap();
         let (accepted, _) = listener.accept().unwrap();
@@ -438,7 +401,7 @@ mod integration_tests {
 
         // accept() ran on this thread, so the accepted socket must be recorded
         // against it rather than against some other task in the process.
-        if ids_are_comparable(&accept_info.info) {
+        if check_accept_tid && ids_are_comparable(&accept_info.info) {
             assert_eq!(accept_info.info.tid, current_tid());
         }
     }
@@ -480,39 +443,15 @@ mod integration_tests {
         }
     }
 
-    fn test_tcp_v6(tracker: &mut LibbpfSocketTracker) {
-        let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
-        let server = listener.local_addr().unwrap();
-        let client = TcpStream::connect(server).unwrap();
-        let (accepted, _) = listener.accept().unwrap();
-        let client_local = client.local_addr().unwrap();
-
-        let connect_info = lookup_with_retry(
-            tracker,
-            client_local.ip(),
-            server.ip(),
-            client_local.port(),
-            server.port(),
-            true,
-        );
-        assert_current_identity(&connect_info);
-
-        let accept_info = lookup_with_retry(
-            tracker,
-            accepted.local_addr().unwrap().ip(),
-            accepted.peer_addr().unwrap().ip(),
-            accepted.local_addr().unwrap().port(),
-            accepted.peer_addr().unwrap().port(),
-            true,
-        );
-        assert_current_identity(&accept_info);
-    }
-
-    fn test_udp_v4(tracker: &mut LibbpfSocketTracker) {
-        let receiver = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    fn test_udp(tracker: &mut LibbpfSocketTracker, loopback: IpAddr) {
+        let unspecified: IpAddr = match loopback {
+            IpAddr::V4(_) => Ipv4Addr::UNSPECIFIED.into(),
+            IpAddr::V6(_) => Ipv6Addr::UNSPECIFIED.into(),
+        };
+        let receiver = UdpSocket::bind((loopback, 0)).unwrap();
         let destination = receiver.local_addr().unwrap();
 
-        let connected = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+        let connected = UdpSocket::bind((unspecified, 0)).unwrap();
         connected.connect(destination).unwrap();
         connected.send(b"connected").unwrap();
         let source = connected.local_addr().unwrap();
@@ -525,42 +464,12 @@ mod integration_tests {
             false,
         ));
 
-        let unconnected = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+        let unconnected = UdpSocket::bind((unspecified, 0)).unwrap();
         unconnected.send_to(b"sendto", destination).unwrap();
         let source = unconnected.local_addr().unwrap();
         assert_current_identity(&lookup_with_retry(
             tracker,
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-            destination.ip(),
-            source.port(),
-            destination.port(),
-            false,
-        ));
-    }
-
-    fn test_udp_v6(tracker: &mut LibbpfSocketTracker) {
-        let receiver = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
-        let destination = receiver.local_addr().unwrap();
-
-        let connected = UdpSocket::bind((Ipv6Addr::UNSPECIFIED, 0)).unwrap();
-        connected.connect(destination).unwrap();
-        connected.send(b"connected").unwrap();
-        let source = connected.local_addr().unwrap();
-        assert_current_identity(&lookup_with_retry(
-            tracker,
-            source.ip(),
-            destination.ip(),
-            source.port(),
-            destination.port(),
-            false,
-        ));
-
-        let unconnected = UdpSocket::bind((Ipv6Addr::UNSPECIFIED, 0)).unwrap();
-        unconnected.send_to(b"sendto", destination).unwrap();
-        let source = unconnected.local_addr().unwrap();
-        assert_current_identity(&lookup_with_retry(
-            tracker,
-            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            loopback,
             destination.ip(),
             source.port(),
             destination.port(),
@@ -580,10 +489,12 @@ mod integration_tests {
                 .contains(crate::linux::ebpf::loader::CORE_CAPABILITIES)
         );
 
-        test_tcp_v4(&mut tracker);
-        test_tcp_v6(&mut tracker);
-        test_udp_v4(&mut tracker);
-        test_udp_v6(&mut tracker);
+        // The v4-only accepted-socket TID assertion mirrors the original
+        // coverage; the v6 run keeps the rest of the scenario in sync.
+        test_tcp(&mut tracker, Ipv4Addr::LOCALHOST.into(), true);
+        test_tcp(&mut tracker, Ipv6Addr::LOCALHOST.into(), false);
+        test_udp(&mut tracker, Ipv4Addr::LOCALHOST.into());
+        test_udp(&mut tracker, Ipv6Addr::LOCALHOST.into());
         test_worker_thread_tid(&mut tracker);
     }
 

--- a/crates/rustnet-host/src/linux/enhanced.rs
+++ b/crates/rustnet-host/src/linux/enhanced.rs
@@ -18,7 +18,7 @@ use crate::linux::process::{refine_truncated_name, resolve_executable, resolve_p
 use rustnet_core::network::types::ProtocolState;
 
 /// Enhanced process lookup that combines eBPF (fast path) with procfs (fallback)
-pub struct EnhancedLinuxProcessLookup {
+pub(super) struct EnhancedLinuxProcessLookup {
     ebpf_tracker: RwLock<Option<Box<EbpfSocketTracker>>>,
     procfs_lookup: LinuxProcessLookup,
     unified_cache: RwLock<ProcessCache>,
@@ -27,7 +27,7 @@ pub struct EnhancedLinuxProcessLookup {
     degradation_reason: DegradationReason,
 }
 
-pub struct ProcessCache {
+struct ProcessCache {
     // Full attributions, not just (pid, name): caching the tuple would drop
     // the credentials, executable path, and match quality on the first hit
     // and silently downgrade every subsequent lookup.
@@ -36,9 +36,9 @@ pub struct ProcessCache {
 }
 
 #[derive(Debug, Clone)]
-pub struct CleanupConfig {
-    pub cleanup_interval_secs: u64,
-    pub stale_threshold_secs: u64,
+struct CleanupConfig {
+    cleanup_interval_secs: u64,
+    stale_threshold_secs: u64,
 }
 
 impl Default for CleanupConfig {
@@ -51,7 +51,7 @@ impl Default for CleanupConfig {
 }
 
 impl EnhancedLinuxProcessLookup {
-    pub fn new() -> Result<Self> {
+    pub(super) fn new() -> Result<Self> {
         let cleanup_config = CleanupConfig::default();
         let procfs_lookup = LinuxProcessLookup::new()?;
 
@@ -153,11 +153,7 @@ impl EnhancedLinuxProcessLookup {
     /// The TGID, credentials, and match quality the kernel recorded are
     /// carried through unchanged. The process name, parent PID, and
     /// executable path are resolved in user space.
-    fn attribution_from_ebpf(
-        &self,
-        matched: SocketMatch,
-        backend: AttributionBackend,
-    ) -> ProcessAttribution {
+    fn attribution_from_ebpf(&self, matched: SocketMatch) -> ProcessAttribution {
         let SocketMatch { info, quality } = matched;
 
         // eBPF captures the group leader's short comm at socket creation.
@@ -191,7 +187,7 @@ impl EnhancedLinuxProcessLookup {
             info.timestamp
         );
 
-        let mut attribution = ProcessAttribution::new(info.pid, name, backend, quality)
+        let mut attribution = ProcessAttribution::new(info.pid, name, quality)
             .with_credentials(info.uid, info.gid)
             .with_executable(executable);
         if let Some(ppid) = ppid {
@@ -203,11 +199,9 @@ impl EnhancedLinuxProcessLookup {
     }
 
     fn try_ebpf_lookup(&self, conn: &Connection) -> Option<ProcessAttribution> {
-        // Scoped so the tracker write lock is released before
-        // attribution_from_ebpf touches /proc. Note `backend()` is read
-        // here rather than via get_attribution_backend(), which would take
-        // the same non-reentrant lock again.
-        let (matched, backend) = {
+        // Scope the tracker lock so it is released before attribution reads
+        // process metadata from procfs.
+        let matched = {
             let mut tracker_guard = self
                 .ebpf_tracker
                 .write()
@@ -224,8 +218,6 @@ impl EnhancedLinuxProcessLookup {
             };
 
             let is_tcp = matches!(conn.protocol, Protocol::Tcp);
-            let backend = tracker.backend();
-
             match tracker.lookup(
                 conn.local_addr.ip(),
                 conn.remote_addr.ip(),
@@ -233,7 +225,7 @@ impl EnhancedLinuxProcessLookup {
                 conn.remote_addr.port(),
                 is_tcp,
             ) {
-                Some(matched) => (matched, backend),
+                Some(matched) => matched,
                 None => {
                     debug!(
                         "eBPF lookup missed for {}:{} -> {}:{}",
@@ -247,20 +239,18 @@ impl EnhancedLinuxProcessLookup {
             }
         };
 
-        Some(self.attribution_from_ebpf(matched, backend))
+        Some(self.attribution_from_ebpf(matched))
     }
 
     fn try_ebpf_icmp_lookup(&self, conn: &Connection, icmp_id: u16) -> Option<ProcessAttribution> {
-        let (matched, backend) = {
+        let matched = {
             let mut tracker_guard = self
                 .ebpf_tracker
                 .write()
                 .expect("ebpf_tracker lock poisoned");
             let tracker = tracker_guard.as_mut()?;
-            let backend = tracker.backend();
-
             match tracker.lookup_icmp(conn.local_addr.ip(), conn.remote_addr.ip(), icmp_id) {
-                Some(matched) => (matched, backend),
+                Some(matched) => matched,
                 None => {
                     debug!(
                         "eBPF ICMP lookup missed for {} -> {} (ID: {})",
@@ -273,7 +263,7 @@ impl EnhancedLinuxProcessLookup {
             }
         };
 
-        Some(self.attribution_from_ebpf(matched, backend))
+        Some(self.attribution_from_ebpf(matched))
     }
 
     /// Seed the unified cache with a ready-made attribution and mark it
@@ -320,13 +310,6 @@ impl EnhancedLinuxProcessLookup {
 }
 
 impl ProcessLookup for EnhancedLinuxProcessLookup {
-    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
-        // Safe because get_process_attribution is overridden below: this
-        // does not fall through to the trait's default bridge.
-        self.get_process_attribution(conn)
-            .map(|attribution| (attribution.tgid, attribution.name))
-    }
-
     fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
         // Perform periodic cleanup of stale eBPF entries
         self.maybe_cleanup_ebpf_map();
@@ -382,24 +365,21 @@ impl ProcessLookup for EnhancedLinuxProcessLookup {
     }
 
     fn get_detection_method(&self) -> &str {
-        match self.get_attribution_backend() {
-            AttributionBackend::EbpfFentry => "eBPF fentry/fexit + procfs",
-            AttributionBackend::EbpfKprobe => "eBPF kprobe + procfs",
-            _ => "procfs",
+        match self
+            .ebpf_tracker
+            .read()
+            .expect("ebpf_tracker lock poisoned")
+            .as_ref()
+            .map(|tracker| tracker.backend())
+        {
+            Some(AttributionBackend::EbpfFentry) => "eBPF fentry/fexit + procfs",
+            Some(AttributionBackend::EbpfKprobe) => "eBPF kprobe + procfs",
+            None => "procfs",
         }
     }
 
     fn get_degradation_reason(&self) -> DegradationReason {
         self.degradation_reason.clone()
-    }
-
-    fn get_attribution_backend(&self) -> AttributionBackend {
-        self.ebpf_tracker
-            .read()
-            .expect("ebpf_tracker lock poisoned")
-            .as_ref()
-            .map(|tracker| tracker.backend())
-            .unwrap_or(AttributionBackend::Procfs)
     }
 }
 
@@ -422,15 +402,10 @@ mod tests {
     /// A result carrying everything only eBPF can observe, so a cache round
     /// trip that drops any of it is visible.
     fn ebpf_attribution() -> ProcessAttribution {
-        ProcessAttribution::new(
-            4242,
-            "curl",
-            AttributionBackend::EbpfFentry,
-            MatchQuality::WildcardLocalAddress,
-        )
-        .with_parent_pid(4000)
-        .with_credentials(1000, 100)
-        .with_executable(Some(PathBuf::from("/usr/bin/curl")))
+        ProcessAttribution::new(4242, "curl", MatchQuality::WildcardLocalAddress)
+            .with_parent_pid(4000)
+            .with_credentials(1000, 100)
+            .with_executable(Some(PathBuf::from("/usr/bin/curl")))
     }
 
     #[test]
@@ -460,18 +435,6 @@ mod tests {
             assert_eq!(cached.quality, MatchQuality::WildcardLocalAddress);
             assert!(!cached.quality.is_exact());
         }
-    }
-
-    #[test]
-    fn the_tuple_api_serves_the_cached_attribution() {
-        let lookup = EnhancedLinuxProcessLookup::new().expect("procfs lookup must initialize");
-        let conn = connection("192.168.1.10:5002", "1.1.1.1:443");
-        lookup.seed_cache(ConnectionKey::from_connection(&conn), ebpf_attribution());
-
-        assert_eq!(
-            lookup.get_process_for_connection(&conn),
-            Some((4242, "curl".to_string()))
-        );
     }
 
     #[test]

--- a/crates/rustnet-host/src/linux/mod.rs
+++ b/crates/rustnet-host/src/linux/mod.rs
@@ -3,11 +3,11 @@
 mod process;
 
 #[cfg(feature = "ebpf")]
-pub mod ebpf;
+mod ebpf;
 #[cfg(feature = "ebpf")]
 mod enhanced;
 
-pub use process::LinuxProcessLookup;
+use process::LinuxProcessLookup;
 
 use crate::ProcessLookup;
 use anyhow::Result;

--- a/crates/rustnet-host/src/linux/process.rs
+++ b/crates/rustnet-host/src/linux/process.rs
@@ -1,8 +1,8 @@
 // network/platform/linux/process.rs - Linux procfs-based process lookup
 
 use crate::{
-    AttributionBackend, ConnectionKey, MatchQuality, ProcessAncestor, ProcessAttribution,
-    ProcessLineage, ProcessLookup, collect_process_lineage, memoized, relaxed_lookup,
+    ConnectionKey, MatchQuality, ProcessAncestor, ProcessAttribution, ProcessLineage,
+    ProcessLookup, collect_process_lineage, memoized, relaxed_lookup,
 };
 use anyhow::Result;
 use rustnet_core::network::types::{Connection, Protocol};
@@ -12,7 +12,6 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
-use std::time::Instant;
 
 /// Resolve the executable path of a TGID from `/proc/<tgid>/exe`.
 ///
@@ -148,37 +147,34 @@ fn resolve_process_lineage(tgid: u32, ppid: u32) -> Option<ProcessLineage> {
 /// Map of socket inode to (PID, process name)
 type InodeProcessMap = HashMap<u64, (u32, String)>;
 /// Map of PID to process name
+#[cfg(feature = "ebpf")]
 type PidNameMap = HashMap<u32, String>;
+#[cfg(not(feature = "ebpf"))]
+type PidNameMap = ();
 /// Map of connection key to (PID, process name)
 type ConnectionProcessMap = HashMap<ConnectionKey, (u32, String)>;
 
-pub struct LinuxProcessLookup {
+pub(super) struct LinuxProcessLookup {
     // Cache: ConnectionKey -> (pid, process_name)
-    cache: RwLock<ProcessCache>,
+    cache: RwLock<ConnectionProcessMap>,
     // Cache: PID -> process_name (for resolving eBPF thread names to main process names)
+    #[cfg(feature = "ebpf")]
     pid_names: RwLock<HashMap<u32, String>>,
     // Memo: TGID -> lineage, so many connections of one process walk /proc
     // once per refresh instead of once each. Failures are memoized too.
     lineages: RwLock<HashMap<u32, Option<ProcessLineage>>>,
 }
 
-struct ProcessCache {
-    lookup: HashMap<ConnectionKey, (u32, String)>,
-    last_refresh: Instant,
-}
-
 impl LinuxProcessLookup {
-    pub fn new() -> Result<Self> {
+    pub(super) fn new() -> Result<Self> {
         // Populate the cache immediately so early connections have process names available.
         // This ensures the PID→name cache is ready before packet capture starts.
-        let (process_map, pid_names) = Self::build_process_map()?;
+        let (process_map, _pid_names) = Self::build_process_map()?;
 
         Ok(Self {
-            cache: RwLock::new(ProcessCache {
-                lookup: process_map,
-                last_refresh: Instant::now(),
-            }),
-            pid_names: RwLock::new(pid_names),
+            cache: RwLock::new(process_map),
+            #[cfg(feature = "ebpf")]
+            pid_names: RwLock::new(_pid_names),
             lineages: RwLock::new(HashMap::new()),
         })
     }
@@ -188,10 +184,8 @@ impl LinuxProcessLookup {
     #[cfg(test)]
     fn with_socket_table(lookup: ConnectionProcessMap) -> Self {
         Self {
-            cache: RwLock::new(ProcessCache {
-                lookup,
-                last_refresh: Instant::now(),
-            }),
+            cache: RwLock::new(lookup),
+            #[cfg(feature = "ebpf")]
             pid_names: RwLock::new(HashMap::new()),
             lineages: RwLock::new(HashMap::new()),
         }
@@ -204,7 +198,8 @@ impl LinuxProcessLookup {
     /// from it while still being perfectly readable from /proc. One tiny
     /// file read; the result is cached so repeated lookups stay cheap.
     /// Returns None if the process has already exited and was never scanned.
-    pub fn get_process_name_by_pid(&self, pid: u32) -> Option<String> {
+    #[cfg(feature = "ebpf")]
+    pub(super) fn get_process_name_by_pid(&self, pid: u32) -> Option<String> {
         if let Some(name) = self
             .pid_names
             .read()
@@ -243,7 +238,7 @@ impl LinuxProcessLookup {
         let cache = self.cache.read().expect("process cache lock poisoned");
 
         // Fast path: exact 4-tuple match (always works for TCP).
-        if let Some((pid, name)) = cache.lookup.get(&key) {
+        if let Some((pid, name)) = cache.get(&key) {
             return Some((*pid, name.clone(), MatchQuality::ProcfsExact));
         }
 
@@ -252,7 +247,7 @@ impl LinuxProcessLookup {
         // shape is deliberately collapsed into a single `ProcfsRelaxed`: what
         // matters downstream is that procfs needed to guess, not which of the
         // three wildcard shapes it guessed with.
-        let ((pid, name), _shape) = relaxed_lookup(&cache.lookup, &key)?;
+        let ((pid, name), _shape) = relaxed_lookup(&cache, &key)?;
         Some((*pid, name.clone(), MatchQuality::ProcfsRelaxed))
     }
 
@@ -278,8 +273,7 @@ impl LinuxProcessLookup {
         let executable = resolve_executable(tgid);
         let name = refine_truncated_name(name, executable.as_deref());
         let mut attribution =
-            ProcessAttribution::new(tgid, name, AttributionBackend::Procfs, quality)
-                .with_executable(executable);
+            ProcessAttribution::new(tgid, name, quality).with_executable(executable);
         if let Some(ppid) = resolve_parent_pid(tgid) {
             attribution = attribution
                 .with_parent_pid(ppid)
@@ -331,7 +325,10 @@ impl LinuxProcessLookup {
     /// Build inode -> (pid, process_name) mapping and PID -> process_name mapping
     fn build_inode_map() -> Result<(InodeProcessMap, PidNameMap)> {
         let mut inode_map = HashMap::new();
+        #[cfg(feature = "ebpf")]
         let mut pid_names = HashMap::new();
+        #[cfg(not(feature = "ebpf"))]
+        let pid_names = ();
 
         for entry in fs::read_dir("/proc")? {
             let entry = entry?;
@@ -352,6 +349,7 @@ impl LinuxProcessLookup {
                     .to_string();
 
                 // Store PID -> name mapping for all processes
+                #[cfg(feature = "ebpf")]
                 pid_names.insert(pid, process_name.clone());
 
                 // Check file descriptors for socket inodes
@@ -461,26 +459,20 @@ impl LinuxProcessLookup {
 }
 
 impl ProcessLookup for LinuxProcessLookup {
-    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
-        // Deliberately not routed through `get_process_attribution`: the tuple
-        // API has no use for the executable path or credentials, and resolving
-        // them costs two syscalls per hit.
-        self.lookup_match(conn).map(|(pid, name, _)| (pid, name))
-    }
-
     fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
         let (tgid, name, quality) = self.lookup_match(conn)?;
         Some(self.build_attribution(tgid, name, quality))
     }
 
     fn refresh(&self) -> Result<()> {
-        let (process_map, pid_names) = Self::build_process_map()?;
+        let (process_map, _pid_names) = Self::build_process_map()?;
 
-        let mut cache = self.cache.write().expect("process cache lock poisoned");
-        cache.lookup = process_map;
-        cache.last_refresh = Instant::now();
+        *self.cache.write().expect("process cache lock poisoned") = process_map;
 
-        *self.pid_names.write().expect("pid_names lock poisoned") = pid_names;
+        #[cfg(feature = "ebpf")]
+        {
+            *self.pid_names.write().expect("pid_names lock poisoned") = _pid_names;
+        }
         self.lineages
             .write()
             .expect("lineages lock poisoned")
@@ -491,10 +483,6 @@ impl ProcessLookup for LinuxProcessLookup {
 
     fn get_detection_method(&self) -> &str {
         "procfs"
-    }
-
-    fn get_attribution_backend(&self) -> AttributionBackend {
-        AttributionBackend::Procfs
     }
 }
 
@@ -703,7 +691,6 @@ mod tests {
         assert_eq!(attribution.tgid, own_pid());
         assert_eq!(attribution.name, "scanned-name");
         assert_eq!(attribution.quality, MatchQuality::ProcfsExact);
-        assert_eq!(attribution.backend, AttributionBackend::Procfs);
         assert_eq!(attribution.executable, std::env::current_exe().ok());
         assert_eq!(
             attribution.ppid,
@@ -754,7 +741,6 @@ mod tests {
 
         let conn = connection("192.168.1.10:8080", "203.0.113.5:44321");
         assert!(lookup.get_process_attribution(&conn).is_none());
-        assert!(lookup.get_process_for_connection(&conn).is_none());
     }
 
     /// End-to-end against the real `/proc/net/tcp` table rather than an
@@ -786,7 +772,6 @@ mod tests {
 
         assert_eq!(attribution.tgid, own_pid());
         assert_eq!(attribution.quality, MatchQuality::ProcfsExact);
-        assert_eq!(attribution.backend, AttributionBackend::Procfs);
         assert_eq!(attribution.executable, std::env::current_exe().ok());
         assert_eq!(
             attribution.ppid,
@@ -795,32 +780,5 @@ mod tests {
         assert_eq!(attribution.uid, Some(unsafe { libc::geteuid() }));
         assert_eq!(attribution.gid, Some(unsafe { libc::getegid() }));
         assert!(!attribution.name.is_empty());
-    }
-
-    #[test]
-    fn the_tuple_api_agrees_with_the_rich_api() {
-        let mut table = HashMap::new();
-        table.insert(
-            key("192.168.1.10:5000", "1.1.1.1:443"),
-            (own_pid(), "scanned-name".to_string()),
-        );
-        table.insert(
-            key("0.0.0.0:8080", "0.0.0.0:0"),
-            (own_pid(), "listener".to_string()),
-        );
-        let lookup = LinuxProcessLookup::with_socket_table(table);
-
-        for (local, remote) in [
-            ("192.168.1.10:5000", "1.1.1.1:443"),
-            ("192.168.1.10:8080", "203.0.113.5:44321"),
-        ] {
-            let conn = connection(local, remote);
-            let tuple = lookup
-                .get_process_for_connection(&conn)
-                .expect("tuple API must keep working");
-            let attribution = lookup.get_process_attribution(&conn).unwrap();
-
-            assert_eq!(tuple, (attribution.tgid, attribution.name));
-        }
     }
 }

--- a/crates/rustnet-host/src/macos/mod.rs
+++ b/crates/rustnet-host/src/macos/mod.rs
@@ -2,11 +2,9 @@
 
 mod process;
 
-pub use process::MacOSProcessLookup;
+use process::MacOSProcessLookup;
 
-use crate::{
-    AttributionBackend, DegradationReason, MatchQuality, ProcessAttribution, ProcessLookup,
-};
+use crate::{DegradationReason, MatchQuality, ProcessAttribution, ProcessLookup};
 use anyhow::Result;
 use rustnet_core::network::types::Connection;
 use std::sync::OnceLock;
@@ -37,23 +35,14 @@ pub(crate) fn pktap_degradation() -> DegradationReason {
 }
 
 /// Enrich process identity carried directly in PKTAP packet metadata.
-pub struct PktapProcessLookup;
+struct PktapProcessLookup;
 
 impl ProcessLookup for PktapProcessLookup {
-    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
-        Some((conn.pid?, conn.process_name.clone()?))
-    }
-
     fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
         let pid = conn.pid?;
         let name = conn.process_name.clone()?;
-        let mut attribution = ProcessAttribution::new(
-            pid,
-            name,
-            AttributionBackend::Pktap,
-            MatchQuality::ExactTuple,
-        )
-        .with_executable(process::resolve_executable(pid));
+        let mut attribution = ProcessAttribution::new(pid, name, MatchQuality::ExactTuple)
+            .with_executable(process::resolve_executable(pid));
         if let Some(details) = process::resolve_process_details(pid) {
             attribution = attribution.with_details(
                 details.ppid,
@@ -71,10 +60,6 @@ impl ProcessLookup for PktapProcessLookup {
 
     fn get_detection_method(&self) -> &str {
         "pktap"
-    }
-
-    fn get_attribution_backend(&self) -> AttributionBackend {
-        AttributionBackend::Pktap
     }
 }
 
@@ -115,7 +100,6 @@ mod tests {
 
         assert_eq!(attribution.tgid, std::process::id());
         assert_eq!(attribution.name, "rustnet-host-test");
-        assert_eq!(attribution.backend, AttributionBackend::Pktap);
         assert_eq!(attribution.quality, MatchQuality::ExactTuple);
         assert_eq!(attribution.executable, std::env::current_exe().ok());
         assert_eq!(
@@ -149,9 +133,8 @@ mod tests {
     }
 
     #[test]
-    fn pktap_factory_reports_its_backend() {
+    fn pktap_factory_reports_its_detection_method() {
         let lookup = create_process_lookup(true).unwrap();
         assert_eq!(lookup.get_detection_method(), "pktap");
-        assert_eq!(lookup.get_attribution_backend(), AttributionBackend::Pktap);
     }
 }

--- a/crates/rustnet-host/src/macos/process.rs
+++ b/crates/rustnet-host/src/macos/process.rs
@@ -1,9 +1,9 @@
 // network/platform/macos/process.rs - macOS lsof-based process lookup
 
 use crate::{
-    AttributionBackend, ConnectionKey, DegradationReason, MatchQuality, ProcessAncestor,
-    ProcessAttribution, ProcessLineage, ProcessLookup, ancestor_display_name,
-    collect_process_lineage, decode_process_name, parse_socket_addr_text, relaxed_lookup,
+    ConnectionKey, DegradationReason, MatchQuality, ProcessAncestor, ProcessAttribution,
+    ProcessLineage, ProcessLookup, ancestor_display_name, collect_process_lineage,
+    decode_process_name, parse_socket_addr_text, relaxed_lookup,
 };
 use anyhow::Result;
 use log::{debug, error, info, warn};
@@ -26,14 +26,14 @@ struct MacOSProcessInfo {
     uid: u32,
 }
 
-pub struct MacOSProcessLookup {
+pub(super) struct MacOSProcessLookup {
     cache: RwLock<HashMap<ConnectionKey, MacOSProcessInfo>>,
 }
 
 pub(super) struct ProcessDetails {
-    pub ppid: u32,
-    pub uid: u32,
-    pub gid: u32,
+    pub(super) ppid: u32,
+    pub(super) uid: u32,
+    pub(super) gid: u32,
     name: String,
     started_at_unix_ms: Option<u64>,
 }
@@ -145,7 +145,7 @@ pub(super) fn resolve_process_lineage(pid: u32, ppid: u32) -> Option<ProcessLine
 }
 
 impl MacOSProcessLookup {
-    pub fn new() -> Result<Self> {
+    pub(super) fn new() -> Result<Self> {
         Ok(Self {
             cache: RwLock::new(HashMap::new()),
         })
@@ -327,16 +327,10 @@ impl MacOSProcessLookup {
 }
 
 impl ProcessLookup for MacOSProcessLookup {
-    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
-        self.lookup_match(conn)
-            .map(|(process, _quality)| (process.pid, process.name))
-    }
-
     fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
         let (process, quality) = self.lookup_match(conn)?;
-        let mut attribution =
-            ProcessAttribution::new(process.pid, process.name, AttributionBackend::Lsof, quality)
-                .with_executable(resolve_executable(process.pid));
+        let mut attribution = ProcessAttribution::new(process.pid, process.name, quality)
+            .with_executable(resolve_executable(process.pid));
         attribution.uid = Some(process.uid);
         if let Some(details) = resolve_process_details(process.pid) {
             attribution = attribution.with_details(
@@ -366,10 +360,6 @@ impl ProcessLookup for MacOSProcessLookup {
         // The reason PKTAP wasn't used is injected by the application (which
         // learns it from the capture layer); see `super::report_pktap_degradation`.
         super::pktap_degradation()
-    }
-
-    fn get_attribution_backend(&self) -> AttributionBackend {
-        AttributionBackend::Lsof
     }
 }
 
@@ -440,21 +430,9 @@ fn parse_lsof_connection_with_hint(
 }
 
 /// Robust normalization of process names to match PKTAP normalization
-/// Handles all types of whitespace and control characters consistently
+/// (shared with rustnet-core so both sides stay identical)
 fn normalize_process_name_robust(name: &str) -> String {
-    let normalized = name
-        .chars()
-        .map(|c| {
-            if c.is_whitespace() || c.is_control() {
-                ' ' // Convert whitespace and control characters to space
-            } else {
-                c
-            }
-        })
-        .collect::<String>()
-        .split_whitespace() // Split on any whitespace
-        .collect::<Vec<&str>>()
-        .join(" "); // Join with single spaces
+    let normalized = rustnet_core::network::link_layer::pktap::normalize_process_name(name);
 
     debug!(
         "📝 Normalized lsof process name: '{}' -> '{}'",
@@ -527,12 +505,7 @@ curl\\x20helper 4294967295 501 9u IPv4 0x1 0t0 TCP 127.0.0.1:5000->1.1.1.1:443 (
         assert_eq!(attribution.uid, Some(501));
         assert_eq!(attribution.gid, None);
         assert_eq!(attribution.executable, None);
-        assert_eq!(attribution.backend, AttributionBackend::Lsof);
         assert_eq!(attribution.quality, MatchQuality::ExactTuple);
-        assert_eq!(
-            lookup.get_process_for_connection(&conn),
-            Some((u32::MAX, "curl helper".to_string()))
-        );
     }
 
     #[test]
@@ -614,7 +587,6 @@ server 42 root 3u IPv4 0x1 0t0 TCP 127.0.0.1:8080 (LISTEN)
         );
         assert_eq!(attribution.uid, Some(expected_uid));
         assert_eq!(attribution.executable, std::env::current_exe().ok());
-        assert_eq!(attribution.backend, AttributionBackend::Lsof);
         assert_eq!(attribution.quality, MatchQuality::ExactTuple);
     }
 

--- a/crates/rustnet-host/src/windows/mod.rs
+++ b/crates/rustnet-host/src/windows/mod.rs
@@ -3,7 +3,7 @@
 mod etw;
 mod process;
 
-pub use process::WindowsProcessLookup;
+use process::WindowsProcessLookup;
 
 use crate::ProcessLookup;
 use anyhow::Result;

--- a/crates/rustnet-host/src/windows/process.rs
+++ b/crates/rustnet-host/src/windows/process.rs
@@ -2,8 +2,8 @@
 
 use super::etw::{EtwAttribution, EtwProcessCache};
 use crate::{
-    AttributionBackend, ConnectionKey, DegradationReason, MatchQuality, ProcessAncestor,
-    ProcessAttribution, ProcessLineage, ProcessLookup, collect_process_lineage,
+    ConnectionKey, DegradationReason, MatchQuality, ProcessAncestor, ProcessAttribution,
+    ProcessLineage, ProcessLookup, collect_process_lineage, relaxed_lookup,
 };
 use anyhow::{Context, Result};
 use rustnet_core::network::types::{Connection, Protocol};
@@ -59,7 +59,7 @@ fn table_buffer_len(table: &[u32]) -> usize {
     std::mem::size_of_val(table)
 }
 
-pub struct WindowsProcessLookup {
+pub(super) struct WindowsProcessLookup {
     cache: RwLock<ProcessCache>,
     process_details: RwLock<HashMap<u32, WindowsProcessDetails>>,
     etw_cache: Arc<EtwProcessCache>,
@@ -86,8 +86,115 @@ struct WindowsRuntimeDetails {
     started_at_unix_ms: Option<u64>,
 }
 
+// The four IP Helper table refreshes share the same unsafe two-call dance:
+// size probe, ERROR_INSUFFICIENT_BUFFER check, size sanity check, allocate,
+// fetch, header and entry bounds checks, then a row loop ending in
+// cache_process. A macro rather than a generic function keeps the exact
+// Windows API types of each expansion intact; only the API function, address
+// family, table class, table and row types, log labels, and per-row key
+// construction vary.
+macro_rules! refresh_table {
+    (
+        $fn_name:ident,
+        $api:ident,
+        $family:expr,
+        $table_class:expr,
+        $table_ty:ty,
+        $row_ty:ty,
+        $api_label:literal,
+        $table_label:literal,
+        $processing_label:literal,
+        |$row:ident| $key:expr $(,)?
+    ) => {
+        fn $fn_name(
+            &self,
+            cache: &mut ProcessMap,
+            process_names: &mut ProcessNameCache,
+        ) -> Result<()> {
+            unsafe {
+                let mut size: u32 = 0;
+
+                // First call to get buffer size
+                let result = $api(None, &mut size, false, $family, $table_class, 0);
+
+                if WIN32_ERROR(result) != ERROR_INSUFFICIENT_BUFFER {
+                    log::debug!(
+                        concat!($api_label, " returned no data or error: {}"),
+                        result
+                    );
+                    return Ok(()); // No connections or error
+                }
+
+                if size == 0 || size > 100_000_000 {
+                    // Sanity check: reject unreasonably large sizes (100MB limit)
+                    log::warn!(concat!($api_label, " returned invalid size: {}"), size);
+                    return Ok(());
+                }
+
+                // Allocate buffer and get actual data
+                let mut table = allocate_table_buffer(size);
+                let result = $api(
+                    Some(table.as_mut_ptr() as *mut _),
+                    &mut size,
+                    false,
+                    $family,
+                    $table_class,
+                    0,
+                );
+
+                if result != 0 {
+                    log::debug!(concat!($api_label, " second call failed: {}"), result);
+                    return Ok(()); // Error getting table
+                }
+
+                // Verify we have enough data for the header
+                if table_buffer_len(&table) < std::mem::size_of::<u32>() {
+                    log::warn!(concat!($table_label, " table buffer too small for header"));
+                    return Ok(());
+                }
+
+                // Parse the table
+                let parsed_table = &*(table.as_ptr() as *const $table_ty);
+                let num_entries = parsed_table.dwNumEntries as usize;
+
+                // Bounds check: ensure we have enough space for all entries
+                let required_size =
+                    std::mem::size_of::<u32>() + num_entries * std::mem::size_of::<$row_ty>();
+                if table_buffer_len(&table) < required_size {
+                    log::warn!(
+                        concat!(
+                            $table_label,
+                            " table buffer too small: got {} bytes, need {} for {} entries"
+                        ),
+                        table_buffer_len(&table),
+                        required_size,
+                        num_entries
+                    );
+                    return Ok(());
+                }
+
+                log::debug!(
+                    concat!("Processing {} ", $processing_label, " connections"),
+                    num_entries
+                );
+
+                // Get pointer to the first entry
+                let rows_ptr = &parsed_table.table[0] as *const $row_ty;
+
+                for i in 0..num_entries {
+                    let $row = &*rows_ptr.add(i);
+                    let key = $key;
+                    cache_process(cache, process_names, key, $row.dwOwningPid);
+                }
+            }
+
+            Ok(())
+        }
+    };
+}
+
 impl WindowsProcessLookup {
-    pub fn new() -> Result<Self> {
+    pub(super) fn new() -> Result<Self> {
         // Use a very old timestamp that's guaranteed to be before now
         // by using checked_sub and falling back to epoch
         let now = Instant::now();
@@ -238,211 +345,51 @@ impl WindowsProcessLookup {
         Ok(())
     }
 
-    fn refresh_tcp_table_v4(
-        &self,
-        cache: &mut ProcessMap,
-        process_names: &mut ProcessNameCache,
-    ) -> Result<()> {
-        unsafe {
-            let mut size: u32 = 0;
-            let mut table: Vec<u32>;
-
-            // First call to get buffer size
-            let result = GetExtendedTcpTable(
-                None,
-                &mut size,
-                false,
-                AF_INET.0 as u32,
-                TCP_TABLE_OWNER_PID_ALL,
-                0,
-            );
-
-            if WIN32_ERROR(result) != ERROR_INSUFFICIENT_BUFFER {
-                log::debug!(
-                    "GetExtendedTcpTable (IPv4) returned no data or error: {}",
-                    result
-                );
-                return Ok(()); // No connections or error
-            }
-
-            if size == 0 || size > 100_000_000 {
-                // Sanity check: reject unreasonably large sizes (100MB limit)
-                log::warn!("GetExtendedTcpTable (IPv4) returned invalid size: {}", size);
-                return Ok(());
-            }
-
-            // Allocate buffer and get actual data
-            table = allocate_table_buffer(size);
-            let result = GetExtendedTcpTable(
-                Some(table.as_mut_ptr() as *mut _),
-                &mut size,
-                false,
-                AF_INET.0 as u32,
-                TCP_TABLE_OWNER_PID_ALL,
-                0,
-            );
-
-            if result != 0 {
-                log::debug!("GetExtendedTcpTable (IPv4) second call failed: {}", result);
-                return Ok(()); // Error getting table
-            }
-
-            // Verify we have enough data for the header
-            if table_buffer_len(&table) < std::mem::size_of::<u32>() {
-                log::warn!("TCP table buffer too small for header");
-                return Ok(());
-            }
-
-            // Parse the table
-            let tcp_table = &*(table.as_ptr() as *const MIB_TCPTABLE_OWNER_PID);
-            let num_entries = tcp_table.dwNumEntries as usize;
-
-            // Bounds check: ensure we have enough space for all entries
-            let required_size = std::mem::size_of::<u32>()
-                + num_entries * std::mem::size_of::<MIB_TCPROW_OWNER_PID>();
-            if table_buffer_len(&table) < required_size {
-                log::warn!(
-                    "TCP table buffer too small: got {} bytes, need {} for {} entries",
-                    table_buffer_len(&table),
-                    required_size,
-                    num_entries
-                );
-                return Ok(());
-            }
-
-            log::debug!("Processing {} TCP IPv4 connections", num_entries);
-
-            // Get pointer to the first entry
-            let rows_ptr = &tcp_table.table[0] as *const MIB_TCPROW_OWNER_PID;
-
-            for i in 0..num_entries {
-                let row = &*rows_ptr.add(i);
-
-                let local_addr = SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::from(row.dwLocalAddr.to_ne_bytes())),
-                    u16::from_be(row.dwLocalPort as u16),
-                );
-
-                let remote_addr = SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::from(row.dwRemoteAddr.to_ne_bytes())),
-                    u16::from_be(row.dwRemotePort as u16),
-                );
-
-                let key = ConnectionKey {
-                    protocol: Protocol::Tcp,
-                    local_addr,
-                    remote_addr,
-                };
-
-                cache_process(cache, process_names, key, row.dwOwningPid);
-            }
+    refresh_table!(
+        refresh_tcp_table_v4,
+        GetExtendedTcpTable,
+        AF_INET.0 as u32,
+        TCP_TABLE_OWNER_PID_ALL,
+        MIB_TCPTABLE_OWNER_PID,
+        MIB_TCPROW_OWNER_PID,
+        "GetExtendedTcpTable (IPv4)",
+        "TCP",
+        "TCP IPv4",
+        |row| ConnectionKey {
+            protocol: Protocol::Tcp,
+            local_addr: SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::from(row.dwLocalAddr.to_ne_bytes())),
+                u16::from_be(row.dwLocalPort as u16),
+            ),
+            remote_addr: SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::from(row.dwRemoteAddr.to_ne_bytes())),
+                u16::from_be(row.dwRemotePort as u16),
+            ),
         }
+    );
 
-        Ok(())
-    }
-
-    fn refresh_tcp_table_v6(
-        &self,
-        cache: &mut ProcessMap,
-        process_names: &mut ProcessNameCache,
-    ) -> Result<()> {
-        unsafe {
-            let mut size: u32 = 0;
-            let mut table: Vec<u32>;
-
-            // First call to get buffer size
-            let result = GetExtendedTcpTable(
-                None,
-                &mut size,
-                false,
-                AF_INET6.0 as u32,
-                TCP_TABLE_OWNER_PID_ALL,
-                0,
-            );
-
-            if WIN32_ERROR(result) != ERROR_INSUFFICIENT_BUFFER {
-                log::debug!(
-                    "GetExtendedTcpTable (IPv6) returned no data or error: {}",
-                    result
-                );
-                return Ok(()); // No connections or error
-            }
-
-            if size == 0 || size > 100_000_000 {
-                // Sanity check: reject unreasonably large sizes (100MB limit)
-                log::warn!("GetExtendedTcpTable (IPv6) returned invalid size: {}", size);
-                return Ok(());
-            }
-
-            // Allocate buffer and get actual data
-            table = allocate_table_buffer(size);
-            let result = GetExtendedTcpTable(
-                Some(table.as_mut_ptr() as *mut _),
-                &mut size,
-                false,
-                AF_INET6.0 as u32,
-                TCP_TABLE_OWNER_PID_ALL,
-                0,
-            );
-
-            if result != 0 {
-                log::debug!("GetExtendedTcpTable (IPv6) second call failed: {}", result);
-                return Ok(()); // Error getting table
-            }
-
-            // Verify we have enough data for the header
-            if table_buffer_len(&table) < std::mem::size_of::<u32>() {
-                log::warn!("TCP IPv6 table buffer too small for header");
-                return Ok(());
-            }
-
-            // Parse the table
-            let tcp_table = &*(table.as_ptr() as *const MIB_TCP6TABLE_OWNER_PID);
-            let num_entries = tcp_table.dwNumEntries as usize;
-
-            // Bounds check: ensure we have enough space for all entries
-            let required_size = std::mem::size_of::<u32>()
-                + num_entries * std::mem::size_of::<MIB_TCP6ROW_OWNER_PID>();
-            if table_buffer_len(&table) < required_size {
-                log::warn!(
-                    "TCP IPv6 table buffer too small: got {} bytes, need {} for {} entries",
-                    table_buffer_len(&table),
-                    required_size,
-                    num_entries
-                );
-                return Ok(());
-            }
-
-            log::debug!("Processing {} TCP IPv6 connections", num_entries);
-
-            // Get pointer to the first entry
-            let rows_ptr = &tcp_table.table[0] as *const MIB_TCP6ROW_OWNER_PID;
-
-            for i in 0..num_entries {
-                let row = &*rows_ptr.add(i);
-
-                let local_addr = SocketAddr::new(
-                    IpAddr::V6(Ipv6Addr::from(row.ucLocalAddr)),
-                    u16::from_be(row.dwLocalPort as u16),
-                );
-
-                let remote_addr = SocketAddr::new(
-                    IpAddr::V6(Ipv6Addr::from(row.ucRemoteAddr)),
-                    u16::from_be(row.dwRemotePort as u16),
-                );
-
-                let key = ConnectionKey {
-                    protocol: Protocol::Tcp,
-                    local_addr,
-                    remote_addr,
-                };
-
-                cache_process(cache, process_names, key, row.dwOwningPid);
-            }
+    refresh_table!(
+        refresh_tcp_table_v6,
+        GetExtendedTcpTable,
+        AF_INET6.0 as u32,
+        TCP_TABLE_OWNER_PID_ALL,
+        MIB_TCP6TABLE_OWNER_PID,
+        MIB_TCP6ROW_OWNER_PID,
+        "GetExtendedTcpTable (IPv6)",
+        "TCP IPv6",
+        "TCP IPv6",
+        |row| ConnectionKey {
+            protocol: Protocol::Tcp,
+            local_addr: SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(row.ucLocalAddr)),
+                u16::from_be(row.dwLocalPort as u16),
+            ),
+            remote_addr: SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(row.ucRemoteAddr)),
+                u16::from_be(row.dwRemotePort as u16),
+            ),
         }
-
-        Ok(())
-    }
+    );
 
     fn refresh_udp_processes(
         &self,
@@ -456,197 +403,51 @@ impl WindowsProcessLookup {
         Ok(())
     }
 
-    fn refresh_udp_table_v4(
-        &self,
-        cache: &mut ProcessMap,
-        process_names: &mut ProcessNameCache,
-    ) -> Result<()> {
-        unsafe {
-            let mut size: u32 = 0;
-            let mut table: Vec<u32>;
-
-            // First call to get buffer size
-            let result = GetExtendedUdpTable(
-                None,
-                &mut size,
-                false,
-                AF_INET.0 as u32,
-                UDP_TABLE_OWNER_PID,
-                0,
-            );
-
-            if WIN32_ERROR(result) != ERROR_INSUFFICIENT_BUFFER {
-                log::debug!(
-                    "GetExtendedUdpTable (IPv4) returned no data or error: {}",
-                    result
-                );
-                return Ok(()); // No connections or error
-            }
-
-            if size == 0 || size > 100_000_000 {
-                // Sanity check: reject unreasonably large sizes (100MB limit)
-                log::warn!("GetExtendedUdpTable (IPv4) returned invalid size: {}", size);
-                return Ok(());
-            }
-
-            // Allocate buffer and get actual data
-            table = allocate_table_buffer(size);
-            let result = GetExtendedUdpTable(
-                Some(table.as_mut_ptr() as *mut _),
-                &mut size,
-                false,
-                AF_INET.0 as u32,
-                UDP_TABLE_OWNER_PID,
-                0,
-            );
-
-            if result != 0 {
-                log::debug!("GetExtendedUdpTable (IPv4) second call failed: {}", result);
-                return Ok(()); // Error getting table
-            }
-
-            // Verify we have enough data for the header
-            if table_buffer_len(&table) < std::mem::size_of::<u32>() {
-                log::warn!("UDP table buffer too small for header");
-                return Ok(());
-            }
-
-            // Parse the table
-            let udp_table = &*(table.as_ptr() as *const MIB_UDPTABLE_OWNER_PID);
-            let num_entries = udp_table.dwNumEntries as usize;
-
-            // Bounds check: ensure we have enough space for all entries
-            let required_size = std::mem::size_of::<u32>()
-                + num_entries * std::mem::size_of::<MIB_UDPROW_OWNER_PID>();
-            if table_buffer_len(&table) < required_size {
-                log::warn!(
-                    "UDP table buffer too small: got {} bytes, need {} for {} entries",
-                    table_buffer_len(&table),
-                    required_size,
-                    num_entries
-                );
-                return Ok(());
-            }
-
-            log::debug!("Processing {} UDP IPv4 connections", num_entries);
-
-            // Get pointer to the first entry
-            let rows_ptr = &udp_table.table[0] as *const MIB_UDPROW_OWNER_PID;
-
-            for i in 0..num_entries {
-                let row = &*rows_ptr.add(i);
-
-                let local_addr = SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::from(row.dwLocalAddr.to_ne_bytes())),
-                    u16::from_be(row.dwLocalPort as u16),
-                );
-
-                // UDP doesn't have remote address in the table
-                let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
-
-                let key = ConnectionKey {
-                    protocol: Protocol::Udp,
-                    local_addr,
-                    remote_addr,
-                };
-
-                cache_process(cache, process_names, key, row.dwOwningPid);
-            }
+    refresh_table!(
+        refresh_udp_table_v4,
+        GetExtendedUdpTable,
+        AF_INET.0 as u32,
+        UDP_TABLE_OWNER_PID,
+        MIB_UDPTABLE_OWNER_PID,
+        MIB_UDPROW_OWNER_PID,
+        "GetExtendedUdpTable (IPv4)",
+        "UDP",
+        "UDP IPv4",
+        |row| ConnectionKey {
+            protocol: Protocol::Udp,
+            local_addr: SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::from(row.dwLocalAddr.to_ne_bytes())),
+                u16::from_be(row.dwLocalPort as u16),
+            ),
+            // UDP doesn't have remote address in the table
+            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
         }
+    );
 
-        Ok(())
-    }
-
-    fn refresh_udp_table_v6(
-        &self,
-        cache: &mut ProcessMap,
-        process_names: &mut ProcessNameCache,
-    ) -> Result<()> {
-        unsafe {
-            let mut size: u32 = 0;
-
-            let result = GetExtendedUdpTable(
-                None,
-                &mut size,
-                false,
-                AF_INET6.0 as u32,
-                UDP_TABLE_OWNER_PID,
-                0,
-            );
-
-            if WIN32_ERROR(result) != ERROR_INSUFFICIENT_BUFFER {
-                log::debug!(
-                    "GetExtendedUdpTable (IPv6) returned no data or error: {}",
-                    result
-                );
-                return Ok(());
-            }
-
-            if size == 0 || size > 100_000_000 {
-                log::warn!("GetExtendedUdpTable (IPv6) returned invalid size: {}", size);
-                return Ok(());
-            }
-
-            let mut table = allocate_table_buffer(size);
-            let result = GetExtendedUdpTable(
-                Some(table.as_mut_ptr() as *mut _),
-                &mut size,
-                false,
-                AF_INET6.0 as u32,
-                UDP_TABLE_OWNER_PID,
-                0,
-            );
-
-            if result != 0 {
-                log::debug!("GetExtendedUdpTable (IPv6) second call failed: {}", result);
-                return Ok(());
-            }
-
-            if table_buffer_len(&table) < std::mem::size_of::<u32>() {
-                log::warn!("UDP IPv6 table buffer too small for header");
-                return Ok(());
-            }
-
-            let udp_table = &*(table.as_ptr() as *const MIB_UDP6TABLE_OWNER_PID);
-            let num_entries = udp_table.dwNumEntries as usize;
-            let required_size = std::mem::size_of::<u32>()
-                + num_entries * std::mem::size_of::<MIB_UDP6ROW_OWNER_PID>();
-            if table_buffer_len(&table) < required_size {
-                log::warn!(
-                    "UDP IPv6 table buffer too small: got {} bytes, need {} for {} entries",
-                    table_buffer_len(&table),
-                    required_size,
-                    num_entries
-                );
-                return Ok(());
-            }
-
-            log::debug!("Processing {} UDP IPv6 connections", num_entries);
-
-            let rows_ptr = &udp_table.table[0] as *const MIB_UDP6ROW_OWNER_PID;
-            for i in 0..num_entries {
-                let row = &*rows_ptr.add(i);
-                let local_addr = SocketAddr::new(
-                    IpAddr::V6(Ipv6Addr::from(row.ucLocalAddr)),
-                    u16::from_be(row.dwLocalPort as u16),
-                );
-                let remote_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0);
-                let key = ConnectionKey {
-                    protocol: Protocol::Udp,
-                    local_addr,
-                    remote_addr,
-                };
-
-                cache_process(cache, process_names, key, row.dwOwningPid);
-            }
+    refresh_table!(
+        refresh_udp_table_v6,
+        GetExtendedUdpTable,
+        AF_INET6.0 as u32,
+        UDP_TABLE_OWNER_PID,
+        MIB_UDP6TABLE_OWNER_PID,
+        MIB_UDP6ROW_OWNER_PID,
+        "GetExtendedUdpTable (IPv6)",
+        "UDP IPv6",
+        "UDP IPv6",
+        |row| ConnectionKey {
+            protocol: Protocol::Udp,
+            local_addr: SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(row.ucLocalAddr)),
+                u16::from_be(row.dwLocalPort as u16),
+            ),
+            // UDP doesn't have remote address in the table
+            remote_addr: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
         }
-
-        Ok(())
-    }
+    );
 }
 
-impl ProcessLookup for WindowsProcessLookup {
-    fn get_process_for_connection(&self, conn: &Connection) -> Option<(u32, String)> {
+impl WindowsProcessLookup {
+    fn lookup_process(&self, conn: &Connection) -> Option<(u32, String)> {
         let key = ConnectionKey::from_connection(conn);
 
         // A fresh IP Helper snapshot reflects the kernel's current socket
@@ -676,7 +477,9 @@ impl ProcessLookup for WindowsProcessLookup {
                     return Some(process_info.clone());
                 }
                 // Exact match missed — try wildcard fallback before declaring a miss
-                if let Some(result) = Self::fallback_lookup(&cache.lookup, &key) {
+                if let Some(result) =
+                    relaxed_lookup(&cache.lookup, &key).map(|(process, _quality)| process.clone())
+                {
                     log::trace!("✓ Fallback hit (cache): {:?} => {:?}", key, result);
                     return Some(result);
                 }
@@ -716,11 +519,9 @@ impl ProcessLookup for WindowsProcessLookup {
                     poisoned.into_inner()
                 }
             };
-            let result = cache
-                .lookup
-                .get(&key)
-                .cloned()
-                .or_else(|| Self::fallback_lookup(&cache.lookup, &key));
+            let result = cache.lookup.get(&key).cloned().or_else(|| {
+                relaxed_lookup(&cache.lookup, &key).map(|(process, _quality)| process.clone())
+            });
             if result.is_some() {
                 log::trace!("✓ Found after refresh: {:?} => {:?}", key, result);
             } else {
@@ -736,15 +537,12 @@ impl ProcessLookup for WindowsProcessLookup {
             etw_process
         }
     }
+}
 
+impl ProcessLookup for WindowsProcessLookup {
     fn get_process_attribution(&self, conn: &Connection) -> Option<ProcessAttribution> {
-        let (pid, name) = self.get_process_for_connection(conn)?;
-        let mut attribution = ProcessAttribution::new(
-            pid,
-            name,
-            AttributionBackend::PlatformNative,
-            MatchQuality::Unspecified,
-        );
+        let (pid, name) = self.lookup_process(conn)?;
+        let mut attribution = ProcessAttribution::new(pid, name, MatchQuality::Unspecified);
         if let Some(details) = self.process_details(pid) {
             let lineage = self.process_lineage(pid, details.ppid);
             attribution = attribution.with_details(details.ppid, None, details.executable, lineage);
@@ -1009,7 +807,6 @@ mod tests {
 
         assert_eq!(attribution.tgid, std::process::id());
         assert_ne!(attribution.name, UNKNOWN_PROCESS_NAME);
-        assert_eq!(attribution.backend, AttributionBackend::PlatformNative);
         assert!(attribution.executable.is_some());
         assert_eq!(
             attribution

--- a/crates/rustnet-sandbox/src/linux/capabilities.rs
+++ b/crates/rustnet-sandbox/src/linux/capabilities.rs
@@ -27,7 +27,7 @@ use caps::{CapSet, Capability};
 /// - `Ok(true)` if CAP_NET_RAW was dropped
 /// - `Ok(false)` if CAP_NET_RAW was not held (nothing to drop)
 /// - `Err` if dropping failed
-pub fn drop_cap_net_raw() -> Result<bool> {
+pub(crate) fn drop_cap_net_raw() -> Result<bool> {
     // Check if we have CAP_NET_RAW in the effective set
     let has_cap = caps::has_cap(None, CapSet::Effective, Capability::CAP_NET_RAW)
         .context("Failed to check CAP_NET_RAW in effective set")?;
@@ -58,7 +58,7 @@ pub fn drop_cap_net_raw() -> Result<bool> {
 }
 
 /// Check if CAP_NET_RAW is currently held in the effective set
-pub fn has_cap_net_raw() -> bool {
+pub(crate) fn has_cap_net_raw() -> bool {
     caps::has_cap(None, CapSet::Effective, Capability::CAP_NET_RAW).unwrap_or(false)
 }
 
@@ -72,7 +72,7 @@ pub fn has_cap_net_raw() -> bool {
 ///
 /// - `Ok(count)` where count is how many capabilities were dropped (0-2)
 /// - `Err` if dropping failed
-pub fn drop_ebpf_caps() -> Result<u32> {
+pub(crate) fn drop_ebpf_caps() -> Result<u32> {
     let mut dropped = 0;
 
     for cap in [Capability::CAP_BPF, Capability::CAP_PERFMON] {
@@ -132,7 +132,7 @@ pub fn drop_unused_thread_caps(thread: &str) {
 /// Clearing them prevents child processes from inheriting any capabilities
 /// that were held by the parent. This is standard practice in container
 /// runtimes (Docker, systemd) and security-sensitive daemons.
-pub fn clear_ambient_caps() -> Result<()> {
+pub(crate) fn clear_ambient_caps() -> Result<()> {
     caps::clear(None, CapSet::Ambient).context("Failed to clear ambient capability set")?;
     log::debug!("Cleared ambient capability set");
     Ok(())

--- a/crates/rustnet-sandbox/src/linux/landlock.rs
+++ b/crates/rustnet-sandbox/src/linux/landlock.rs
@@ -64,7 +64,7 @@ const ABI_SCOPE: ABI = ABI::V6;
 const ACCOUNT_DATABASE_PATHS: [&str; 3] = ["/etc/passwd", "/etc/group", "/etc/nsswitch.conf"];
 
 /// Result of Landlock application
-pub struct LandlockResult {
+pub(super) struct LandlockResult {
     /// Whether filesystem restrictions were applied
     pub fs_applied: bool,
     /// Whether network restrictions were applied
@@ -100,7 +100,7 @@ fn abi_version(abi: ABI) -> u8 {
 
 /// Check if Landlock is available by attempting a test restriction
 /// Note: This actually attempts to create a minimal ruleset to check
-pub fn is_available() -> bool {
+pub(super) fn is_available() -> bool {
     // Try to create a minimal ruleset - this will fail if Landlock isn't available
     Ruleset::default()
         .handle_access(AccessFs::Execute)
@@ -109,7 +109,7 @@ pub fn is_available() -> bool {
 }
 
 /// Apply Landlock restrictions based on configuration
-pub fn apply_landlock(config: &SandboxConfig) -> Result<LandlockResult> {
+pub(super) fn apply_landlock(config: &SandboxConfig) -> Result<LandlockResult> {
     // Check if disabled
     if config.mode == SandboxMode::Disabled {
         return Ok(LandlockResult {

--- a/crates/rustnet-sandbox/src/macos/mod.rs
+++ b/crates/rustnet-sandbox/src/macos/mod.rs
@@ -93,7 +93,6 @@ pub(crate) fn apply(config: &SandboxConfig) -> anyhow::Result<SandboxReport> {
                     fs_restricted: result.fs_restricted,
                     net_restricted: result.net_blocked,
                     uid_dropped,
-                    ..SandboxReport::default()
                 })
             }
             Err(e) => {

--- a/crates/rustnet-sandbox/src/macos/seatbelt.rs
+++ b/crates/rustnet-sandbox/src/macos/seatbelt.rs
@@ -37,7 +37,7 @@ use std::path::Path;
 use crate::SandboxConfig;
 
 /// Result of Seatbelt application
-pub struct SeatbeltResult {
+pub(super) struct SeatbeltResult {
     /// Whether the sandbox was applied
     pub applied: bool,
     /// Human-readable message
@@ -186,7 +186,7 @@ fn build_sbpl_profile(config: &SandboxConfig) -> String {
 ///
 /// The caller (`apply` in mod.rs) handles the `Disabled` mode check, so this
 /// function assumes sandboxing is requested.
-pub fn apply_seatbelt(config: &SandboxConfig) -> Result<SeatbeltResult> {
+pub(super) fn apply_seatbelt(config: &SandboxConfig) -> Result<SeatbeltResult> {
     let profile = build_sbpl_profile(config);
     let profile_cstr = CString::new(profile).context("Profile contains null byte")?;
 

--- a/crates/rustnet-sandbox/src/privdrop.rs
+++ b/crates/rustnet-sandbox/src/privdrop.rs
@@ -108,7 +108,7 @@ pub fn chown_to_target(file: &std::fs::File, target: DropTarget) -> std::io::Res
 /// Side effect on Linux: transitioning all three uids away from 0 clears the
 /// effective and permitted capability sets, which subsumes the explicit
 /// capability drops that run before this.
-pub fn drop_to(target: DropTarget) -> Result<()> {
+pub(crate) fn drop_to(target: DropTarget) -> Result<()> {
     if target.uid == 0 || target.gid == 0 {
         return Err(anyhow!("refusing to 'drop' to uid 0 / gid 0"));
     }

--- a/crates/rustnet-sandbox/src/windows/restricted.rs
+++ b/crates/rustnet-sandbox/src/windows/restricted.rs
@@ -45,7 +45,7 @@ const PRIVILEGES_TO_REMOVE: &[&str] = &[
 ];
 
 /// Result of restricted token application
-pub struct RestrictedTokenResult {
+pub(super) struct RestrictedTokenResult {
     /// Whether at least one privilege was removed (count > 0).
     /// False for non-elevated processes that never held the privileges.
     pub privileges_removed: bool,
@@ -60,7 +60,7 @@ pub struct RestrictedTokenResult {
 }
 
 /// Result of job object application
-pub struct JobObjectResult {
+pub(super) struct JobObjectResult {
     /// Whether the job object was applied
     pub applied: bool,
     /// Human-readable message
@@ -71,7 +71,7 @@ pub struct JobObjectResult {
 ///
 /// Uses SE_PRIVILEGE_REMOVED which permanently removes privileges —
 /// they cannot be re-enabled, even by the process itself.
-pub fn remove_dangerous_privileges() -> Result<RestrictedTokenResult> {
+pub(super) fn remove_dangerous_privileges() -> Result<RestrictedTokenResult> {
     unsafe {
         let mut token_handle = HANDLE::default();
 
@@ -177,7 +177,7 @@ unsafe fn remove_single_privilege(token: HANDLE, privilege_name: &str) -> Result
 ///
 /// After this call, any attempt to create a child process will fail.
 /// This blocks reverse shells, data exfiltration via exec, etc.
-pub fn apply_job_object() -> Result<JobObjectResult> {
+pub(super) fn apply_job_object() -> Result<JobObjectResult> {
     unsafe {
         // Create an unnamed job object
         let job = CreateJobObjectW(None, None).context("Failed to create job object")?;

--- a/examples/headless.rs
+++ b/examples/headless.rs
@@ -35,16 +35,16 @@ fn main() -> anyhow::Result<()> {
     //    survive it; see the rustnet-sandbox crate docs for the ordering
     //    contract. On Linux/macOS/FreeBSD also drop root to the invoking
     //    sudo user.
-    #[allow(unused_mut)]
-    let mut sandbox_config = SandboxConfig {
+    let sandbox_config = SandboxConfig {
         mode: SandboxMode::BestEffort,
         block_network: true, // passive monitor: no outbound TCP needed
         ..SandboxConfig::default()
     };
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
-    {
-        sandbox_config.drop_uid = rustnet_sandbox::privdrop::resolve_drop_target();
-    }
+    let sandbox_config = SandboxConfig {
+        drop_uid: rustnet_sandbox::privdrop::resolve_drop_target(),
+        ..sandbox_config
+    };
     let report = apply_sandbox(&sandbox_config)?;
     println!("sandbox: {} ({})", report.status.label(), report.message);
 
@@ -107,8 +107,8 @@ fn main() -> anyhow::Result<()> {
                 .clone()
                 .or_else(|| {
                     process_lookup
-                        .get_process_for_connection(conn)
-                        .map(|(_, name)| name)
+                        .get_process_attribution(conn)
+                        .map(|attribution| attribution.name)
                 })
                 .unwrap_or_else(|| "-".to_string());
             println!(

--- a/src/app/capture.rs
+++ b/src/app/capture.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use crossbeam::channel::{self, Receiver, Sender};
 use log::{debug, error, info, warn};
+use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::thread;
@@ -246,6 +247,34 @@ impl App {
                         }
                     };
 
+                    // Hand the current batch to the processors and reset the
+                    // deadline. Returns `Break` when the receiving side is gone
+                    // and the capture loop must exit.
+                    let send_batch = |batch: &mut Vec<CapturedPacket>,
+                                      batch_deadline: &mut Instant,
+                                      what: &str|
+                     -> ControlFlow<()> {
+                        let to_send = std::mem::replace(batch, Vec::with_capacity(100));
+                        let batch_size = to_send.len() as u64;
+                        debug!("try_send: {} batch of {} packets", what, batch_size);
+                        match packet_tx.try_send(to_send) {
+                            Ok(()) => {}
+                            Err(crossbeam::channel::TrySendError::Full(_)) => {
+                                stats.packets_dropped.fetch_add(batch_size, Ordering::Relaxed);
+                            }
+                            Err(crossbeam::channel::TrySendError::Disconnected(_)) => {
+                                warn!("Packet channel closed");
+                                record_failure(capture_failure_message(
+                                    "Capture stopped",
+                                    &"the packet processing threads exited",
+                                ));
+                                return ControlFlow::Break(());
+                            }
+                        }
+                        *batch_deadline = Instant::now() + Duration::from_millis(100);
+                        ControlFlow::Continue(())
+                    };
+
                     loop {
                         if should_stop.load(Ordering::Relaxed) {
                             info!("Capture thread stopping");
@@ -290,48 +319,21 @@ impl App {
                                 batch.push(packet);
 
                                 // Send batch when full or deadline reached
-                                if batch.len() >= 100 || Instant::now() >= batch_deadline {
-                                    let to_send = std::mem::replace(&mut batch, Vec::with_capacity(100));
-                                    let batch_size = to_send.len() as u64;
-                                    debug!("try_send: sending batch of {} packets", batch_size);
-                                    match packet_tx.try_send(to_send) {
-                                        Ok(()) => {}
-                                        Err(crossbeam::channel::TrySendError::Full(_)) => {
-                                            stats.packets_dropped.fetch_add(batch_size, Ordering::Relaxed);
-                                        }
-                                        Err(crossbeam::channel::TrySendError::Disconnected(_)) => {
-                                            warn!("Packet channel closed");
-                                            record_failure(capture_failure_message(
-                                                "Capture stopped",
-                                                &"the packet processing threads exited",
-                                            ));
-                                            break;
-                                        }
-                                    }
-                                    batch_deadline = Instant::now() + Duration::from_millis(100);
+                                if (batch.len() >= 100 || Instant::now() >= batch_deadline)
+                                    && send_batch(&mut batch, &mut batch_deadline, "sending")
+                                        .is_break()
+                                {
+                                    break;
                                 }
                             }
                             Ok(None) => {
                                 // Timeout - flush partial batch if deadline reached
-                                if !batch.is_empty() && Instant::now() >= batch_deadline {
-                                    let to_send = std::mem::replace(&mut batch, Vec::with_capacity(100));
-                                    let batch_size = to_send.len() as u64;
-                                    debug!("try_send: flushing partial batch of {} packets", batch_size);
-                                    match packet_tx.try_send(to_send) {
-                                        Ok(()) => {}
-                                        Err(crossbeam::channel::TrySendError::Full(_)) => {
-                                            stats.packets_dropped.fetch_add(batch_size, Ordering::Relaxed);
-                                        }
-                                        Err(crossbeam::channel::TrySendError::Disconnected(_)) => {
-                                            warn!("Packet channel closed");
-                                            record_failure(capture_failure_message(
-                                                "Capture stopped",
-                                                &"the packet processing threads exited",
-                                            ));
-                                            break;
-                                        }
-                                    }
-                                    batch_deadline = Instant::now() + Duration::from_millis(100);
+                                if !batch.is_empty()
+                                    && Instant::now() >= batch_deadline
+                                    && send_batch(&mut batch, &mut batch_deadline, "flushing partial")
+                                        .is_break()
+                                {
+                                    break;
                                 }
 
                                 // Check stats every second
@@ -706,10 +708,8 @@ mod capture_failure_message_tests {
 #[cfg(test)]
 mod connection_lifecycle_tests {
     use super::*;
-    use crate::network::{
-        protocol::tcp::{TcpFlags, TcpHeaderInfo},
-        types::{AddrKind, Protocol, ProtocolState, TcpState},
-    };
+    use crate::network::types::{Protocol, ProtocolState, TcpState};
+    use rustnet_core::network::protocol::tcp::{TcpFlags, TcpHeaderInfo};
     use std::net::SocketAddr;
     use std::path::{Path, PathBuf};
 
@@ -739,27 +739,24 @@ mod connection_lifecycle_tests {
     }
 
     fn tcp_packet(flags: TcpFlags) -> ParsedPacket {
-        ParsedPacket {
-            protocol: Protocol::Tcp,
-            local_addr: SocketAddr::from(([192, 0, 2, 1], 40_000)),
-            remote_addr: SocketAddr::from(([198, 51, 100, 1], 443)),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            tcp_header: Some(TcpHeaderInfo {
-                seq: 1_000,
-                ack: 0,
-                window: 65_535,
-                flags,
-                payload_len: 0,
-            }),
-            protocol_state: ProtocolState::Tcp(TcpState::Unknown),
-            is_outgoing: true,
-            packet_len: 60,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
-        }
+        let mut packet = ParsedPacket::new(
+            Protocol::Tcp,
+            SocketAddr::from(([192, 0, 2, 1], 40_000)),
+            SocketAddr::from(([198, 51, 100, 1], 443)),
+            ProtocolState::Tcp(TcpState::Unknown),
+            true,
+            60,
+            None,
+            None,
+        );
+        packet.tcp_header = Some(TcpHeaderInfo {
+            seq: 1_000,
+            ack: 0,
+            window: 65_535,
+            flags,
+            payload_len: 0,
+        });
+        packet
     }
 
     fn flags(syn: bool, rst: bool) -> TcpFlags {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -14,10 +14,7 @@ mod types;
 
 pub use state::App;
 pub(crate) use types::ConnectionCounts;
-pub use types::{
-    AppOutputHandles, AppStats, Config, ConnRateHistory, ConnRateHistorySnapshot,
-    ProcessDetectionStatus,
-};
+pub use types::{AppOutputHandles, AppStats, Config};
 
 use std::time::Duration;
 

--- a/src/app/pcapng_export.rs
+++ b/src/app/pcapng_export.rs
@@ -428,7 +428,7 @@ fn sanitize_comment_value(value: &str) -> String {
 mod pcapng_export_tests {
     use super::*;
     use crate::network::parser::ParsedPacket;
-    use crate::network::types::{AddrKind, Protocol};
+    use crate::network::types::Protocol;
     use std::net::SocketAddr;
 
     fn record(data: u8, key: Option<ConnectionKey>, deadline: Instant) -> PcapngRecord {
@@ -447,38 +447,33 @@ mod pcapng_export_tests {
     /// generation must not claim it.
     #[test]
     fn annotation_requires_matching_connection_generation() {
-        use crate::network::{
-            protocol::tcp::{TcpFlags, TcpHeaderInfo},
-            types::{ProtocolState, TcpState},
-        };
+        use crate::network::types::{ProtocolState, TcpState};
+        use rustnet_core::network::protocol::tcp::{TcpFlags, TcpHeaderInfo};
 
         let tracker = ConnectionTracker::new();
-        let outcome = tracker.ingest(&ParsedPacket {
-            protocol: Protocol::Tcp,
-            local_addr: SocketAddr::from(([192, 0, 2, 9], 41_000)),
-            remote_addr: SocketAddr::from(([198, 51, 100, 9], 443)),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            tcp_header: Some(TcpHeaderInfo {
-                seq: 1,
-                ack: 0,
-                window: 65_535,
-                flags: TcpFlags {
-                    syn: true,
-                    ack: false,
-                    fin: false,
-                    rst: false,
-                },
-                payload_len: 0,
-            }),
-            protocol_state: ProtocolState::Tcp(TcpState::Unknown),
-            is_outgoing: true,
-            packet_len: 60,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
+        let mut packet = ParsedPacket::new(
+            Protocol::Tcp,
+            SocketAddr::from(([192, 0, 2, 9], 41_000)),
+            SocketAddr::from(([198, 51, 100, 9], 443)),
+            ProtocolState::Tcp(TcpState::Unknown),
+            true,
+            60,
+            None,
+            None,
+        );
+        packet.tcp_header = Some(TcpHeaderInfo {
+            seq: 1,
+            ack: 0,
+            window: 65_535,
+            flags: TcpFlags {
+                syn: true,
+                ack: false,
+                fin: false,
+                rst: false,
+            },
+            payload_len: 0,
         });
+        let outcome = tracker.ingest_at(&packet, std::time::SystemTime::now());
         let key = outcome.key;
         tracker.connections().get_mut(&key).unwrap().process_name = Some("nginx".to_string());
         let created_at = tracker.connections().get(&key).unwrap().created_at;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -588,13 +588,13 @@ impl App {
     }
 
     /// Get sandbox status information. Rendered by the Linux, Windows, and
-    /// macOS (with `macos-sandbox`) UIs, including the external GUI crate.
+    /// macOS (with `macos-sandbox`) UIs.
     #[cfg(any(
         target_os = "linux",
         target_os = "windows",
         all(target_os = "macos", feature = "macos-sandbox")
     ))]
-    pub fn get_sandbox_info(&self) -> SandboxReport {
+    pub(crate) fn get_sandbox_info(&self) -> SandboxReport {
         self.sandbox_info
             .read()
             .map(|s| s.clone())

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -587,9 +587,14 @@ impl App {
             .unwrap_or_default()
     }
 
-    /// Get sandbox status information. Only the Linux UI renders it.
-    #[cfg(target_os = "linux")]
-    pub(crate) fn get_sandbox_info(&self) -> SandboxReport {
+    /// Get sandbox status information. Rendered by the Linux, Windows, and
+    /// macOS (with `macos-sandbox`) UIs, including the external GUI crate.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "windows",
+        all(target_os = "macos", feature = "macos-sandbox")
+    ))]
+    pub fn get_sandbox_info(&self) -> SandboxReport {
         self.sandbox_info
             .read()
             .map(|s| s.clone())

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -156,8 +156,10 @@ pub struct App {
 }
 
 impl App {
-    /// Create a new application instance
-    pub fn new(config: Config) -> Result<Self> {
+    /// Create an application instance with default output handles. Tests only:
+    /// production goes through [`new_with_output_handles`](Self::new_with_output_handles).
+    #[cfg(test)]
+    pub(crate) fn new(config: Config) -> Result<Self> {
         Self::new_with_output_handles(config, AppOutputHandles::default())
     }
 
@@ -437,7 +439,7 @@ impl App {
     }
 
     /// Get interface statistics
-    pub fn get_interface_stats(&self) -> Vec<InterfaceStats> {
+    pub(crate) fn get_interface_stats(&self) -> Vec<InterfaceStats> {
         self.interface_stats
             .iter()
             .map(|entry| entry.value().clone())
@@ -445,7 +447,7 @@ impl App {
     }
 
     /// Get interface rates (bytes/sec)
-    pub fn get_interface_rates(&self) -> HashMap<String, InterfaceRates> {
+    pub(crate) fn get_interface_rates(&self) -> HashMap<String, InterfaceRates> {
         self.interface_rates
             .iter()
             .map(|entry| (entry.key().clone(), entry.value().clone()))
@@ -453,7 +455,7 @@ impl App {
     }
 
     /// Get traffic transferred over each interface's rolling 60-second window.
-    pub fn get_interface_traffic_windows(&self) -> HashMap<String, InterfaceTrafficWindow> {
+    pub(crate) fn get_interface_traffic_windows(&self) -> HashMap<String, InterfaceTrafficWindow> {
         self.interface_traffic_windows
             .iter()
             .map(|entry| (entry.key().clone(), entry.value().clone()))
@@ -461,7 +463,7 @@ impl App {
     }
 
     /// Get the latest retained process traffic snapshot.
-    pub fn get_process_activity_snapshot(&self) -> ProcessActivitySnapshot {
+    pub(crate) fn get_process_activity_snapshot(&self) -> ProcessActivitySnapshot {
         self.process_activity
             .read()
             .map(|activity| activity.snapshot())
@@ -472,7 +474,7 @@ impl App {
     /// RX/TX rate history for one connection (by `Connection::key()`),
     /// as (rx, tx) bytes/sec vectors oldest→newest. None until the
     /// traffic-history thread has sampled the connection at least once.
-    pub fn get_connection_rate_history(&self, key: &str) -> Option<ConnRateHistorySnapshot> {
+    pub(crate) fn get_connection_rate_history(&self, key: &str) -> Option<ConnRateHistorySnapshot> {
         self.conn_rate_history
             .read()
             .ok()?
@@ -485,7 +487,7 @@ impl App {
             })
     }
 
-    pub fn get_traffic_history(&self) -> TrafficHistory {
+    pub(crate) fn get_traffic_history(&self) -> TrafficHistory {
         self.traffic_history
             .read()
             .map(|h| h.clone())
@@ -547,12 +549,12 @@ impl App {
     }
 
     /// Whether annotated PCAPNG export is active for this run.
-    pub fn is_pcapng_export_enabled(&self) -> bool {
+    pub(crate) fn is_pcapng_export_enabled(&self) -> bool {
         self.config.pcapng_export_file.is_some()
     }
 
     /// Whether classic PCAP export is active for this run.
-    pub fn is_pcap_export_enabled(&self) -> bool {
+    pub(crate) fn is_pcap_export_enabled(&self) -> bool {
         self.config.pcap_export_file.is_some()
     }
 
@@ -562,12 +564,12 @@ impl App {
     }
 
     /// Get the current network interface name
-    pub fn get_current_interface(&self) -> Option<String> {
+    pub(crate) fn get_current_interface(&self) -> Option<String> {
         self.current_interface.read().unwrap().clone()
     }
 
     /// Get the persistent packet-capture failure shown by the TUI.
-    pub fn get_capture_error(&self) -> Option<String> {
+    pub(crate) fn get_capture_error(&self) -> Option<String> {
         self.capture_status
             .read()
             .ok()
@@ -578,15 +580,16 @@ impl App {
     }
 
     /// Get the current process detection status (method and degradation info)
-    pub fn get_process_detection_status(&self) -> ProcessDetectionStatus {
+    pub(crate) fn get_process_detection_status(&self) -> ProcessDetectionStatus {
         self.process_detection_status
             .read()
             .map(|s| s.clone())
             .unwrap_or_default()
     }
 
-    /// Get sandbox status information
-    pub fn get_sandbox_info(&self) -> SandboxReport {
+    /// Get sandbox status information. Only the Linux UI renders it.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn get_sandbox_info(&self) -> SandboxReport {
         self.sandbox_info
             .read()
             .map(|s| s.clone())
@@ -602,7 +605,7 @@ impl App {
 
     /// Get link layer information for the current interface
     /// Returns (link_layer_type_name, is_tunnel)
-    pub fn get_link_layer_info(&self) -> (String, bool) {
+    pub(crate) fn get_link_layer_info(&self) -> (String, bool) {
         use crate::network::link_layer::LinkLayerType;
 
         if let Ok(linktype_opt) = self.linktype.read()
@@ -625,18 +628,18 @@ impl App {
     }
 
     /// Get the DNS resolver if enabled
-    pub fn get_dns_resolver(&self) -> Option<Arc<DnsResolver>> {
+    pub(crate) fn get_dns_resolver(&self) -> Option<Arc<DnsResolver>> {
         self.dns_resolver.clone()
     }
 
     /// Check if DNS resolution is enabled
-    pub fn is_dns_resolution_enabled(&self) -> bool {
+    pub(crate) fn is_dns_resolution_enabled(&self) -> bool {
         self.dns_resolver.is_some()
     }
 
     /// The ARP/NDP-learned MAC/vendor mapping for `ip`, if one has been
     /// observed.
-    pub fn lookup_neighbor(&self, ip: std::net::IpAddr) -> Option<NeighborEntry> {
+    pub(crate) fn lookup_neighbor(&self, ip: std::net::IpAddr) -> Option<NeighborEntry> {
         self.tracker.neighbor(&ip)
     }
 
@@ -651,13 +654,13 @@ impl App {
     }
 
     /// Toggle the show_historic flag
-    pub fn toggle_show_historic(&self) {
+    pub(crate) fn toggle_show_historic(&self) {
         let prev = self.show_historic.load(Ordering::Relaxed);
         self.show_historic.store(!prev, Ordering::Relaxed);
     }
 
     /// Set the show_historic flag directly
-    pub fn set_show_historic(&self, value: bool) {
+    pub(crate) fn set_show_historic(&self, value: bool) {
         self.show_historic.store(value, Ordering::Relaxed);
     }
 
@@ -677,7 +680,7 @@ impl App {
     /// Seed the tracker's neighbor cache through a real ARP ingest. Tests only.
     #[cfg(test)]
     pub(crate) fn ingest_packet_for_test(&self, parsed: &ParsedPacket) {
-        self.tracker.ingest(parsed);
+        self.tracker.ingest_at(parsed, SystemTime::now());
     }
 
     /// Override the current interface label. Tests only.
@@ -731,10 +734,19 @@ impl App {
         connections: &[Connection],
         now: SystemTime,
     ) {
-        self.process_activity
-            .write()
-            .unwrap()
-            .observe_connections(connections, now);
+        self.process_activity.write().unwrap().observe_sources(
+            now,
+            |observe| {
+                for connection in connections.iter().filter(|conn| !conn.is_historic) {
+                    observe(connection);
+                }
+            },
+            |observe| {
+                for connection in connections.iter().filter(|conn| conn.is_historic) {
+                    observe(connection);
+                }
+            },
+        );
     }
 
     /// Clear all connections and related data, starting fresh
@@ -744,7 +756,7 @@ impl App {
     /// - RTT measurements
     /// - QUIC connection mappings
     /// - Resets statistics counters
-    pub fn clear_all_connections(&self) {
+    pub(crate) fn clear_all_connections(&self) {
         info!("Clearing all connections and resetting statistics");
 
         // Clear the tracker (active + historic tables, RTT, and QUIC mappings)

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -10,7 +10,7 @@ use regex_lite::Regex;
 
 /// How to match a text field (case-insensitive for literals; regex handles its own flags)
 #[derive(Debug, Clone)]
-pub enum FilterValue {
+enum FilterValue {
     /// Case-insensitive substring match (existing default)
     Literal(String),
     /// Pre-compiled regex (compiled with (?i) prefix for case-insensitive matching)
@@ -19,7 +19,7 @@ pub enum FilterValue {
 
 /// How to match a port number
 #[derive(Debug, Clone)]
-pub enum PortMatch {
+enum PortMatch {
     /// Exact equality — default when the filter value is all digits
     Exact(u16),
     /// Substring match — fallback for non-numeric, non-regex values
@@ -29,7 +29,7 @@ pub enum PortMatch {
 }
 
 #[derive(Debug, Clone)]
-pub enum FilterCriteria {
+enum FilterCriteria {
     /// Match any field containing this text
     General(FilterValue),
     /// Match port number (local or remote)
@@ -66,7 +66,7 @@ pub enum FilterCriteria {
 }
 
 pub struct ConnectionFilter {
-    pub criteria: Vec<FilterCriteria>,
+    criteria: Vec<FilterCriteria>,
 }
 
 /// Parse a filter value string into a `PortMatch`.
@@ -538,6 +538,23 @@ impl ConnectionFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::network::types::{Protocol, TcpState};
+
+    /// Connection fixture: TCP flows come up `Established`, UDP flows in the
+    /// plain `Udp` state. Tests needing another state override
+    /// `protocol_state` after construction.
+    fn conn(protocol: Protocol, local: &str, remote: &str) -> Connection {
+        let state = match protocol {
+            Protocol::Udp => ProtocolState::Udp,
+            _ => ProtocolState::Tcp(TcpState::Established),
+        };
+        Connection::new(
+            protocol,
+            local.parse().unwrap(),
+            remote.parse().unwrap(),
+            state,
+        )
+    }
 
     #[test]
     fn test_parse_general_filter() {
@@ -609,28 +626,10 @@ mod tests {
 
     #[test]
     fn test_port_exact_no_partial_match() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
         // port:22 should NOT match port 2223 or 5522
-        let conn_2223 = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 2223),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-            ProtocolState::Tcp(TcpState::Established),
-        );
-        let conn_5522 = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 5522),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-            ProtocolState::Tcp(TcpState::Established),
-        );
-        let conn_22 = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 22),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let conn_2223 = conn(Protocol::Tcp, "127.0.0.1:2223", "10.0.0.1:80");
+        let conn_5522 = conn(Protocol::Tcp, "127.0.0.1:5522", "10.0.0.1:80");
+        let conn_22 = conn(Protocol::Tcp, "127.0.0.1:22", "10.0.0.1:80");
 
         let filter = ConnectionFilter::parse("port:22");
         assert!(
@@ -646,16 +645,12 @@ mod tests {
 
     #[test]
     fn test_port_regex_partial_match() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
         // port:/22/ should match 22, 220, 2200, 5522
         let make_conn = |local_port: u16| {
-            Connection::new(
+            conn(
                 Protocol::Tcp,
-                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), local_port),
-                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-                ProtocolState::Tcp(TcpState::Established),
+                &format!("127.0.0.1:{local_port}"),
+                "10.0.0.1:80",
             )
         };
 
@@ -669,15 +664,7 @@ mod tests {
 
     #[test]
     fn test_state_filter_tcp_states() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12345),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = conn(Protocol::Tcp, "127.0.0.1:12345", "10.0.0.1:80");
 
         let established_filter = ConnectionFilter::parse("state:established");
         assert!(established_filter.matches(&conn));
@@ -698,15 +685,7 @@ mod tests {
 
     #[test]
     fn test_state_filter_udp_states() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        let conn = Connection::new(
-            Protocol::Udp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12345),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
-            ProtocolState::Udp,
-        );
+        let conn = conn(Protocol::Udp, "127.0.0.1:12345", "8.8.8.8:53");
 
         let active_filter = ConnectionFilter::parse("state:udp_active");
         assert!(active_filter.matches(&conn));
@@ -717,15 +696,8 @@ mod tests {
 
     #[test]
     fn test_combined_state_and_port_filter() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        let conn = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 443),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 54321),
-            ProtocolState::Tcp(TcpState::SynReceived),
-        );
+        let mut conn = conn(Protocol::Tcp, "0.0.0.0:443", "192.168.1.100:54321");
+        conn.protocol_state = ProtocolState::Tcp(TcpState::SynReceived);
 
         let combined_filter = ConnectionFilter::parse("sport:443 state:syn_recv");
         assert!(combined_filter.matches(&conn));
@@ -739,15 +711,7 @@ mod tests {
 
     #[test]
     fn test_state_filter_case_insensitive() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        let conn = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12345),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let conn = conn(Protocol::Tcp, "127.0.0.1:12345", "10.0.0.1:80");
 
         let filters = vec![
             "state:established",
@@ -768,42 +732,23 @@ mod tests {
 
     #[test]
     fn test_regex_general_search() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        let conn = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 12345),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 443),
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let conn_private = conn(Protocol::Tcp, "192.168.1.100:12345", "10.0.0.1:443");
 
         // Regex matching IP pattern
         let filter = ConnectionFilter::parse("/192\\.168\\.[0-9]+/");
-        assert!(filter.matches(&conn));
+        assert!(filter.matches(&conn_private));
 
         // Should not match unrelated connection
-        let conn2 = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 12345),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let conn2 = conn(Protocol::Tcp, "10.0.0.1:12345", "8.8.8.8:53");
         assert!(!filter.matches(&conn2));
     }
 
     #[test]
     fn test_attributed_hostname_matches_hostname_and_general_filters() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+        use crate::network::types::{AttributedHostname, AttributionSource};
         use std::time::SystemTime;
 
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 12345),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(142, 250, 1, 1)), 443),
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        let mut conn = conn(Protocol::Tcp, "192.168.1.100:12345", "142.250.1.1:443");
         conn.attributed_hostname = Some(AttributedHostname {
             name: "youtube.com".to_string(),
             source: AttributionSource::CapturedDns,
@@ -831,15 +776,11 @@ mod tests {
     #[cfg(feature = "kubernetes")]
     #[test]
     fn test_kubernetes_filter_keywords() {
-        use crate::network::types::*;
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+        use crate::network::types::K8sInfo;
 
-        let mut conn = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12345),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-            ProtocolState::Tcp(TcpState::Established),
-        );
+        // Built up front: `conn` below shadows the fixture fn.
+        let bare = conn(Protocol::Tcp, "127.0.0.1:12345", "10.0.0.1:80");
+        let mut conn = conn(Protocol::Tcp, "127.0.0.1:12345", "10.0.0.1:80");
         conn.k8s_info = Some(K8sInfo {
             pod_uid: Some("c3b4d893-473e-43c2-8013-8ee2955a4630".to_string()),
             pod_name: Some("nginx-86644db9cc-mf5lx".to_string()),
@@ -870,12 +811,6 @@ mod tests {
         assert!(ConnectionFilter::parse("ns:demo-traffic pod:nginx").matches(&conn));
 
         // Filter on connections without K8s info returns no match for any pod filter.
-        let bare = Connection::new(
-            Protocol::Tcp,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12345),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 80),
-            ProtocolState::Tcp(TcpState::Established),
-        );
         assert!(!ConnectionFilter::parse("pod:nginx").matches(&bare));
         assert!(!ConnectionFilter::parse("ns:demo").matches(&bare));
         assert!(!ConnectionFilter::parse("container:nginx").matches(&bare));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! - [`app`] — application orchestration, packet pipeline, and shared
 //!   state.
-//! - [`filter`] — vim/fzf-style connection filter parser and matcher.
+//! - `filter` — vim/fzf-style connection filter parser and matcher.
 //! - [`network`] — packet capture, parsers, DPI, DNS, GeoIP, interface
 //!   stats, and platform-specific process lookup.
 //! - [`ui`] — ratatui rendering, tabs, tables, and keyboard handling.
@@ -57,8 +57,8 @@
 
 pub mod app;
 pub mod cli;
-pub mod export;
-pub mod filter;
+pub(crate) mod export;
+pub(crate) mod filter;
 pub mod network;
 pub mod ui;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,20 +274,23 @@ fn main() -> Result<()> {
         #[cfg(target_os = "linux")]
         let read_paths: Vec<PathBuf> = {
             use network::geoip::GeoIpResolver;
-            #[allow(unused_mut)]
-            let mut paths: Vec<PathBuf> = GeoIpResolver::get_search_paths()
+            let paths: Vec<PathBuf> = GeoIpResolver::get_search_paths()
                 .into_iter()
                 .filter(|p| p.exists() && p.as_os_str() != ".")
                 .collect();
             #[cfg(feature = "kubernetes")]
-            if config.kubernetes_mode.enabled() {
-                for dir in ["/var/log/containers", "/var/log/pods"] {
-                    let pb = PathBuf::from(dir);
-                    if pb.exists() {
-                        paths.push(pb);
+            let paths = {
+                let mut paths = paths;
+                if config.kubernetes_mode.enabled() {
+                    for dir in ["/var/log/containers", "/var/log/pods"] {
+                        let pb = PathBuf::from(dir);
+                        if pb.exists() {
+                            paths.push(pb);
+                        }
                     }
                 }
-            }
+                paths
+            };
             paths
         };
 
@@ -338,8 +341,7 @@ fn main() -> Result<()> {
             write_paths.push(PathBuf::from(pcapng_path));
         }
 
-        #[allow(unused_mut)]
-        let mut sandbox_config = SandboxConfig {
+        let sandbox_config = SandboxConfig {
             mode: sandbox_mode,
             block_network: true, // RustNet is passive, doesn't need TCP
             read_paths,
@@ -347,9 +349,10 @@ fn main() -> Result<()> {
             ..SandboxConfig::default()
         };
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
-        {
-            sandbox_config.drop_uid = uid_drop_target;
-        }
+        let sandbox_config = SandboxConfig {
+            drop_uid: uid_drop_target,
+            ..sandbox_config
+        };
 
         match apply_sandbox(&sandbox_config) {
             Ok(report) => app.set_sandbox_info(report),

--- a/src/network/kubernetes.rs
+++ b/src/network/kubernetes.rs
@@ -34,7 +34,7 @@ pub struct CgroupInfo {
 /// kubepods-related info if any line refers to a Kubernetes pod. Returns
 /// `None` for processes that aren't part of a pod cgroup.
 #[cfg(any(test, target_os = "linux"))]
-pub fn parse_cgroup(contents: &str) -> Option<CgroupInfo> {
+pub(crate) fn parse_cgroup(contents: &str) -> Option<CgroupInfo> {
     let path = contents
         .lines()
         .map(extract_path)
@@ -98,7 +98,7 @@ impl KubernetesMode {
 /// (the same signal client-go uses for in-cluster detection). This is reliable
 /// regardless of cgroup namespacing, unlike inspecting `/proc/self/cgroup`,
 /// which a namespaced pod sees as just `/`.
-pub fn running_in_pod() -> bool {
+pub(crate) fn running_in_pod() -> bool {
     std::env::var_os("KUBERNETES_SERVICE_HOST").is_some()
 }
 
@@ -334,7 +334,7 @@ fn parse_pod_dir_name(name: &str) -> Option<(String, PodMeta)> {
 /// IP protocol distinction for the socket table key. We track TCP and UDP
 /// separately because the same 4-tuple can be reused across protocols.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum SocketProtocol {
+pub(crate) enum SocketProtocol {
     Tcp,
     Udp,
 }
@@ -342,7 +342,7 @@ pub enum SocketProtocol {
 /// Lookup key matching what `network::types::ConnectionKey` would produce:
 /// the connection's 4-tuple plus its transport protocol.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct SocketKey {
+pub(crate) struct SocketKey {
     pub protocol: SocketProtocol,
     pub local: std::net::SocketAddr,
     pub remote: std::net::SocketAddr,
@@ -401,7 +401,7 @@ impl KubernetesSocketTable {
 
     /// Look up a (pid, K8sInfo) for the given socket 4-tuple. Returns `None`
     /// when the tuple isn't owned by any kubepods PID.
-    pub fn lookup(&self, key: &SocketKey) -> Option<&(u32, crate::network::types::K8sInfo)> {
+    fn lookup(&self, key: &SocketKey) -> Option<&(u32, crate::network::types::K8sInfo)> {
         self.by_key.get(key)
     }
 
@@ -494,7 +494,11 @@ fn discover_kubepods_pids() -> Vec<u32> {
 /// little-endian boxes the byte order is reversed). IPv6 is 32 hex chars
 /// representing four u32s, each printed in host byte order.
 #[cfg(any(test, target_os = "linux"))]
-pub fn parse_proc_net_line(line: &str, protocol: SocketProtocol, is_v6: bool) -> Option<SocketKey> {
+pub(crate) fn parse_proc_net_line(
+    line: &str,
+    protocol: SocketProtocol,
+    is_v6: bool,
+) -> Option<SocketKey> {
     let mut fields = line.split_whitespace();
     // Skip the "sl" column.
     fields.next()?;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,9 +1,8 @@
 //! Networking layer for the `rustnet` binary.
 //!
-//! The analysis core, including parsers, DPI, protocol/connection types,
-//! connection merging, GeoIP/DNS/OUI lookups, and interface-stats providers,
-//! lives in the [`rustnet_core`] library crate and is re-exported here so
-//! existing `crate::network::*` paths keep resolving unchanged.
+//! The analysis core lives in the [`rustnet_core`] library crate. Modules used
+//! by the binary are re-exported here to keep its `crate::network::*` paths
+//! concise.
 //!
 //! The host-tied binary modules are the `rustnet-host` process-lookup wiring
 //! ([`platform`]) and the [`privileges`] preflight check. libpcap-based packet
@@ -19,14 +18,8 @@ pub mod privileges;
 // the historical path so the app, tests, and platform code are unchanged.
 pub use rustnet_capture as capture;
 
-// Re-export the analysis core. Keeps `crate::network::types`, `::parser`,
-// `::dpi`, `::link_layer`, etc. working for the rest of the binary, the
-// integration tests, and the benches without touching their imports.
-// `allow(unused_imports)`: the `rustnet` bin doesn't touch every module
-// directly, but the `rustnet_monitor` lib re-exports the full facade for
-// tests, benches, and external consumers.
-#[allow(unused_imports)]
+// Re-export the analysis modules used by the binary and its tests.
 pub use rustnet_core::network::{
-    bogon, dns, dpi, geoip, interface_stats, link_layer, merge, neighbors, oui, parser,
-    process_activity, protocol, services, tracker, types, util,
+    bogon, dns, geoip, interface_stats, link_layer, neighbors, oui, parser, process_activity,
+    services, tracker, types, util,
 };

--- a/src/network/privileges.rs
+++ b/src/network/privileges.rs
@@ -199,22 +199,21 @@ fn is_running_in_container() -> bool {
     false
 }
 
-#[cfg(target_os = "macos")]
-fn check_macos_privileges() -> Result<PrivilegeStatus> {
+/// Shared macOS/FreeBSD check: root always suffices; otherwise packet capture
+/// requires access to BPF devices, so probe `/dev/bpf0..9` for open access.
+/// The platform-specific remediation instructions come from the caller.
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+fn check_bpf_privileges(instructions: Vec<String>) -> Result<PrivilegeStatus> {
     use std::fs;
 
     // Check if running as root by reading effective UID from process
-    let is_root = is_root_user();
-
-    if is_root {
+    if is_root_user() {
         info!("Running as root - all privileges available");
         return Ok(PrivilegeStatus::sufficient());
     }
 
     debug!("Not running as root, checking BPF device permissions");
 
-    // On macOS, packet capture requires access to BPF devices
-    // Try to open a BPF device to check permissions
     let bpf_devices = (0..10)
         .map(|i| format!("/dev/bpf{}", i))
         .collect::<Vec<_>>();
@@ -245,6 +244,11 @@ fn check_macos_privileges() -> Result<PrivilegeStatus> {
     // No BPF access - build error message
     let missing = vec!["Access to BPF devices (/dev/bpf*)".to_string()];
 
+    Ok(PrivilegeStatus::insufficient(missing, instructions))
+}
+
+#[cfg(target_os = "macos")]
+fn check_macos_privileges() -> Result<PrivilegeStatus> {
     let instructions = vec![
         "Run with sudo: sudo rustnet".to_string(),
         "Change BPF device permissions (temporary):\n  \
@@ -255,7 +259,7 @@ fn check_macos_privileges() -> Result<PrivilegeStatus> {
             .to_string(),
     ];
 
-    Ok(PrivilegeStatus::insufficient(missing, instructions))
+    check_bpf_privileges(instructions)
 }
 
 #[cfg(target_os = "windows")]
@@ -304,50 +308,6 @@ fn check_windows_privileges() -> Result<PrivilegeStatus> {
 
 #[cfg(target_os = "freebsd")]
 fn check_freebsd_privileges() -> Result<PrivilegeStatus> {
-    use std::fs;
-
-    // Check if running as root by reading effective UID from process
-    let is_root = is_root_user();
-
-    if is_root {
-        info!("Running as root - all privileges available");
-        return Ok(PrivilegeStatus::sufficient());
-    }
-
-    debug!("Not running as root, checking BPF device permissions");
-
-    // On FreeBSD, packet capture requires access to BPF devices
-    // Try to open a BPF device to check permissions
-    let bpf_devices = (0..10)
-        .map(|i| format!("/dev/bpf{}", i))
-        .collect::<Vec<_>>();
-
-    let mut can_access_bpf = false;
-    for bpf_device in &bpf_devices {
-        if fs::metadata(bpf_device).is_ok() {
-            debug!("Checking BPF device: {}", bpf_device);
-
-            // Try to actually open it (this is the real test)
-            if std::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(bpf_device)
-                .is_ok()
-            {
-                can_access_bpf = true;
-                debug!("Successfully opened BPF device: {}", bpf_device);
-                break;
-            }
-        }
-    }
-
-    if can_access_bpf {
-        return Ok(PrivilegeStatus::sufficient());
-    }
-
-    // No BPF access - build error message
-    let missing = vec!["Access to BPF devices (/dev/bpf*)".to_string()];
-
     let instructions = vec![
         "Run with sudo: sudo rustnet".to_string(),
         "Add your user to the bpf group:\n  \
@@ -359,7 +319,7 @@ fn check_freebsd_privileges() -> Result<PrivilegeStatus> {
             .to_string(),
     ];
 
-    Ok(PrivilegeStatus::insufficient(missing, instructions))
+    check_bpf_privileges(instructions)
 }
 
 /// Check if running as root user on Unix systems

--- a/src/ui/connection_table.rs
+++ b/src/ui/connection_table.rs
@@ -953,7 +953,6 @@ mod tests {
                     ..TlsInfo::new()
                 }),
             }),
-            last_update_time: std::time::Instant::now(),
         });
         assert_eq!(
             remote_display(&conn, &ui_state, None, 24),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -92,9 +92,10 @@ pub fn set_no_color(enabled: bool) {
 }
 
 mod state;
+pub(crate) use state::process_group_label;
 pub use state::{
     ActivityDirection, ActivitySort, ClickAction, ClickableRegions, GroupedRow, PaneScroll,
-    SortColumn, UIState, compute_grouped_rows, compute_scroll_offset, process_group_label,
+    SortColumn, UIState, compute_grouped_rows, compute_scroll_offset,
 };
 pub(crate) use widgets::tabs_bar::{HELP_TAB_INDEX, TAB_COUNT};
 
@@ -107,9 +108,9 @@ mod clipboard;
 pub use clipboard::copy_to_clipboard;
 
 mod actions;
-pub use actions::{
-    clear_all_with_confirmation, try_handle_connection_nav, try_handle_pane_scroll,
-    try_handle_pane_wheel,
+pub use actions::clear_all_with_confirmation;
+pub(crate) use actions::{
+    try_handle_connection_nav, try_handle_pane_scroll, try_handle_pane_wheel,
 };
 
 mod component;
@@ -875,6 +876,46 @@ mod snapshot_tests {
         app
     }
 
+    /// Full-page render of `app` through `draw`, owning the stats /
+    /// click-regions boilerplate every such test repeats. Returns the text
+    /// dump plus the click regions the frame registered.
+    fn render_app_frame(
+        app: &App,
+        ui_state: &UIState,
+        connections: &[Connection],
+        grouped: Option<&[GroupedRow]>,
+        width: u16,
+        height: u16,
+    ) -> (String, ClickableRegions) {
+        let stats = app.get_stats();
+        let mut click_regions = ClickableRegions::default();
+        let output = render(width, height, |f| {
+            draw(
+                f,
+                app,
+                ui_state,
+                connections,
+                grouped,
+                &stats,
+                &mut click_regions,
+            )
+            .expect("draw full page");
+        });
+        (output, click_regions)
+    }
+
+    /// [`render_app_frame`] for the tests that only need the text dump.
+    fn render_app(
+        app: &App,
+        ui_state: &UIState,
+        connections: &[Connection],
+        grouped: Option<&[GroupedRow]>,
+        width: u16,
+        height: u16,
+    ) -> String {
+        render_app_frame(app, ui_state, connections, grouped, width, height).0
+    }
+
     #[test]
     fn full_page_shows_capture_error() {
         let app = test_app();
@@ -883,13 +924,7 @@ mod snapshot_tests {
             show_system_panel: false,
             ..Default::default()
         };
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        let output = render(100, 16, |f| {
-            draw(f, &app, &ui_state, &[], None, &stats, &mut click_regions)
-                .expect("draw Overview with capture error");
-        });
+        let output = render_app(&app, &ui_state, &[], None, 100, 16);
 
         assert!(
             output
@@ -910,13 +945,7 @@ mod snapshot_tests {
             show_system_panel: false,
             ..Default::default()
         };
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        let output = render(80, 16, |f| {
-            draw(f, &app, &ui_state, &[], None, &stats, &mut click_regions)
-                .expect("draw Overview with a long capture error");
-        });
+        let output = render_app(&app, &ui_state, &[], None, 80, 16);
 
         let rows: Vec<&str> = output.lines().collect();
         let hint_row = rows
@@ -1063,21 +1092,14 @@ mod snapshot_tests {
         };
         let grouped_rows =
             grouped.then(|| compute_grouped_rows(&connections, &ui_state.expanded_groups));
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        render(140, 26, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                grouped_rows.as_deref(),
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw overview");
-        })
+        render_app(
+            &app,
+            &ui_state,
+            &connections,
+            grouped_rows.as_deref(),
+            140,
+            26,
+        )
     }
 
     #[test]
@@ -1097,21 +1119,7 @@ mod snapshot_tests {
         connections[3].process_name = Some("firefox".to_string());
         app.set_connections_snapshot_for_test(connections.clone());
         let ui_state = UIState::default();
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw overview statistics");
-        });
+        let output = render_app(&app, &ui_state, &connections, None, 140, 40);
 
         assert!(output.contains("Processes: 3"));
     }
@@ -1126,21 +1134,7 @@ mod snapshot_tests {
             filter_query: "process:firefox".to_string(),
             ..Default::default()
         };
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &filtered,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw filtered overview statistics");
-        });
+        let output = render_app(&app, &ui_state, &filtered, None, 140, 40);
 
         assert!(output.contains("Live Connections · 1 shown"));
         assert!(output.contains("Processes: 4"));
@@ -1152,19 +1146,15 @@ mod snapshot_tests {
     /// MAC + vendor. The fixture's remote (140.82.121.4) is public and never
     /// ARPs, so its "Remote MAC" row renders the placeholder.
     fn gateway_arp_reply() -> crate::network::parser::ParsedPacket {
-        use crate::network::types::{AddrKind, ArpInfo, ArpOperation};
+        use crate::network::types::{ArpInfo, ArpOperation};
 
         let gateway = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
         let host = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10));
-        crate::network::parser::ParsedPacket {
-            protocol: Protocol::Arp,
-            local_addr: SocketAddr::new(host, 0),
-            remote_addr: SocketAddr::new(gateway, 0),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            tcp_header: None,
-            protocol_state: ProtocolState::Arp(ArpInfo {
+        crate::network::parser::ParsedPacket::new(
+            Protocol::Arp,
+            SocketAddr::new(host, 0),
+            SocketAddr::new(gateway, 0),
+            ProtocolState::Arp(ArpInfo {
                 operation: ArpOperation::Reply,
                 sender_mac: "04:d9:f5:c5:ed:e8".to_string(),
                 sender_ip: gateway,
@@ -1173,31 +1163,26 @@ mod snapshot_tests {
                 sender_vendor: Some("ASUSTek COMPUTER INC.".to_string()),
                 target_vendor: Some("Apple, Inc.".to_string()),
             }),
-            is_outgoing: false,
-            packet_len: 42,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
-        }
+            false,
+            42,
+            None,
+            None,
+        )
     }
 
     /// An ARP reply from the sshd fixture's on-link peer (10.0.0.5). Seeds
     /// the neighbor cache so a Details render of that connection resolves
     /// its "Remote MAC" row to an actual address.
     fn sshd_peer_arp_reply() -> crate::network::parser::ParsedPacket {
-        use crate::network::types::{AddrKind, ArpInfo, ArpOperation};
+        use crate::network::types::{ArpInfo, ArpOperation};
 
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
         let host = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10));
-        crate::network::parser::ParsedPacket {
-            protocol: Protocol::Arp,
-            local_addr: SocketAddr::new(host, 0),
-            remote_addr: SocketAddr::new(peer, 0),
-            local_addr_kind: AddrKind::Unicast,
-            remote_addr_kind: AddrKind::Unicast,
-            remote_is_gateway: false,
-            tcp_header: None,
-            protocol_state: ProtocolState::Arp(ArpInfo {
+        crate::network::parser::ParsedPacket::new(
+            Protocol::Arp,
+            SocketAddr::new(host, 0),
+            SocketAddr::new(peer, 0),
+            ProtocolState::Arp(ArpInfo {
                 operation: ArpOperation::Reply,
                 sender_mac: "b8:27:eb:12:34:56".to_string(),
                 sender_ip: peer,
@@ -1206,12 +1191,11 @@ mod snapshot_tests {
                 sender_vendor: Some("Raspberry Pi Foundation".to_string()),
                 target_vendor: Some("Apple, Inc.".to_string()),
             }),
-            is_outgoing: false,
-            packet_len: 42,
-            dpi_result: None,
-            process_name: None,
-            process_id: None,
-        }
+            false,
+            42,
+            None,
+            None,
+        )
     }
 
     /// Details render of `connections[selected]` through the full-page
@@ -1229,21 +1213,7 @@ mod snapshot_tests {
             selected_connection_key: Some(connections[selected].key()),
             ..Default::default()
         };
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-        let output = render(140, height, |f| {
-            draw(
-                f,
-                app,
-                &ui_state,
-                connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw details");
-        });
-        (output, click_regions)
+        render_app_frame(app, &ui_state, connections, None, 140, height)
     }
 
     /// Standard Details render at the 140x40 reference size.
@@ -1304,7 +1274,6 @@ mod snapshot_tests {
         quic_conn.initial_rtt = Some(Duration::from_micros(23_400));
         quic_conn.dpi_info = Some(DpiInfo {
             application: ApplicationProtocol::Quic(Box::new(quic)),
-            last_update_time: std::time::Instant::now(),
         });
 
         app.set_connections_snapshot_for_test(connections.clone());
@@ -1366,7 +1335,6 @@ mod snapshot_tests {
                 rcode: Some(0),
                 nodata: Some(false),
             }),
-            last_update_time: std::time::Instant::now(),
         });
 
         app.set_connections_snapshot_for_test(connections.clone());
@@ -1427,7 +1395,6 @@ mod snapshot_tests {
                 response_ips: Vec::new(),
                 txid: 0x1234,
             }),
-            last_update_time: std::time::Instant::now(),
         });
         let connections = vec![llmnr];
 
@@ -1460,7 +1427,6 @@ mod snapshot_tests {
                 is_response: true,
                 response_status: Some(NetBiosResponseStatus::NameService(3)),
             }),
-            last_update_time: std::time::Instant::now(),
         });
 
         app.set_connections_snapshot_for_test(connections.clone());
@@ -1564,7 +1530,6 @@ mod snapshot_tests {
                 transaction_id: [7u8; 12],
                 software: None,
             }),
-            last_update_time: std::time::Instant::now(),
         });
         let connections = vec![stun];
 
@@ -1596,7 +1561,6 @@ mod snapshot_tests {
                 origin_timestamp: 0xAABB,
                 transmit_timestamp: 0xCCDD,
             }),
-            last_update_time: std::time::Instant::now(),
         });
         let connections = vec![ntp];
 
@@ -2062,21 +2026,7 @@ mod snapshot_tests {
             ..Default::default()
         };
         let connections = app.get_connections();
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        let output = render(140, 30, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw Activity interface details");
-        });
+        let output = render_app(&app, &ui_state, &connections, None, 140, 30);
 
         insta::with_settings!({
             filters => time_filters(),
@@ -2122,21 +2072,7 @@ mod snapshot_tests {
             ..Default::default()
         };
         let connections = app.get_connections();
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        render(150, 40, |f| {
-            draw(
-                f,
-                app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw process Activity");
-        })
+        render_app(app, &ui_state, &connections, None, 150, 40)
     }
 
     #[test]
@@ -2162,21 +2098,7 @@ mod snapshot_tests {
             ..Default::default()
         };
         let connections = app.get_connections();
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        let output = render(140, 40, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw graph");
-        });
+        let output = render_app(&app, &ui_state, &connections, None, 140, 40);
 
         insta::with_settings!({
             filters => time_filters(),
@@ -2189,23 +2111,8 @@ mod snapshot_tests {
     fn loading_screen_via_app() {
         let app = App::new(test_config()).expect("App::new");
         // Leave is_loading=true so draw() takes the loading branch.
-        let connections: Vec<Connection> = Vec::new();
         let ui_state = UIState::default();
-        let stats = app.get_stats();
-        let mut click_regions = ClickableRegions::default();
-
-        let output = render(80, 20, |f| {
-            draw(
-                f,
-                &app,
-                &ui_state,
-                &connections,
-                None,
-                &stats,
-                &mut click_regions,
-            )
-            .expect("draw loading");
-        });
+        let output = render_app(&app, &ui_state, &[], None, 80, 20);
 
         insta::assert_snapshot!(output);
     }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -938,7 +938,7 @@ impl UIState {
 
 /// Compute grouped rows from a list of connections
 /// Group label shown for connections without a resolved process name.
-pub const UNKNOWN_PROCESS_GROUP: &str = "<unknown>";
+pub(super) const UNKNOWN_PROCESS_GROUP: &str = "<unknown>";
 
 /// The process-group label for a connection. Attribution can fail two ways:
 /// no owner found at all (`process_name` is `None`), or an owner PID whose

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -1,6 +1,6 @@
 //! Details tab — full record for the selected connection: protocol
 //! header, TCP analytics, traffic stats, and protocol-specific DPI
-//! info. Also owns the push_detail_field / register_detail_clicks
+//! info. Also owns the DetailsBuilder / register_detail_clicks
 //! helpers that build the label/value lines and the click-to-copy
 //! registry.
 
@@ -131,91 +131,107 @@ impl Component for DetailsTab {
     }
 }
 
-fn push_detail_field<'a>(
-    lines: &mut Vec<Line<'a>>,
-    fields: &mut Vec<Option<(String, String)>>,
-    label: &str,
-    value: String,
+/// Builder for one Details pane: the rendered lines and the parallel
+/// click-to-copy field entries, sharing a single label style. The two
+/// vectors stay index-aligned so `register_detail_clicks` can map an
+/// on-screen row back to its copyable value.
+struct DetailsBuilder<'a> {
+    lines: Vec<Line<'a>>,
+    fields: Vec<Option<(String, String)>>,
     label_style: Style,
-) {
-    push_detail_field_styled(lines, fields, label, value, label_style, Style::default());
 }
 
-/// Push a label-value line with a custom-styled value span.
-fn push_detail_field_styled<'a>(
-    lines: &mut Vec<Line<'a>>,
-    fields: &mut Vec<Option<(String, String)>>,
-    label: &str,
-    value: String,
-    label_style: Style,
-    value_style: Style,
-) {
-    push_detail_field_with_copy(
-        lines,
-        fields,
-        label,
-        value.clone(),
-        value,
-        label_style,
-        value_style,
-    );
-}
-
-/// Push a label-value line whose rendered value differs from what
-/// click-to-copy yields (a shortened path, say).
-fn push_detail_field_with_copy<'a>(
-    lines: &mut Vec<Line<'a>>,
-    fields: &mut Vec<Option<(String, String)>>,
-    label: &str,
-    display: String,
-    copy: String,
-    label_style: Style,
-    value_style: Style,
-) {
-    lines.push(Line::from(vec![
-        Span::styled(
-            format!("{:<width$}", label, width = DETAIL_LABEL_WIDTH),
+impl<'a> DetailsBuilder<'a> {
+    fn new(label_style: Style) -> Self {
+        Self {
+            lines: Vec::new(),
+            fields: Vec::new(),
             label_style,
-        ),
-        Span::styled(display, value_style),
-    ]));
-    fields.push(Some((label.to_string(), copy)));
-}
+        }
+    }
 
-/// Push an RTT field with the value colored by latency (green < 50ms,
-/// yellow < 150ms, red above), or the "-" placeholder when unmeasured.
-fn push_rtt_field<'a>(
-    lines: &mut Vec<Line<'a>>,
-    fields: &mut Vec<Option<(String, String)>>,
-    label: &str,
-    rtt: Option<std::time::Duration>,
-    label_style: Style,
-) {
-    if let Some(rtt) = rtt {
-        let rtt_ms = rtt.as_secs_f64() * 1000.0;
-        let rtt_color = if rtt_ms < 50.0 {
-            theme::ok()
-        } else if rtt_ms < 150.0 {
-            theme::warn()
+    /// Number of rows pushed so far; anchors section ranges and padding.
+    fn rows(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// Push a line with no click-to-copy target (custom headings, blank
+    /// separators).
+    fn plain_line(&mut self, line: Line<'a>) {
+        self.lines.push(line);
+        self.fields.push(None);
+    }
+
+    fn field(&mut self, label: &str, value: String) {
+        self.field_styled(label, value, Style::default());
+    }
+
+    /// Push a label-value line with a custom-styled value span.
+    fn field_styled(&mut self, label: &str, value: String, value_style: Style) {
+        self.field_with_copy(label, value.clone(), value, value_style);
+    }
+
+    /// Push a label-value line whose rendered value differs from what
+    /// click-to-copy yields (a shortened path, say).
+    fn field_with_copy(&mut self, label: &str, display: String, copy: String, value_style: Style) {
+        self.lines.push(Line::from(vec![
+            Span::styled(
+                format!("{:<width$}", label, width = DETAIL_LABEL_WIDTH),
+                self.label_style,
+            ),
+            Span::styled(display, value_style),
+        ]));
+        self.fields.push(Some((label.to_string(), copy)));
+    }
+
+    /// Push an RTT field with the value colored by latency (green < 50ms,
+    /// yellow < 150ms, red above), or the "-" placeholder when unmeasured.
+    fn rtt_field(&mut self, label: &str, rtt: Option<std::time::Duration>) {
+        if let Some(rtt) = rtt {
+            let rtt_ms = rtt.as_secs_f64() * 1000.0;
+            let rtt_color = if rtt_ms < 50.0 {
+                theme::ok()
+            } else if rtt_ms < 150.0 {
+                theme::warn()
+            } else {
+                theme::err()
+            };
+            self.field_styled(label, format!("{:.1}ms", rtt_ms), theme::fg(rtt_color));
         } else {
-            theme::err()
-        };
-        push_detail_field_styled(
-            lines,
-            fields,
-            label,
-            format!("{:.1}ms", rtt_ms),
-            label_style,
-            theme::fg(rtt_color),
-        );
-    } else {
-        push_detail_field(
-            lines,
-            fields,
-            label,
-            NONE_PLACEHOLDER.to_string(),
-            label_style,
-        );
+            self.field(label, NONE_PLACEHOLDER.to_string());
+        }
+    }
+
+    /// Push a muted explanatory line into a card. Unlike a field row this
+    /// carries no label/value pair, so it registers no click-to-copy target.
+    fn note(&mut self, note: &'a str) {
+        self.plain_line(Line::from(Span::styled(note, theme::fg(theme::muted()))));
+    }
+
+    /// Push a bold section heading, used to group fields under a common label
+    /// (e.g. "Geolocation", "Application: HTTPS"). Headings carry no
+    /// click-to-copy target.
+    fn section(&mut self, title: impl Into<String>) {
+        self.section_styled(title, theme::bold_fg(theme::heading()));
+    }
+
+    /// Variant of [`Self::section`] that lets the caller pick the heading
+    /// style. Used by the Application section so its title takes the
+    /// protocol's own color (HTTPS green, QUIC cyan, etc.) and visually links
+    /// to the matching Application cell in the Overview table.
+    fn section_styled(&mut self, title: impl Into<String>, style: Style) {
+        self.plain_line(Line::from(""));
+        self.plain_line(Line::from(Span::styled(title.into(), style)));
+    }
+
+    /// Pad a detail section to a stable height. Padding rows deliberately
+    /// have no click target and render as whitespace in the borderless card
+    /// layout.
+    fn pad_section(&mut self, section_start: usize, target_rows: usize) {
+        let missing = target_rows.saturating_sub(self.rows().saturating_sub(section_start));
+        for _ in 0..missing {
+            self.plain_line(Line::from(""));
+        }
     }
 }
 
@@ -542,32 +558,6 @@ fn remote_scope(conn: &Connection) -> crate::network::bogon::Scope {
     }
 }
 
-/// Push a muted explanatory line into a card. Unlike a field row this carries
-/// no label/value pair, so it registers no click-to-copy target.
-fn push_detail_note<'a>(
-    lines: &mut Vec<Line<'a>>,
-    fields: &mut Vec<Option<(String, String)>>,
-    note: &'a str,
-) {
-    lines.push(Line::from(Span::styled(note, theme::fg(theme::muted()))));
-    fields.push(None);
-}
-
-/// Pad a detail section to a stable height. Padding rows deliberately have no
-/// click target and render as whitespace in the borderless card layout.
-fn pad_detail_section<'a>(
-    lines: &mut Vec<Line<'a>>,
-    fields: &mut Vec<Option<(String, String)>>,
-    section_start: usize,
-    target_rows: usize,
-) {
-    let missing = target_rows.saturating_sub(lines.len().saturating_sub(section_start));
-    for _ in 0..missing {
-        lines.push(Line::from(""));
-        fields.push(None);
-    }
-}
-
 /// True when a line is empty (used to trim leading separator on the right pane).
 fn line_is_blank(line: &Line<'_>) -> bool {
     line.spans.iter().all(|s| s.content.is_empty())
@@ -610,33 +600,6 @@ fn register_detail_clicks(
             );
         }
     }
-}
-
-/// Push a bold section heading, used to group fields under a common label
-/// (e.g. "Geolocation", "Application: HTTPS"). Pushes a `None` field entry
-/// so click-to-copy hit-testing skips this row.
-fn push_detail_section<'a>(
-    lines: &mut Vec<Line<'a>>,
-    fields: &mut Vec<Option<(String, String)>>,
-    title: impl Into<String>,
-) {
-    push_detail_section_styled(lines, fields, title, theme::bold_fg(theme::heading()));
-}
-
-/// Variant of `push_detail_section` that lets the caller pick the heading
-/// style. Used by the Application section so its title takes the protocol's
-/// own color (HTTPS green, QUIC cyan, etc.) and visually links to the
-/// matching Application cell in the Overview table.
-fn push_detail_section_styled<'a>(
-    lines: &mut Vec<Line<'a>>,
-    fields: &mut Vec<Option<(String, String)>>,
-    title: impl Into<String>,
-    style: Style,
-) {
-    lines.push(Line::from(""));
-    fields.push(None);
-    lines.push(Line::from(Span::styled(title.into(), style)));
-    fields.push(None);
 }
 
 /// Height of the continuity strip: column header (1) + header margin (1)
@@ -848,11 +811,10 @@ pub(in crate::ui) fn draw_connection_details(
 
     // Connection details - build lines and field entries in parallel for click-to-copy.
     // All sections share a single label_style (muted gray); visual grouping comes
-    // from the bold section headings inserted by push_detail_section.
+    // from the bold section headings inserted by DetailsBuilder::section.
     let label_style = theme::fg(theme::label());
-    let mut details_text: Vec<Line> = Vec::new();
-    let mut detail_fields: Vec<Option<(String, String)>> = Vec::new();
-    // Index ranges in details_text/detail_fields that should move to the
+    let mut details = DetailsBuilder::new(label_style);
+    // Index ranges in the details builder that should move to the
     // right pane when the layout splits horizontally (Application fields and
     // Transport Health). Pushed in source order; drained in reverse later.
     let mut right_ranges: Vec<std::ops::Range<usize>> = Vec::new();
@@ -861,19 +823,12 @@ pub(in crate::ui) fn draw_connection_details(
     // Together with the fixed nine-row Network Context card below this gives
     // the left dashboard column a 21-row footprint for every protocol, ARP
     // included, so the cards below never move.
-    details_text.push(Line::from(Span::styled(
+    details.plain_line(Line::from(Span::styled(
         "Connection",
         theme::bold_fg(theme::heading()),
     )));
-    detail_fields.push(None);
 
-    push_detail_field(
-        &mut details_text,
-        &mut detail_fields,
-        "Protocol",
-        conn.protocol.to_string(),
-        label_style,
-    );
+    details.field("Protocol", conn.protocol.to_string());
     if conn.is_historic {
         let closed_display = if let Some(closed_at) = conn.closed_at {
             format!(
@@ -883,14 +838,7 @@ pub(in crate::ui) fn draw_connection_details(
         } else {
             "Closed".to_string()
         };
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
-            "Status",
-            closed_display,
-            label_style,
-            theme::fg(theme::muted()),
-        );
+        details.field_styled("Status", closed_display, theme::fg(theme::muted()));
     } else {
         // Mirror the historic Status line for active connections so the
         // user can see how recently traffic moved on this connection.
@@ -904,78 +852,50 @@ pub(in crate::ui) fn draw_connection_details(
         let active_color = theme::expiry_glow_intensity(staleness)
             .map(theme::expiry_glow)
             .unwrap_or_else(theme::ok);
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
-            "Status",
-            active_display,
-            label_style,
-            theme::fg(active_color),
-        );
+        details.field_styled("Status", active_display, theme::fg(active_color));
     }
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Local Address",
         annotated_addr(conn.local_addr, conn.local_addr_kind),
-        label_style,
         theme::fg(theme::field_local_addr()),
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Remote Address",
         annotated_remote_addr(
             conn.remote_addr,
             conn.remote_addr_kind,
             conn.remote_is_gateway,
         ),
-        label_style,
         theme::fg(theme::field_remote_addr()),
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Scope",
         remote_scope(conn).label().to_string(),
-        label_style,
         theme::fg(theme::field_remote_addr()),
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "State",
         conn.state().into_owned(),
-        label_style,
         theme::fg(state_color(conn)),
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Process",
         conn.process_name
             .clone()
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         theme::fg(theme::field_process()),
     );
-    push_detail_field(
-        &mut details_text,
-        &mut detail_fields,
+    details.field(
         "PID",
         conn.pid
             .map(|p| p.to_string())
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Service",
         conn.service_name
             .clone()
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         theme::fg(theme::field_service()),
     );
 
@@ -1045,35 +965,26 @@ pub(in crate::ui) fn draw_connection_details(
         })
         .unwrap_or_else(|| NONE_PLACEHOLDER.to_string());
 
-    push_detail_section(&mut details_text, &mut detail_fields, "Network Context");
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.section("Network Context");
+    details.field_styled(
         "Local Hostname",
         local_hostname.unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         theme::fg(theme::field_local_addr()),
     );
     // MAC and attribution rows always render, with a placeholder when
     // unresolved, so the cards below keep static positions while navigating,
     // for every protocol including ARP. The details pane scrolls, so the
     // fixed rows cannot make content unreachable on short terminals.
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Local MAC",
         local_mac
             .map(format_mac)
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         theme::fg(theme::field_local_addr()),
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Remote Hostname",
         remote_hostname.unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         theme::fg(theme::field_remote_addr()),
     );
     // Hostname inferred from a DNS response observed on the wire, with
@@ -1096,57 +1007,27 @@ pub(in crate::ui) fn draw_connection_details(
         }
         None => (NONE_PLACEHOLDER.to_string(), NONE_PLACEHOLDER.to_string()),
     };
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Attributed Name",
         attributed_name,
-        label_style,
         theme::fg(theme::field_attributed_hostname()),
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Attributed Via",
         attributed_via,
-        label_style,
         theme::fg(theme::field_attributed_hostname()),
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Remote MAC",
         remote_mac
             .map(format_mac)
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         theme::fg(theme::field_remote_addr()),
     );
     let location_value_style = theme::fg(theme::field_location());
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
-        "Country",
-        country,
-        label_style,
-        location_value_style,
-    );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
-        "City",
-        city,
-        label_style,
-        location_value_style,
-    );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
-        "ASN",
-        asn,
-        label_style,
-        location_value_style,
-    );
+    details.field_styled("Country", country, location_value_style);
+    details.field_styled("City", city, location_value_style);
+    details.field_styled("ASN", asn, location_value_style);
 
     // Richer process attribution. Every row renders with a placeholder when
     // the platform's lookup could not resolve it, so the cards below keep
@@ -1156,78 +1037,57 @@ pub(in crate::ui) fn draw_connection_details(
     // The Kubernetes block below stays conditional: being a k8s workload is
     // a class distinction, not missing data.
     let process_value_style = theme::fg(theme::field_process());
-    push_detail_section(&mut details_text, &mut detail_fields, "Attribution");
+    details.section("Attribution");
 
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "PID",
         conn.pid
             .map(|pid| pid.to_string())
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         process_value_style,
     );
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "PPID",
         conn.process_ppid
             .map(|ppid| ppid.to_string())
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         process_value_style,
     );
     if let (Some(lineage), Some(owner_name)) = (&conn.process_lineage, conn.process_name.as_deref())
     {
-        push_detail_field_with_copy(
-            &mut details_text,
-            &mut detail_fields,
+        details.field_with_copy(
             "Process Tree",
             process_tree_value(lineage, owner_name, value_width),
             process_tree_value(lineage, owner_name, usize::MAX),
-            label_style,
             process_value_style,
         );
     } else {
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
+        details.field_styled(
             "Process Tree",
             NONE_PLACEHOLDER.to_string(),
-            label_style,
             process_value_style,
         );
     }
     if let Some(ref executable) = conn.executable {
         let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
-        push_detail_field_with_copy(
-            &mut details_text,
-            &mut detail_fields,
+        details.field_with_copy(
             "Executable",
             shorten_executable_path(executable, home.as_deref(), value_width),
             executable.display().to_string(),
-            label_style,
             process_value_style,
         );
     } else {
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
+        details.field_styled(
             "Executable",
             NONE_PLACEHOLDER.to_string(),
-            label_style,
             process_value_style,
         );
     }
-    push_detail_field(
-        &mut details_text,
-        &mut detail_fields,
+    details.field(
         "User",
         conn.process_uid
             .map(|uid| format_user_group(uid, conn.process_gid))
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
     );
     // A relaxed match is a plausible owner, not a proven one, so it
     // reads as a warning rather than as confirmed fact.
@@ -1236,14 +1096,11 @@ pub(in crate::ui) fn draw_connection_details(
         Some(MatchQuality::Unspecified) | None => theme::muted(),
         Some(_) => theme::warn(),
     };
-    push_detail_field_styled(
-        &mut details_text,
-        &mut detail_fields,
+    details.field_styled(
         "Match",
         conn.attribution_quality
             .map(|quality| quality.to_string())
             .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-        label_style,
         theme::fg(quality_color),
     );
 
@@ -1255,7 +1112,7 @@ pub(in crate::ui) fn draw_connection_details(
     #[cfg(feature = "kubernetes")]
     if let Some(ref k8s) = conn.k8s_info {
         let k8s_value_style = theme::fg(theme::field_process());
-        push_detail_section(&mut details_text, &mut detail_fields, "Kubernetes");
+        details.section("Kubernetes");
         // Prefer the human-readable pod name over the raw UID; show both when
         // both are present.
         let pod_display = match (&k8s.pod_name, &k8s.pod_namespace) {
@@ -1263,39 +1120,24 @@ pub(in crate::ui) fn draw_connection_details(
             (Some(name), None) => name.clone(),
             (None, _) => NONE_PLACEHOLDER.to_string(),
         };
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
-            "Pod",
-            pod_display,
-            label_style,
-            k8s_value_style,
-        );
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
+        details.field_styled("Pod", pod_display, k8s_value_style);
+        details.field_styled(
             "Pod UID",
             k8s.pod_uid
                 .clone()
                 .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
             k8s_value_style,
         );
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
+        details.field_styled(
             "Container",
             k8s.container_name
                 .clone()
                 .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
             k8s_value_style,
         );
         // Container IDs are 64 hex chars; truncate to the short form
         // typically shown by `kubectl get pod ... -o wide`.
-        push_detail_field_styled(
-            &mut details_text,
-            &mut detail_fields,
+        details.field_styled(
             "Container ID",
             k8s.container_id
                 .as_deref()
@@ -1307,28 +1149,22 @@ pub(in crate::ui) fn draw_connection_details(
                     }
                 })
                 .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
             k8s_value_style,
         );
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
+        details.field(
             "Cgroup",
             k8s.cgroup_path
                 .clone()
                 .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
         );
     }
 
     // Add DPI / application protocol information. Section heading carries
     // both the label and the protocol so we don't need a redundant
     // "Application: <proto>" field below.
-    let application_start = details_text.len();
+    let application_start = details.rows();
     if let Some(dpi) = &conn.dpi_info {
-        push_detail_section_styled(
-            &mut details_text,
-            &mut detail_fields,
+        details.section_styled(
             format!("Application: {}", dpi.application.sort_key()),
             theme::bold_fg(dpi_color(&dpi.application)),
         );
@@ -1337,61 +1173,25 @@ pub(in crate::ui) fn draw_connection_details(
         match &dpi.application {
             crate::network::types::ApplicationProtocol::Http(info) => {
                 if let Some(method) = &info.method {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "HTTP Method",
-                        method.clone(),
-                        label_style,
-                    );
+                    details.field("HTTP Method", method.clone());
                 }
                 if let Some(path) = &info.path {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "HTTP Path",
-                        path.clone(),
-                        label_style,
-                    );
+                    details.field("HTTP Path", path.clone());
                 }
                 if let Some(status) = info.status_code {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "HTTP Status",
-                        status.to_string(),
-                        label_style,
-                    );
+                    details.field("HTTP Status", status.to_string());
                 }
             }
             crate::network::types::ApplicationProtocol::Https(info) => {
                 if let Some(tls_info) = &info.tls_info {
                     if let Some(sni) = &tls_info.sni {
-                        push_detail_field(
-                            &mut details_text,
-                            &mut detail_fields,
-                            "SNI",
-                            sni.clone(),
-                            label_style,
-                        );
+                        details.field("SNI", sni.clone());
                     }
                     if !tls_info.alpn.is_empty() {
-                        push_detail_field(
-                            &mut details_text,
-                            &mut detail_fields,
-                            "ALPN",
-                            tls_info.alpn.join(", "),
-                            label_style,
-                        );
+                        details.field("ALPN", tls_info.alpn.join(", "));
                     }
                     if let Some(version) = &tls_info.version {
-                        push_detail_field(
-                            &mut details_text,
-                            &mut detail_fields,
-                            "TLS Version",
-                            version.to_string(),
-                            label_style,
-                        );
+                        details.field("TLS Version", version.to_string());
                     }
                     if let Some(formatted_cipher) = tls_info.format_cipher_suite() {
                         let cipher_color = if tls_info.is_cipher_suite_secure().unwrap_or(false) {
@@ -1399,12 +1199,9 @@ pub(in crate::ui) fn draw_connection_details(
                         } else {
                             theme::warn()
                         };
-                        push_detail_field_styled(
-                            &mut details_text,
-                            &mut detail_fields,
+                        details.field_styled(
                             "Cipher Suite",
                             formatted_cipher,
-                            label_style,
                             theme::fg(cipher_color),
                         );
                     }
@@ -1412,42 +1209,21 @@ pub(in crate::ui) fn draw_connection_details(
             }
             crate::network::types::ApplicationProtocol::Dns(info) => {
                 if let Some(query_name) = &info.query_name {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "DNS Query",
-                        query_name.clone(),
-                        label_style,
-                    );
+                    details.field("DNS Query", query_name.clone());
                 }
                 if let Some(query_type) = &info.query_type {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "DNS Type",
-                        format!("{}", query_type),
-                        label_style,
-                    );
+                    details.field("DNS Type", format!("{}", query_type));
                 }
                 if !info.response_ips.is_empty() {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "DNS Response IPs",
-                        format!("{:?}", info.response_ips),
-                        label_style,
-                    );
+                    details.field("DNS Response IPs", format!("{:?}", info.response_ips));
                 }
                 // Disambiguate "record doesn't exist" from "answer not
                 // parsed": a NOERROR response whose answer section held no
                 // record of the queried type is a deliberate empty answer.
                 if info.nodata == Some(true) {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
+                    details.field(
                         "DNS Answer",
                         "no data (name exists, no record of this type)".to_string(),
-                        label_style,
                     );
                 }
             }
@@ -1457,319 +1233,103 @@ pub(in crate::ui) fn draw_connection_details(
                         .sni
                         .clone()
                         .unwrap_or_else(|| NONE_PLACEHOLDER.to_string());
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "QUIC SNI",
-                        sni,
-                        label_style,
-                    );
+                    details.field("QUIC SNI", sni);
                     let alpn = tls_info.alpn.join(", ");
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "QUIC ALPN",
-                        alpn,
-                        label_style,
-                    );
+                    details.field("QUIC ALPN", alpn);
                 }
                 if let Some(version) = info.version_string.as_deref() {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "QUIC Version",
-                        version.to_owned(),
-                        label_style,
-                    );
+                    details.field("QUIC Version", version.to_owned());
                 }
                 if let Some(connection_id) = &info.connection_id_hex {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Connection ID",
-                        connection_id.clone(),
-                        label_style,
-                    );
+                    details.field("Connection ID", connection_id.clone());
                 }
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Packet Type",
-                    info.packet_type.to_string(),
-                    label_style,
-                );
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Connection State",
-                    info.connection_state.to_string(),
-                    label_style,
-                );
+                details.field("Packet Type", info.packet_type.to_string());
+                details.field("Connection State", info.connection_state.to_string());
             }
             crate::network::types::ApplicationProtocol::Ssh(info) => {
                 if let Some(version) = &info.version {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "SSH Version",
-                        format!("{:?}", version),
-                        label_style,
-                    );
+                    details.field("SSH Version", format!("{:?}", version));
                 }
                 if let Some(server_software) = &info.server_software {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Server Software",
-                        server_software.clone(),
-                        label_style,
-                    );
+                    details.field("Server Software", server_software.clone());
                 }
                 if let Some(client_software) = &info.client_software {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Client Software",
-                        client_software.clone(),
-                        label_style,
-                    );
+                    details.field("Client Software", client_software.clone());
                 }
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Connection State",
-                    format!("{:?}", info.connection_state),
-                    label_style,
-                );
+                details.field("Connection State", format!("{:?}", info.connection_state));
                 if !info.algorithms.is_empty() {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Algorithms",
-                        info.algorithms.join(", "),
-                        label_style,
-                    );
+                    details.field("Algorithms", info.algorithms.join(", "));
                 }
                 if let Some(auth_method) = &info.auth_method {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Auth Method",
-                        auth_method.clone(),
-                        label_style,
-                    );
+                    details.field("Auth Method", auth_method.clone());
                 }
             }
             crate::network::types::ApplicationProtocol::Ntp(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "NTP Version",
-                    format!("{}", info.version),
-                    label_style,
-                );
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "NTP Mode",
-                    info.mode.to_string(),
-                    label_style,
-                );
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Stratum",
-                    format!("{}", info.stratum),
-                    label_style,
-                );
+                details.field("NTP Version", format!("{}", info.version));
+                details.field("NTP Mode", info.mode.to_string());
+                details.field("Stratum", format!("{}", info.stratum));
             }
             crate::network::types::ApplicationProtocol::Mdns(info) => {
                 if let Some(query_name) = &info.query_name {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Query Name",
-                        query_name.clone(),
-                        label_style,
-                    );
+                    details.field("Query Name", query_name.clone());
                 }
                 if let Some(query_type) = &info.query_type {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Query Type",
-                        format!("{}", query_type),
-                        label_style,
-                    );
+                    details.field("Query Type", format!("{}", query_type));
                 }
                 if !info.response_ips.is_empty() {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Response IPs",
-                        format!("{:?}", info.response_ips),
-                        label_style,
-                    );
+                    details.field("Response IPs", format!("{:?}", info.response_ips));
                 }
             }
             crate::network::types::ApplicationProtocol::Llmnr(info) => {
                 if let Some(query_name) = &info.query_name {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Query Name",
-                        query_name.clone(),
-                        label_style,
-                    );
+                    details.field("Query Name", query_name.clone());
                 }
                 if let Some(query_type) = &info.query_type {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Query Type",
-                        format!("{}", query_type),
-                        label_style,
-                    );
+                    details.field("Query Type", format!("{}", query_type));
                 }
                 if !info.response_ips.is_empty() {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Response IPs",
-                        format!("{:?}", info.response_ips),
-                        label_style,
-                    );
+                    details.field("Response IPs", format!("{:?}", info.response_ips));
                 }
             }
             crate::network::types::ApplicationProtocol::Dhcp(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Message Type",
-                    info.message_type.to_string(),
-                    label_style,
-                );
+                details.field("Message Type", info.message_type.to_string());
                 if let Some(hostname) = &info.hostname {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Hostname",
-                        hostname.clone(),
-                        label_style,
-                    );
+                    details.field("Hostname", hostname.clone());
                 }
                 if let Some(client_mac) = &info.client_mac {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Client MAC",
-                        client_mac.clone(),
-                        label_style,
-                    );
+                    details.field("Client MAC", client_mac.clone());
                 }
             }
             crate::network::types::ApplicationProtocol::Snmp(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "SNMP Version",
-                    info.version.to_string(),
-                    label_style,
-                );
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "PDU Type",
-                    info.pdu_type.to_string(),
-                    label_style,
-                );
+                details.field("SNMP Version", info.version.to_string());
+                details.field("PDU Type", info.pdu_type.to_string());
                 if let Some(community) = &info.community {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Community",
-                        community.clone(),
-                        label_style,
-                    );
+                    details.field("Community", community.clone());
                 }
             }
             crate::network::types::ApplicationProtocol::Ssdp(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Method",
-                    info.method.to_string(),
-                    label_style,
-                );
+                details.field("Method", info.method.to_string());
                 if let Some(service_type) = &info.service_type {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Service Type",
-                        service_type.clone(),
-                        label_style,
-                    );
+                    details.field("Service Type", service_type.clone());
                 }
             }
             crate::network::types::ApplicationProtocol::NetBios(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Service",
-                    info.service.to_string(),
-                    label_style,
-                );
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Opcode",
-                    info.opcode.to_string(),
-                    label_style,
-                );
+                details.field("Service", info.service.to_string());
+                details.field("Opcode", info.opcode.to_string());
                 if let Some(name) = &info.name {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Name",
-                        name.clone(),
-                        label_style,
-                    );
+                    details.field("Name", name.clone());
                 }
             }
             crate::network::types::ApplicationProtocol::BitTorrent(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Type",
-                    info.protocol_type.to_string(),
-                    label_style,
-                );
+                details.field("Type", info.protocol_type.to_string());
                 if let Some(client) = &info.client {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Client",
-                        client.clone(),
-                        label_style,
-                    );
+                    details.field("Client", client.clone());
                 }
                 if let Some(info_hash) = &info.info_hash {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Info Hash",
-                        info_hash.clone(),
-                        label_style,
-                    );
+                    details.field("Info Hash", info_hash.clone());
                 }
                 if let Some(method) = &info.dht_method {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "DHT Method",
-                        method.clone(),
-                        label_style,
-                    );
+                    details.field("DHT Method", method.clone());
                 }
                 let mut extensions = Vec::new();
                 if info.supports_dht {
@@ -1782,235 +1342,80 @@ pub(in crate::ui) fn draw_connection_details(
                     extensions.push("Fast");
                 }
                 if !extensions.is_empty() {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Extensions",
-                        extensions.join(", "),
-                        label_style,
-                    );
+                    details.field("Extensions", extensions.join(", "));
                 }
             }
             crate::network::types::ApplicationProtocol::Stun(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Method",
-                    info.method.to_string(),
-                    label_style,
-                );
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Class",
-                    info.message_class.to_string(),
-                    label_style,
-                );
+                details.field("Method", info.method.to_string());
+                details.field("Class", info.message_class.to_string());
                 let txn_id = crate::network::util::hex_encode(&info.transaction_id, "");
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Transaction ID",
-                    txn_id,
-                    label_style,
-                );
+                details.field("Transaction ID", txn_id);
                 if let Some(software) = &info.software {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Software",
-                        software.clone(),
-                        label_style,
-                    );
+                    details.field("Software", software.clone());
                 }
             }
             crate::network::types::ApplicationProtocol::Ftp(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Message Type",
-                    info.message_type.to_string(),
-                    label_style,
-                );
+                details.field("Message Type", info.message_type.to_string());
                 if let Some(cmd) = &info.command {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Command",
-                        cmd.clone(),
-                        label_style,
-                    );
+                    details.field("Command", cmd.clone());
                 }
                 if let Some(args) = &info.args {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Arguments",
-                        args.clone(),
-                        label_style,
-                    );
+                    details.field("Arguments", args.clone());
                 }
                 if let Some(code) = info.response_code {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Response Code",
-                        code.to_string(),
-                        label_style,
-                    );
+                    details.field("Response Code", code.to_string());
                 }
                 if let Some(message) = &info.response_message {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Response",
-                        message.clone(),
-                        label_style,
-                    );
+                    details.field("Response", message.clone());
                 }
                 if let Some(user) = &info.username {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Username",
-                        user.clone(),
-                        label_style,
-                    );
+                    details.field("Username", user.clone());
                 }
                 if let Some(sw) = &info.server_software {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Server Software",
-                        sw.clone(),
-                        label_style,
-                    );
+                    details.field("Server Software", sw.clone());
                 }
                 if let Some(sys) = &info.system_type {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "System Type",
-                        sys.clone(),
-                        label_style,
-                    );
+                    details.field("System Type", sys.clone());
                 }
             }
             crate::network::types::ApplicationProtocol::Mqtt(info) => {
-                push_detail_field(
-                    &mut details_text,
-                    &mut detail_fields,
-                    "Packet Type",
-                    info.packet_type.to_string(),
-                    label_style,
-                );
+                details.field("Packet Type", info.packet_type.to_string());
                 if let Some(version) = &info.version {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Version",
-                        version.to_string(),
-                        label_style,
-                    );
+                    details.field("Version", version.to_string());
                 }
                 if let Some(client_id) = &info.client_id {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Client ID",
-                        client_id.clone(),
-                        label_style,
-                    );
+                    details.field("Client ID", client_id.clone());
                 }
                 if let Some(topic) = &info.topic {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "Topic",
-                        topic.clone(),
-                        label_style,
-                    );
+                    details.field("Topic", topic.clone());
                 }
                 if let Some(qos) = info.qos {
-                    push_detail_field(
-                        &mut details_text,
-                        &mut detail_fields,
-                        "QoS",
-                        qos.to_string(),
-                        label_style,
-                    );
+                    details.field("QoS", qos.to_string());
                 }
             }
         }
     } else if let ProtocolState::Arp(arp_info) = &conn.protocol_state {
-        push_detail_section(&mut details_text, &mut detail_fields, "Application: ARP");
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Sender MAC",
-            arp_info.sender_mac.clone(),
-            label_style,
-        );
+        details.section("Application: ARP");
+        details.field("Sender MAC", arp_info.sender_mac.clone());
         if let Some(ref vendor) = arp_info.sender_vendor {
-            push_detail_field(
-                &mut details_text,
-                &mut detail_fields,
-                "Sender Vendor",
-                vendor.clone(),
-                label_style,
-            );
+            details.field("Sender Vendor", vendor.clone());
         }
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Sender IP",
-            arp_info.sender_ip.to_string(),
-            label_style,
-        );
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Target MAC",
-            arp_info.target_mac.clone(),
-            label_style,
-        );
+        details.field("Sender IP", arp_info.sender_ip.to_string());
+        details.field("Target MAC", arp_info.target_mac.clone());
         if let Some(ref vendor) = arp_info.target_vendor {
-            push_detail_field(
-                &mut details_text,
-                &mut detail_fields,
-                "Target Vendor",
-                vendor.clone(),
-                label_style,
-            );
+            details.field("Target Vendor", vendor.clone());
         }
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Target IP",
-            arp_info.target_ip.to_string(),
-            label_style,
-        );
+        details.field("Target IP", arp_info.target_ip.to_string());
     } else {
-        push_detail_section(&mut details_text, &mut detail_fields, "Application");
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Detected",
-            NONE_PLACEHOLDER.to_string(),
-            label_style,
-        );
+        details.section("Application");
+        details.field("Detected", NONE_PLACEHOLDER.to_string());
     }
 
     // Short application records keep their whitespace inside the card instead
     // of pulling Transport Health and Traffic Statistics upward. All current
     // decoders fit within this budget, including FTP's eight detail fields.
-    pad_detail_section(
-        &mut details_text,
-        &mut detail_fields,
-        application_start,
-        APPLICATION_CARD_ROWS,
-    );
-    right_ranges.push(application_start..details_text.len());
+    details.pad_section(application_start, APPLICATION_CARD_ROWS);
+    right_ranges.push(application_start..details.rows());
 
     // Transport Health is also a fixed card, but its rows are protocol
     // specific. QUIC has no equivalent of the TCP loss counters: packet numbers
@@ -2089,237 +1494,114 @@ pub(in crate::ui) fn draw_connection_details(
         } => *icmp_sequence,
         _ => None,
     };
-    let metrics_start = details_text.len();
-    push_detail_section(&mut details_text, &mut detail_fields, "Transport Health");
+    let metrics_start = details.rows();
+    details.section("Transport Health");
     let show_rtt = conn.protocol == Protocol::Tcp || quic_info.is_some();
     if let Some(dns) = dns_info {
-        push_rtt_field(
-            &mut details_text,
-            &mut detail_fields,
-            "DNS Response Time",
-            conn.dns_response_time,
-            label_style,
-        );
+        details.rtt_field("DNS Response Time", conn.dns_response_time);
         if let Some(rcode) = dns.rcode {
             let rcode_color = if rcode == 0 {
                 theme::ok()
             } else {
                 theme::err()
             };
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
+            details.field_styled(
                 "Last Response Code",
                 crate::network::types::dns_rcode_name(rcode).into_owned(),
-                label_style,
                 theme::fg(rcode_color),
             );
         } else {
-            push_detail_field(
-                &mut details_text,
-                &mut detail_fields,
-                "Last Response Code",
-                NONE_PLACEHOLDER.to_string(),
-                label_style,
-            );
+            details.field("Last Response Code", NONE_PLACEHOLDER.to_string());
         }
         // Footnote style matching the QUIC branch below.
-        details_text.push(Line::from(""));
-        detail_fields.push(None);
-        push_detail_note(
-            &mut details_text,
-            &mut detail_fields,
-            "Timed by pairing query and response IDs",
-        );
+        details.plain_line(Line::from(""));
+        details.note("Timed by pairing query and response IDs");
     } else if llmnr_info.is_some() {
-        push_rtt_field(
-            &mut details_text,
-            &mut detail_fields,
-            "LLMNR Response Time",
-            conn.llmnr_response_time,
-            label_style,
-        );
-        details_text.push(Line::from(""));
-        detail_fields.push(None);
-        push_detail_note(
-            &mut details_text,
-            &mut detail_fields,
-            "First response paired by transaction ID",
-        );
+        details.rtt_field("LLMNR Response Time", conn.llmnr_response_time);
+        details.plain_line(Line::from(""));
+        details.note("First response paired by transaction ID");
     } else if let Some(netbios) = netbios_info {
-        push_rtt_field(
-            &mut details_text,
-            &mut detail_fields,
-            "NetBIOS Response Time",
-            conn.netbios_response_time,
-            label_style,
-        );
+        details.rtt_field("NetBIOS Response Time", conn.netbios_response_time);
         if let Some(status) = netbios.response_status {
             let status_color = if status.is_success() {
                 theme::ok()
             } else {
                 theme::err()
             };
-            push_detail_field_styled(
-                &mut details_text,
-                &mut detail_fields,
+            details.field_styled(
                 "Last Response Status",
                 status.to_string(),
-                label_style,
                 theme::fg(status_color),
             );
         } else {
-            push_detail_field(
-                &mut details_text,
-                &mut detail_fields,
-                "Last Response Status",
-                NONE_PLACEHOLDER.to_string(),
-                label_style,
-            );
+            details.field("Last Response Status", NONE_PLACEHOLDER.to_string());
         }
-        details_text.push(Line::from(""));
-        detail_fields.push(None);
-        push_detail_note(
-            &mut details_text,
-            &mut detail_fields,
-            "Timed by pairing request and response IDs",
-        );
+        details.plain_line(Line::from(""));
+        details.note("Timed by pairing request and response IDs");
     } else if let Some(stun) = stun_info {
-        push_rtt_field(
-            &mut details_text,
-            &mut detail_fields,
-            "STUN RTT",
-            conn.stun_rtt,
-            label_style,
-        );
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
+        details.rtt_field("STUN RTT", conn.stun_rtt);
+        details.field(
             "Last Message",
             format!("{} {}", stun.method, stun.message_class),
-            label_style,
         );
-        details_text.push(Line::from(""));
-        detail_fields.push(None);
-        push_detail_note(
-            &mut details_text,
-            &mut detail_fields,
-            "Paired by 96-bit transaction ID",
-        );
+        details.plain_line(Line::from(""));
+        details.note("Paired by 96-bit transaction ID");
     } else if let Some(ntp) = ntp_info {
-        push_rtt_field(
-            &mut details_text,
-            &mut detail_fields,
-            "NTP RTT",
-            conn.ntp_rtt,
-            label_style,
-        );
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
+        details.rtt_field("NTP RTT", conn.ntp_rtt);
+        details.field(
             "Stratum",
             if ntp.stratum == 0 {
                 NONE_PLACEHOLDER.to_string()
             } else {
                 ntp.stratum.to_string()
             },
-            label_style,
         );
-        details_text.push(Line::from(""));
-        detail_fields.push(None);
-        push_detail_note(
-            &mut details_text,
-            &mut detail_fields,
-            "Paired by originate timestamp echo",
-        );
+        details.plain_line(Line::from(""));
+        details.note("Paired by originate timestamp echo");
     } else if let Some(sequence) = icmp_echo_sequence {
         // The row set depends only on the class (an echo flow), never on
         // direction or measurement, which both resolve asynchronously. An
         // inbound echo keeps the row as a placeholder; the footnote explains
         // that the remote sender is the one timing it.
         let is_responder = conn.connection_direction == Some(false);
-        push_rtt_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Ping RTT",
-            conn.icmp_echo_rtt,
-            label_style,
-        );
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Last Sequence",
-            sequence.to_string(),
-            label_style,
-        );
-        details_text.push(Line::from(""));
-        detail_fields.push(None);
-        push_detail_note(
-            &mut details_text,
-            &mut detail_fields,
-            if is_responder {
-                "Inbound echo: RTT is timed by the remote sender"
-            } else {
-                "Paired by echo ID and sequence"
-            },
-        );
+        details.rtt_field("Ping RTT", conn.icmp_echo_rtt);
+        details.field("Last Sequence", sequence.to_string());
+        details.plain_line(Line::from(""));
+        details.note(if is_responder {
+            "Inbound echo: RTT is timed by the remote sender"
+        } else {
+            "Paired by echo ID and sequence"
+        });
     } else if !show_rtt {
         // Nothing on a bare UDP or non-echo ICMP flow is timeable or
         // countable: there is no handshake or request/reply ID to pair.
-        push_detail_note(
-            &mut details_text,
-            &mut detail_fields,
-            "No transport metrics for this protocol",
-        );
+        details.note("No transport metrics for this protocol");
     } else {
-        push_rtt_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Initial RTT",
-            conn.initial_rtt,
-            label_style,
-        );
+        details.rtt_field("Initial RTT", conn.initial_rtt);
     }
     if let Some(quic) = quic_info {
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
+        details.field(
             "Idle Timeout",
             quic.idle_timeout
                 .map(format_idle_timeout)
                 .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
         );
-        push_detail_field(
-            &mut details_text,
-            &mut detail_fields,
+        details.field(
             "Connection Close",
             quic.connection_close
                 .as_ref()
                 .map(format_quic_close)
                 .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-            label_style,
         );
         // Separated from the fields above so it reads as a footnote on the
         // card rather than another value that failed to resolve.
-        details_text.push(Line::from(""));
-        detail_fields.push(None);
-        push_detail_note(
-            &mut details_text,
-            &mut detail_fields,
-            "Loss counters are encrypted in QUIC",
-        );
+        details.plain_line(Line::from(""));
+        details.note("Loss counters are encrypted in QUIC");
     } else if conn.protocol == Protocol::Tcp {
         let counters = conn.tcp_analytics.as_ref();
         // Live RTT: EWMA over data-segment round trips, updated for the whole
         // life of the connection (unlike the one-shot handshake RTT above).
-        push_rtt_field(
-            &mut details_text,
-            &mut detail_fields,
-            "Live RTT",
-            counters.and_then(|a| a.smoothed_rtt),
-            label_style,
-        );
+        details.rtt_field("Live RTT", counters.and_then(|a| a.smoothed_rtt));
         for (label, value) in [
             ("TCP Retransmits", counters.map(|a| a.retransmit_count)),
             (
@@ -2333,24 +1615,16 @@ pub(in crate::ui) fn draw_connection_details(
             ),
             ("Window Size", counters.map(|a| a.last_window_size as u64)),
         ] {
-            push_detail_field(
-                &mut details_text,
-                &mut detail_fields,
+            details.field(
                 label,
                 value
                     .map(|v| v.to_string())
                     .unwrap_or_else(|| NONE_PLACEHOLDER.to_string()),
-                label_style,
             );
         }
     }
-    pad_detail_section(
-        &mut details_text,
-        &mut detail_fields,
-        metrics_start,
-        TRANSPORT_CARD_ROWS,
-    );
-    right_ranges.push(metrics_start..details_text.len());
+    details.pad_section(metrics_start, TRANSPORT_CARD_ROWS);
+    right_ranges.push(metrics_start..details.rows());
 
     // Continuity: the header band echoes the selected row so users feel
     // like they zoomed into the Overview entry rather than landed on a
@@ -2408,6 +1682,12 @@ pub(in crate::ui) fn draw_connection_details(
     // readable. The right pane needs no title of its own — its content
     // starts with the bold Application and Transport Health headings.
     let split_horizontally = info_area.width >= DETAILS_SPLIT_MIN_WIDTH;
+    // The builder is done; the drain below reshuffles raw lines and fields.
+    let DetailsBuilder {
+        lines: mut details_text,
+        fields: mut detail_fields,
+        ..
+    } = details;
     let mut right_text: Vec<Line> = Vec::new();
     let mut right_fields: Vec<Option<(String, String)>> = Vec::new();
     if split_horizontally {
@@ -2493,8 +1773,7 @@ pub(in crate::ui) fn draw_connection_details(
     );
 
     // Traffic details - also track fields for click-to-copy
-    let mut traffic_text: Vec<Line> = Vec::new();
-    let mut traffic_fields: Vec<Option<(String, String)>> = Vec::new();
+    let mut traffic = DetailsBuilder::new(label_style);
 
     let rx_value_style = theme::fg(theme::rx());
     let tx_value_style = theme::fg(theme::tx());
@@ -2508,54 +1787,33 @@ pub(in crate::ui) fn draw_connection_details(
     } else {
         format_rate(conn.current_outgoing_rate_bps)
     };
-    push_detail_field_styled(
-        &mut traffic_text,
-        &mut traffic_fields,
-        "Bytes Sent",
-        format_bytes(conn.bytes_sent),
-        label_style,
-        tx_value_style,
-    );
-    push_detail_field_styled(
-        &mut traffic_text,
-        &mut traffic_fields,
+    traffic.field_styled("Bytes Sent", format_bytes(conn.bytes_sent), tx_value_style);
+    traffic.field_styled(
         "Bytes Received",
         format_bytes(conn.bytes_received),
-        label_style,
         rx_value_style,
     );
-    push_detail_field_styled(
-        &mut traffic_text,
-        &mut traffic_fields,
+    traffic.field_styled(
         "Packets Sent",
         conn.packets_sent.to_string(),
-        label_style,
         tx_value_style,
     );
-    push_detail_field_styled(
-        &mut traffic_text,
-        &mut traffic_fields,
+    traffic.field_styled(
         "Packets Received",
         conn.packets_received.to_string(),
-        label_style,
         rx_value_style,
     );
-    push_detail_field_styled(
-        &mut traffic_text,
-        &mut traffic_fields,
-        "Current Rate (In)",
-        current_in_rate.clone(),
-        label_style,
-        rx_value_style,
-    );
-    push_detail_field_styled(
-        &mut traffic_text,
-        &mut traffic_fields,
+    traffic.field_styled("Current Rate (In)", current_in_rate.clone(), rx_value_style);
+    traffic.field_styled(
         "Current Rate (Out)",
         current_out_rate.clone(),
-        label_style,
         tx_value_style,
     );
+    let DetailsBuilder {
+        lines: traffic_text,
+        fields: traffic_fields,
+        ..
+    } = traffic;
 
     // Traffic section directly under the info panes: one blank spacer
     // row, the section header, then the stat fields with per-connection

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -41,30 +41,30 @@ pub fn set_preset(preset: ThemePreset) {
 }
 
 /// Whether the Classic (full-color) preset is active.
-pub fn is_classic() -> bool {
+pub(super) fn is_classic() -> bool {
     CLASSIC.load(Ordering::Relaxed)
 }
 
 // --- Base color accessors ---
-pub fn ok() -> Color {
+pub(super) fn ok() -> Color {
     OK
 }
-pub fn warn() -> Color {
+pub(super) fn warn() -> Color {
     WARN
 }
-pub fn err() -> Color {
+pub(super) fn err() -> Color {
     ERR
 }
-pub fn accent() -> Color {
+pub(super) fn accent() -> Color {
     ACCENT
 }
-pub fn muted() -> Color {
+pub(super) fn muted() -> Color {
     MUTED
 }
-pub fn info() -> Color {
+pub(super) fn info() -> Color {
     INFO
 }
-pub fn special() -> Color {
+pub(super) fn special() -> Color {
     SPECIAL
 }
 
@@ -79,24 +79,24 @@ pub fn special() -> Color {
 // `primary()` returns a full Style because it always pairs with BOLD;
 // the others return raw Colors so callers can compose with `fg()` /
 // `bold_fg()` as needed.
-pub fn primary() -> Style {
+pub(super) fn primary() -> Style {
     bold_fg(accent())
 }
-pub fn label() -> Color {
+pub(super) fn label() -> Color {
     muted()
 }
-pub fn heading() -> Color {
+pub(super) fn heading() -> Color {
     if is_classic() { warn() } else { muted() }
 }
-pub fn key() -> Color {
+pub(super) fn key() -> Color {
     if is_classic() { warn() } else { accent() }
 }
 
 // --- Network aliases ---
-pub fn rx() -> Color {
+pub(super) fn rx() -> Color {
     ok()
 }
-pub fn tx() -> Color {
+pub(super) fn tx() -> Color {
     info()
 }
 
@@ -185,47 +185,47 @@ fn five_stop(stops: &[(u8, u8, u8); 5], t: f64) -> Color {
 }
 
 /// RX wave gradient color at intensity `t` (0 = dim base, 1 = crest).
-pub fn rx_wave(t: f64) -> Color {
+pub(super) fn rx_wave(t: f64) -> Color {
     five_stop(&RX_WAVE_STOPS, t)
 }
 /// TX wave gradient color at intensity `t` (0 = dim base, 1 = crest).
-pub fn tx_wave(t: f64) -> Color {
+pub(super) fn tx_wave(t: f64) -> Color {
     five_stop(&TX_WAVE_STOPS, t)
 }
 /// Accent (cyan) wave gradient for non-directional graphs like the
 /// connection count, at intensity `t` (0 = dim base, 1 = crest).
-pub fn accent_wave(t: f64) -> Color {
+pub(super) fn accent_wave(t: f64) -> Color {
     five_stop(&ACCENT_WAVE_STOPS, t)
 }
 /// Green gradient for healthy/success bars (same ramp as RX).
-pub fn ok_wave(t: f64) -> Color {
+pub(super) fn ok_wave(t: f64) -> Color {
     five_stop(&RX_WAVE_STOPS, t)
 }
 /// Amber gradient for caution bars.
-pub fn warn_wave(t: f64) -> Color {
+pub(super) fn warn_wave(t: f64) -> Color {
     five_stop(&WARN_WAVE_STOPS, t)
 }
 /// Red gradient for critical bars.
-pub fn err_wave(t: f64) -> Color {
+pub(super) fn err_wave(t: f64) -> Color {
     five_stop(&ERR_WAVE_STOPS, t)
 }
 /// Fuchsia gradient for special/distinct bars (DNS).
-pub fn special_wave(t: f64) -> Color {
+pub(super) fn special_wave(t: f64) -> Color {
     five_stop(&SPECIAL_WAVE_STOPS, t)
 }
 /// Gray gradient for secondary/inactive bars.
-pub fn muted_wave(t: f64) -> Color {
+pub(super) fn muted_wave(t: f64) -> Color {
     five_stop(&MUTED_WAVE_STOPS, t)
 }
 /// Yellow-to-red glow for connections nearing their removal timeout.
-pub fn expiry_glow(t: f64) -> Color {
+pub(super) fn expiry_glow(t: f64) -> Color {
     five_stop(&EXPIRY_GLOW_STOPS, t)
 }
 
 /// Map connection staleness to the expiry glow. The row turns yellow at 75%
 /// of its timeout, stays yellow through the warning window, then intensifies
 /// toward red during the final 10% before removal.
-pub fn expiry_glow_intensity(staleness: f32) -> Option<f64> {
+pub(super) fn expiry_glow_intensity(staleness: f32) -> Option<f64> {
     (staleness >= EXPIRY_WARNING_START).then(|| {
         f64::from(
             ((staleness - EXPIRY_CRITICAL_START) / (1.0 - EXPIRY_CRITICAL_START)).clamp(0.0, 1.0),
@@ -234,41 +234,41 @@ pub fn expiry_glow_intensity(staleness: f32) -> Option<f64> {
 }
 
 // --- Protocol aliases ---
-pub fn proto_https() -> Color {
+pub(super) fn proto_https() -> Color {
     ok()
 }
-pub fn proto_quic() -> Color {
+pub(super) fn proto_quic() -> Color {
     accent()
 }
-pub fn proto_http() -> Color {
+pub(super) fn proto_http() -> Color {
     warn()
 }
-pub fn proto_dns() -> Color {
+pub(super) fn proto_dns() -> Color {
     special()
 }
-pub fn proto_ssh() -> Color {
+pub(super) fn proto_ssh() -> Color {
     info()
 }
-pub fn proto_other() -> Color {
+pub(super) fn proto_other() -> Color {
     muted()
 }
 
 // --- TCP state aliases ---
 // Muted preset: ESTABLISHED is the common case and reads as plain text;
 // only transitional states (a genuine signal) keep an attention color.
-pub fn tcp_established() -> Color {
+pub(super) fn tcp_established() -> Color {
     if is_classic() { ok() } else { Color::Reset }
 }
-pub fn tcp_opening() -> Color {
+pub(super) fn tcp_opening() -> Color {
     warn()
 }
-pub fn tcp_closing() -> Color {
+pub(super) fn tcp_closing() -> Color {
     if is_classic() { accent() } else { muted() }
 }
-pub fn tcp_waiting() -> Color {
+pub(super) fn tcp_waiting() -> Color {
     if is_classic() { special() } else { muted() }
 }
-pub fn tcp_closed() -> Color {
+pub(super) fn tcp_closed() -> Color {
     muted()
 }
 
@@ -277,31 +277,31 @@ pub fn tcp_closed() -> Color {
 // monitored), the other identifying fields render in the terminal's
 // default foreground (`Color::Reset`), supporting context fades to
 // gray. Same address colors in both presets.
-pub fn field_local_addr() -> Color {
+pub(super) fn field_local_addr() -> Color {
     accent()
 }
-pub fn field_remote_addr() -> Color {
+pub(super) fn field_remote_addr() -> Color {
     info()
 }
-pub fn field_state() -> Color {
+pub(super) fn field_state() -> Color {
     if is_classic() { ok() } else { Color::Reset }
 }
-pub fn field_service() -> Color {
+pub(super) fn field_service() -> Color {
     if is_classic() { warn() } else { muted() }
 }
-pub fn field_location() -> Color {
+pub(super) fn field_location() -> Color {
     if is_classic() { special() } else { muted() }
 }
-pub fn field_process() -> Color {
+pub(super) fn field_process() -> Color {
     if is_classic() { ok() } else { Color::Reset }
 }
-pub fn field_application() -> Color {
+pub(super) fn field_application() -> Color {
     if is_classic() { warn() } else { muted() }
 }
 /// Color for hostnames inferred from a recently observed DNS resolution
 /// (shown with a `~` prefix). Dimmer than `field_remote_addr` so the
 /// inference is visually distinct from authoritative SNI / Host data.
-pub fn field_attributed_hostname() -> Color {
+pub(super) fn field_attributed_hostname() -> Color {
     muted()
 }
 
@@ -312,7 +312,7 @@ pub fn field_attributed_hostname() -> Color {
 // are available: terminals disagree wildly on it (invisible on light
 // themes, barely-there in WezTerm dark). Under NO_COLOR it returns as
 // the only row-level cue, alongside the "closed" state text.
-pub fn historic_row() -> Style {
+pub(super) fn historic_row() -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) {
         Style::default().add_modifier(Modifier::DIM)
     } else {
@@ -321,7 +321,7 @@ pub fn historic_row() -> Style {
 }
 
 // --- Panel border ---
-pub fn border() -> Color {
+pub(super) fn border() -> Color {
     if is_classic() {
         special()
     } else {
@@ -331,7 +331,7 @@ pub fn border() -> Color {
 
 // --- Status bar styles ---
 // Uses REVERSED modifier instead of fg(Black).bg(Color) which breaks on dark terminals
-pub fn status_bar_confirm() -> Style {
+pub(super) fn status_bar_confirm() -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) {
         return Style::default().add_modifier(Modifier::REVERSED);
     }
@@ -339,7 +339,7 @@ pub fn status_bar_confirm() -> Style {
         .fg(warn())
         .add_modifier(Modifier::BOLD | Modifier::REVERSED)
 }
-pub fn status_bar_success() -> Style {
+pub(super) fn status_bar_success() -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) {
         return Style::default().add_modifier(Modifier::REVERSED);
     }
@@ -347,7 +347,7 @@ pub fn status_bar_success() -> Style {
         .fg(ok())
         .add_modifier(Modifier::BOLD | Modifier::REVERSED)
 }
-pub fn status_bar_error() -> Style {
+pub(super) fn status_bar_error() -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) {
         return Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED);
     }
@@ -355,14 +355,14 @@ pub fn status_bar_error() -> Style {
         .fg(err())
         .add_modifier(Modifier::BOLD | Modifier::REVERSED)
 }
-pub fn status_bar_default() -> Style {
+pub(super) fn status_bar_default() -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) || !is_classic() {
         return Style::default().add_modifier(Modifier::REVERSED);
     }
     Style::default().fg(info()).add_modifier(Modifier::REVERSED)
 }
 
-pub fn row_highlight() -> Style {
+pub(super) fn row_highlight() -> Style {
     // No fg override: the highlight inherits the row's existing fg, so
     // when REVERSED swaps fg ↔ bg, a red staleness row gets a red
     // selection bar, a yellow row gets a yellow bar, and a default row
@@ -374,7 +374,7 @@ pub fn row_highlight() -> Style {
 // --- Style builders (NO_COLOR-aware) ---
 
 /// Apply a foreground color, respecting NO_COLOR.
-pub fn fg(color: Color) -> Style {
+pub(super) fn fg(color: Color) -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) {
         Style::default()
     } else {
@@ -383,7 +383,7 @@ pub fn fg(color: Color) -> Style {
 }
 
 /// Apply a foreground color with BOLD, respecting NO_COLOR.
-pub fn bold_fg(color: Color) -> Style {
+pub(super) fn bold_fg(color: Color) -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) {
         Style::default().add_modifier(Modifier::BOLD)
     } else {
@@ -392,7 +392,7 @@ pub fn bold_fg(color: Color) -> Style {
 }
 
 /// Apply a foreground color with BOLD + UNDERLINED, respecting NO_COLOR.
-pub fn bold_underline_fg(color: Color) -> Style {
+pub(super) fn bold_underline_fg(color: Color) -> Style {
     if super::NO_COLOR.load(super::Ordering::Relaxed) {
         Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
     } else {


### PR DESCRIPTION
Continues the #551 cleanup across the whole workspace.

- Remove remaining dead code and test-only production API (write-only cache fields, `ConnectionTracker::ingest`, test-only constructors)
- Narrow public items with no external consumers to crate or module visibility, including cfg-gated macOS and Windows internals the Linux lint pass could not see
- Dedup repeated logic: the four Windows socket-table refreshes, the macOS/FreeBSD BPF privilege probe, PKTAP and lsof process-name normalization, `ParsedPacket` construction, and the Details tab field rendering
- Config constructors (`TrackerConfig`, `ProcessActivityConfig`, `DnsResolverConfig`) become `pub(crate)` instead of being removed; the fields stay production-read

The macOS and Windows `rustnet-host` changes have no local compile coverage, so CI is the verification for those targets (FreeBSD cross-checks clean locally).