### PR TITLE
Fix Npcap loading from the default Windows installation

### DIFF
--- a/.github/actions/build-rustnet/action.yml
+++ b/.github/actions/build-rustnet/action.yml
@@ -62,15 +62,17 @@ runs:
         if ($LASTEXITCODE -ne 0) {
           throw "dumpbin failed while inspecting rustnet.exe"
         }
-        if ($imports -notmatch '(?is)following delay load imports:.*?wpcap\.dll') {
-          throw "wpcap.dll is not listed as a delay-loaded import"
+        foreach ($dll in @("Packet.dll", "wpcap.dll")) {
+          if ($imports -notmatch "(?is)following delay load imports:.*?$([regex]::Escape($dll))") {
+            throw "$dll is not listed as a delay-loaded import"
+          }
         }
 
         & $executable --version
         if ($LASTEXITCODE -ne 0) {
-          throw "rustnet --version failed"
+          throw "rustnet --version failed with exit code $LASTEXITCODE"
         }
         & $executable --help | Out-Null
         if ($LASTEXITCODE -ne 0) {
-          throw "rustnet --help failed"
+          throw "rustnet --help failed with exit code $LASTEXITCODE"
         }

--- a/.github/actions/build-rustnet/action.yml
+++ b/.github/actions/build-rustnet/action.yml
@@ -36,3 +36,41 @@ runs:
 
         echo "Running: $BUILD_CMD"
         $BUILD_CMD
+
+    - name: Verify Windows Npcap delay loading
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+        $installPath = & $vswhere -latest -products * `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -property installationPath
+        if (-not $installPath) {
+          throw "Visual Studio C++ tools were not found"
+        }
+
+        $dumpbinPattern = Join-Path $installPath "VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe"
+        $dumpbin = Get-ChildItem $dumpbinPattern |
+          Sort-Object FullName -Descending |
+          Select-Object -First 1
+        if (-not $dumpbin) {
+          throw "dumpbin.exe was not found"
+        }
+
+        $executable = (Resolve-Path "target\${{ inputs.target }}\release\rustnet.exe").Path
+        $imports = (& $dumpbin.FullName /imports $executable | Out-String)
+        if ($LASTEXITCODE -ne 0) {
+          throw "dumpbin failed while inspecting rustnet.exe"
+        }
+        if ($imports -notmatch '(?is)following delay load imports:.*?wpcap\.dll') {
+          throw "wpcap.dll is not listed as a delay-loaded import"
+        }
+
+        & $executable --version
+        if ($LASTEXITCODE -ne 0) {
+          throw "rustnet --version failed"
+        }
+        & $executable --help | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+          throw "rustnet --help failed"
+        }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shows controls and concepts relevant to that view. The tab bar now contains
   the four application views, with direct shortcuts `1` through `4`
 
+### Fixed
+
+- **Default Npcap Installations on Windows**: RustNet now finds Npcap in its
+  standard `System32\Npcap` directory, so WinPcap API-compatible mode is no
+  longer required. `--help` and `--version` also work without Npcap installed
+
 ### Removed
 - **Ubuntu 25.10 (Questing) PPA**: the series reached end of life and
   Launchpad rejects new uploads for it, so the PPA build matrix and install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ windows = { version = "0.62", features = [
     "Win32_Security",
     "Win32_System_JobObjects",
     "Win32_System_LibraryLoader",
+    "Win32_System_SystemInformation",
     "Win32_System_Threading",
 ] }
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,7 +66,7 @@ Pre-built packages are available for each release on the [GitHub Releases](https
 
 1. **Install Npcap Runtime** (required for packet capture):
    - Download from https://npcap.com/dist/
-   - Run the installer and select **"WinPcap API compatible mode"**
+   - Run the installer. The default settings are supported; WinPcap API-compatible mode is not required
 
 2. **Download and install** the appropriate MSI package:
    - `Rustnet_Windows_64-bit.msi` for 64-bit Windows
@@ -77,7 +77,7 @@ Pre-built packages are available for each release on the [GitHub Releases](https
 4. **Run RustNet**:
    - Open Command Prompt or PowerShell
    - Run: `rustnet.exe`
-   - If Npcap is not installed or not in WinPcap compatible mode, RustNet will display a helpful error message with installation instructions
+   - If Npcap is not installed or cannot be loaded, RustNet will display a helpful error message with installation instructions
    - Note: Depending on your Npcap installation settings, you may or may not need Administrator privileges
 
 ### Windows Chocolatey Installation
@@ -89,7 +89,7 @@ The easiest way to install RustNet on Windows is via [Chocolatey](https://commun
 choco install rustnet
 ```
 
-**Note:** You still need to install [Npcap](https://npcap.com) separately with "WinPcap API compatible mode" enabled.
+**Note:** You still need to install [Npcap](https://npcap.com) separately. The default installer settings are supported.
 
 ### Linux Package Installation
 
@@ -541,8 +541,7 @@ Building RustNet on Windows requires the Npcap SDK and proper environment config
 
 1. **Install Npcap Runtime**:
    - Download the Npcap installer from https://npcap.com/dist/
-   - Run the installer and **select "WinPcap API compatible mode"** during installation
-   - This ensures compatibility with the packet capture library
+   - Run the installer. The default settings are supported; WinPcap API-compatible mode is not required
 
 2. **Run RustNet**:
    ```cmd
@@ -1111,7 +1110,7 @@ for memlock, etc.) that points at the root cause.
 #### Windows: Npcap Not Found
 
 - Ensure Npcap is installed from https://npcap.com/dist/
-- During Npcap installation, select **"WinPcap API compatible mode"**
+- The default Npcap settings are supported; WinPcap API-compatible mode is not required
 - Verify Npcap service is running: `sc query npcap`
 - Try reinstalling Npcap with administrator privileges
 

--- a/INSTALL.zh-CN.md
+++ b/INSTALL.zh-CN.md
@@ -66,7 +66,7 @@
 
 1. **安装 Npcap Runtime**（包捕获必需）：
    - 从 https://npcap.com/dist/ 下载
-   - 运行安装程序并选择 **"WinPcap API compatible mode"**
+   - 运行安装程序。支持默认设置；无需启用 WinPcap API-compatible mode
 
 2. **下载并安装**适合的 MSI 包：
    - 64 位 Windows 使用 `Rustnet_Windows_64-bit.msi`
@@ -77,7 +77,7 @@
 4. **运行 RustNet**：
    - 打开命令提示符或 PowerShell
    - 运行：`rustnet.exe`
-   - 如果未安装 Npcap 或未处于 WinPcap 兼容模式，RustNet 会显示一条有用的错误消息及安装说明
+   - 如果未安装 Npcap 或无法加载 Npcap，RustNet 会显示一条有用的错误消息及安装说明
    - 注意：根据你的 Npcap 安装设置，你可能需要或不需要 Administrator 特权
 
 ### Windows Chocolatey 安装<a id="windows-chocolatey-installation"></a>
@@ -89,7 +89,7 @@
 choco install rustnet
 ```
 
-**注意：** 你仍需要单独安装 [Npcap](https://npcap.com)，并启用 "WinPcap API compatible mode"。
+**注意：** 你仍需要单独安装 [Npcap](https://npcap.com)。支持安装程序的默认设置。
 
 ### Linux 包安装<a id="linux-package-installation"></a>
 
@@ -540,8 +540,7 @@ cargo build --release --no-default-features
 
 1. **安装 Npcap Runtime**：
    - 从 https://npcap.com/dist/ 下载 Npcap 安装程序
-   - 运行安装程序并在安装期间**选择 "WinPcap API compatible mode"**
-   - 这确保与包捕获库的兼容性
+   - 运行安装程序。支持默认设置；无需启用 WinPcap API-compatible mode
 
 2. **运行 RustNet**：
    ```cmd
@@ -1062,7 +1061,7 @@ docker run --cap-add=NET_RAW --cap-add=BPF --cap-add=PERFMON \
 #### Windows：未找到 Npcap<a id="windows-npcap-not-found"></a>
 
 - 确保从 https://npcap.com/dist/ 安装了 Npcap
-- 在 Npcap 安装期间，选择 **"WinPcap API compatible mode"**
+- 支持 Npcap 的默认设置；无需启用 WinPcap API-compatible mode
 - 验证 Npcap 服务正在运行：`sc query npcap`
 - 尝试使用管理员权限重新安装 Npcap
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@ Cargo:
 cargo install rustnet-monitor
 ```
 
-Windows では Npcap を WinPcap API 互換モードでインストールし、管理者 PowerShell で実行します。
+Windows では Npcap を標準設定でインストールできます。WinPcap API 互換モードは不要です。Npcap の設定によっては管理者 PowerShell が必要です。
 
 ```powershell
 choco install rustnet

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cargo install rustnet-monitor
 **Windows (Chocolatey):**
 ```powershell
 # Run in Administrator PowerShell
-# Requires Npcap (https://npcap.com) installed with "WinPcap API-compatible Mode" enabled
+# Requires Npcap (https://npcap.com); default installer settings are supported
 choco install rustnet
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -161,7 +161,7 @@ cargo install rustnet-monitor
 **Windows(Chocolatey):**
 ```powershell
 # 需在管理员权限的 PowerShell 中执行
-# 需要先安装 Npcap(https://npcap.com)，并启用 "WinPcap API-compatible Mode"
+# 需要先安装 Npcap(https://npcap.com)；支持安装程序的默认设置
 choco install rustnet
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,11 @@ fn main() -> Result<()> {
     // Add library search paths for cross-compilation
     setup_cross_compilation_libs();
 
+    // A stock Npcap install keeps wpcap.dll under System32\Npcap, outside the
+    // default loader search path. Delay-loading lets main() add that directory
+    // before Windows resolves the import.
+    setup_windows_npcap_delay_load();
+
     // eBPF program compilation now lives in the rustnet-host crate's build.rs.
 
     #[cfg(target_os = "windows")]
@@ -50,6 +55,16 @@ fn setup_cross_compilation_libs() {
         _ => {
             // For other targets, including native builds, let pkg-config handle it
         }
+    }
+}
+
+fn setup_windows_npcap_delay_load() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+
+    if target_os == "windows" && target_env == "msvc" {
+        println!("cargo:rustc-link-arg=/DELAYLOAD:wpcap.dll");
+        println!("cargo:rustc-link-arg=/DEFAULTLIB:delayimp.lib");
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -8,9 +8,9 @@ fn main() -> Result<()> {
     // Add library search paths for cross-compilation
     setup_cross_compilation_libs();
 
-    // A stock Npcap install keeps wpcap.dll under System32\Npcap, outside the
+    // A stock Npcap install keeps its DLLs under System32\Npcap, outside the
     // default loader search path. Delay-loading lets main() add that directory
-    // before Windows resolves the import.
+    // before Windows resolves the imports.
     setup_windows_npcap_delay_load();
 
     // eBPF program compilation now lives in the rustnet-host crate's build.rs.
@@ -63,6 +63,7 @@ fn setup_windows_npcap_delay_load() {
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
 
     if target_os == "windows" && target_env == "msvc" {
+        println!("cargo:rustc-link-arg=/DELAYLOAD:Packet.dll");
         println!("cargo:rustc-link-arg=/DELAYLOAD:wpcap.dll");
         println!("cargo:rustc-link-arg=/DEFAULTLIB:delayimp.lib");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,14 @@ use std::path::Path;
 use std::time::Duration;
 
 fn main() -> Result<()> {
-    // Check for required dependencies on Windows
-    #[cfg(target_os = "windows")]
-    check_windows_dependencies()?;
-
     // Parse command line arguments
     let matches = cli::build_cli().get_matches();
+
+    // Clap handles --help and --version before this point, so both remain
+    // available even when Npcap is not installed. wpcap.dll is delay-loaded
+    // specifically so Windows can enter main() before resolving that import.
+    #[cfg(target_os = "windows")]
+    initialize_windows_npcap()?;
 
     // Set up logging only if log-level was provided
     if let Some(log_level_str) = matches.get_one::<String>("log-level") {
@@ -1119,15 +1121,46 @@ fn check_privileges_early() -> Result<()> {
 }
 
 #[cfg(target_os = "windows")]
-fn check_windows_dependencies() -> Result<()> {
-    use anyhow::anyhow;
+fn initialize_windows_npcap() -> Result<()> {
+    use anyhow::{Context, anyhow};
+    use windows::Win32::System::LibraryLoader::{LoadLibraryW, SetDllDirectoryW};
+    use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
+    use windows::core::{PCWSTR, w};
 
-    // Check if Npcap/WinPcap DLLs are available
-    // Try to load the DLLs to see if they're in the system path
-    let wpcap_available = check_dll_available("wpcap.dll");
-    let packet_available = check_dll_available("Packet.dll");
+    // Windows paths can exceed MAX_PATH when long-path support is enabled.
+    // The system directory is normally short, but a full-size UTF-16 buffer
+    // avoids depending on that configuration detail.
+    let mut system_directory = vec![0u16; 32_768];
+    let length = unsafe { GetSystemDirectoryW(Some(&mut system_directory)) } as usize;
+    if length == 0 {
+        return Err(anyhow!(windows::core::Error::from_thread()))
+            .context("Failed to locate the Windows system directory");
+    }
+    if length >= system_directory.len() {
+        return Err(anyhow!(
+            "Windows system directory path exceeds the supported length"
+        ));
+    }
 
-    if !wpcap_available || !packet_available {
+    system_directory.truncate(length);
+    if system_directory.last() != Some(&u16::from(b'\\')) {
+        system_directory.push(u16::from(b'\\'));
+    }
+    system_directory.extend("Npcap".encode_utf16());
+    system_directory.push(0);
+
+    let npcap_directory =
+        String::from_utf16_lossy(&system_directory[..system_directory.len().saturating_sub(1)]);
+
+    if let Err(error) = unsafe { SetDllDirectoryW(PCWSTR(system_directory.as_ptr())) } {
+        return Err(anyhow!(error)).with_context(|| {
+            format!("Failed to add the Npcap directory '{npcap_directory}' to the DLL search path")
+        });
+    }
+
+    // Keep the module loaded for the life of the process. When the first pcap
+    // function is called, the delay-load helper reuses this module by name.
+    if let Err(error) = unsafe { LoadLibraryW(w!("wpcap.dll")) } {
         eprintln!(
             "\n╔═══════════════════════════════════════════════════════════════════════════╗"
         );
@@ -1136,58 +1169,22 @@ fn check_windows_dependencies() -> Result<()> {
         eprintln!();
         eprintln!("RustNet requires Npcap for packet capture on Windows.");
         eprintln!();
-
-        if !wpcap_available {
-            eprintln!("  ✗ wpcap.dll not found");
-        }
-        if !packet_available {
-            eprintln!("  ✗ Packet.dll not found");
-        }
-
+        eprintln!("  ✗ Could not load wpcap.dll from {npcap_directory}");
+        eprintln!("    {error}");
         eprintln!();
         eprintln!("To fix this:");
         eprintln!();
         eprintln!("  1. Download Npcap from: https://npcap.com/dist/");
         eprintln!("  2. Run the installer");
-        eprintln!("  3. IMPORTANT: Check \"Install Npcap in WinPcap API-compatible Mode\"");
-        eprintln!("  4. Complete the installation");
+        eprintln!("  3. Complete the installation with the default settings");
         eprintln!();
         eprintln!("After installation, restart your terminal and try again.");
         eprintln!();
 
         return Err(anyhow!(
-            "Npcap is not installed or not in WinPcap compatible mode"
+            "Npcap is not installed or its runtime could not be loaded"
         ));
     }
 
     Ok(())
-}
-
-#[cfg(target_os = "windows")]
-fn check_dll_available(dll_name: &str) -> bool {
-    use std::ffi::CString;
-    use windows::Win32::Foundation::{FreeLibrary, HMODULE};
-    use windows::Win32::System::LibraryLoader::LoadLibraryA;
-    use windows::core::PCSTR;
-
-    // Try to load the DLL
-    let dll_cstring = match CString::new(dll_name) {
-        Ok(s) => s,
-        Err(_) => return false,
-    };
-
-    unsafe {
-        // Use LoadLibraryA to check if the DLL can be loaded
-        let handle = LoadLibraryA(PCSTR(dll_cstring.as_ptr() as *const u8));
-
-        if let Ok(h) = handle
-            && h != HMODULE(std::ptr::null_mut())
-        {
-            // Free the library if it was loaded
-            let _ = FreeLibrary(h);
-            true
-        } else {
-            false
-        }
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();
 
     // Clap handles --help and --version before this point, so both remain
-    // available even when Npcap is not installed. wpcap.dll is delay-loaded
-    // specifically so Windows can enter main() before resolving that import.
+    // available even when Npcap is not installed. The Npcap DLLs are
+    // delay-loaded so Windows can enter main() before resolving those imports.
     #[cfg(target_os = "windows")]
     initialize_windows_npcap()?;
 

--- a/src/network/privileges.rs
+++ b/src/network/privileges.rs
@@ -290,7 +290,7 @@ fn check_windows_privileges() -> Result<PrivilegeStatus> {
 
                 let instructions = vec![
                     "Run as Administrator: Right-click the terminal and select 'Run as Administrator'".to_string(),
-                    "If using Npcap: Ensure it was installed with 'WinPcap API-compatible Mode' enabled".to_string(),
+                    "If using Npcap: Ensure its packet-capture service is running".to_string(),
                 ];
 
                 Ok(PrivilegeStatus::insufficient(missing, instructions))


### PR DESCRIPTION
- Load Npcap from its default Windows system directory.
- Delay-load `wpcap.dll` and validate startup in Windows CI.
- Update Windows setup documentation.

Tests:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`