### PR TITLE
fix(tcp): apply RFC 7323 window scaling to the displayed window size

### DIFF
--- a/benches/connection_merge.rs
+++ b/benches/connection_merge.rs
@@ -35,6 +35,7 @@ fn make_parsed_packet() -> rustnet_monitor::network::parser::ParsedPacket {
             rst: false,
         },
         payload_len: 1400,
+        window_scale: None,
     });
     packet
 }

--- a/benches/tracker_ingest.rs
+++ b/benches/tracker_ingest.rs
@@ -33,6 +33,7 @@ fn make_packet(flow: u16, seq: u32) -> ParsedPacket {
             rst: false,
         },
         payload_len: 1400,
+        window_scale: None,
     });
     packet
 }

--- a/crates/rustnet-core/src/network/merge.rs
+++ b/crates/rustnet-core/src/network/merge.rs
@@ -4,7 +4,7 @@ use log::{debug, info, warn};
 use std::time::{Duration, SystemTime};
 
 use crate::network::dpi::{DpiResult, is_partial_sni, try_extract_tls_from_reassembler};
-use crate::network::parser::{ParsedPacket, TcpFlags};
+use crate::network::parser::{ParsedPacket, SynWindowScale, TcpFlags};
 use crate::network::types::{
     ApplicationProtocol, Connection, DnsInfo, DpiInfo, FtpInfo, HttpInfo, MqttInfo, NetBiosInfo,
     ProtocolState, QuicConnectionState, QuicInfo, SshInfo, TcpState, TlsInfo,
@@ -88,6 +88,9 @@ struct TcpSegment {
     payload_len: u32,
     is_outgoing: bool,
     has_ack_flag: bool,
+    is_syn: bool,
+    /// Window-scale verdict from this segment's options (SYN only).
+    window_scale: Option<SynWindowScale>,
 }
 
 /// Analyze TCP segment and update analytics for retransmissions, packet
@@ -104,11 +107,38 @@ fn analyze_tcp_segment(
         payload_len,
         is_outgoing,
         has_ack_flag,
+        is_syn,
+        window_scale,
     } = segment;
     let mut events = TcpMergeEvents::default();
 
-    // Track window size
+    // Learn each side's window-scale shift from its SYN. Only a fully
+    // examined SYN without the option turns scaling off (RFC 7323); a SYN
+    // whose options could not be examined (truncated capture, malformed
+    // options) proves nothing, and a complete retransmitted SYN may still
+    // supply the shift later.
+    if is_syn {
+        match window_scale {
+            Some(SynWindowScale::Present(shift)) => {
+                if is_outgoing {
+                    analytics.window_scale_out = Some(shift);
+                } else {
+                    analytics.window_scale_in = Some(shift);
+                }
+            }
+            Some(SynWindowScale::Absent) => analytics.window_scaling_disabled = true,
+            Some(SynWindowScale::Unknown) | None => {}
+        }
+    }
+
+    // Track window size. SYN windows are never scaled; for data segments the
+    // sender's negotiated shift applies (0 when the handshake wasn't seen).
     analytics.last_window_size = window;
+    analytics.last_window_shift = if is_syn {
+        0
+    } else {
+        analytics.window_shift_for(is_outgoing)
+    };
 
     if is_outgoing {
         // Outbound packet - check for retransmissions
@@ -309,6 +339,8 @@ pub fn merge_packet_into_connection(
                     payload_len: seq_consumed,
                     is_outgoing: parsed.is_outgoing,
                     has_ack_flag: tcp_header.flags.ack,
+                    is_syn: tcp_header.flags.syn,
+                    window_scale: tcp_header.window_scale,
                 },
                 now,
             );
@@ -1020,6 +1052,7 @@ mod tests {
                     rst: false,
                 },
                 payload_len: 60, // Simulated payload length
+                window_scale: None,
             },
         );
         packet.is_outgoing = is_outgoing;
@@ -1346,6 +1379,8 @@ mod tests {
                 payload_len: len,
                 is_outgoing: true,
                 has_ack_flag: false,
+                is_syn: false,
+                window_scale: None,
             },
             at,
         );
@@ -1372,9 +1407,83 @@ mod tests {
                 payload_len: len,
                 is_outgoing: false,
                 has_ack_flag: true,
+                is_syn: false,
+                window_scale: None,
             },
             at,
         )
+    }
+
+    /// One SYN (or SYN-ACK, via `is_outgoing`/`ack`) with the given
+    /// window-scale verdict and a raw window of 65535.
+    fn syn(analytics: &mut TcpAnalytics, is_outgoing: bool, window_scale: SynWindowScale) {
+        analyze_tcp_segment(
+            analytics,
+            TcpSegment {
+                seq: 0,
+                ack: 0,
+                window: 65535,
+                payload_len: 1,
+                is_outgoing,
+                has_ack_flag: !is_outgoing,
+                is_syn: true,
+                window_scale: Some(window_scale),
+            },
+            t0(),
+        );
+    }
+
+    #[test]
+    fn window_scale_applies_after_observed_handshake() {
+        let mut a = TcpAnalytics::new();
+        syn(&mut a, true, SynWindowScale::Present(7));
+        assert_eq!(a.last_window_shift, 0, "SYN windows are never scaled");
+        syn(&mut a, false, SynWindowScale::Present(8));
+        assert_eq!(a.last_window_shift, 0, "SYN-ACK windows are never scaled");
+
+        recv(&mut a, 1, 1, 100);
+        assert_eq!(a.last_window_shift, 8, "inbound uses the remote's shift");
+        assert_eq!(a.last_window_bytes(), 65535 << 8);
+
+        send(&mut a, 1, 100);
+        assert_eq!(a.last_window_shift, 7, "outbound uses the local shift");
+        assert_eq!(a.last_window_bytes(), 65535 << 7);
+    }
+
+    #[test]
+    fn window_scale_off_when_one_side_lacks_the_option() {
+        let mut a = TcpAnalytics::new();
+        syn(&mut a, true, SynWindowScale::Present(7));
+        syn(&mut a, false, SynWindowScale::Absent); // peer refused scaling
+        recv(&mut a, 1, 1, 100);
+        assert_eq!(a.last_window_shift, 0);
+        assert_eq!(a.last_window_bytes(), 65535);
+    }
+
+    #[test]
+    fn truncated_syn_options_do_not_disable_scaling() {
+        // A SYN-ACK whose options were cut off by the snaplen proves
+        // nothing; a complete retransmitted SYN-ACK must still be able to
+        // enable scaling afterwards.
+        let mut a = TcpAnalytics::new();
+        syn(&mut a, true, SynWindowScale::Present(7));
+        syn(&mut a, false, SynWindowScale::Unknown); // options unexaminable
+        recv(&mut a, 1, 1, 100);
+        assert_eq!(a.last_window_shift, 0, "no conclusion yet, raw window");
+
+        syn(&mut a, false, SynWindowScale::Present(8)); // retransmitted, complete
+        recv(&mut a, 101, 1, 100);
+        assert_eq!(a.last_window_shift, 8);
+        assert_eq!(a.last_window_bytes(), 65535 << 8);
+    }
+
+    #[test]
+    fn window_unscaled_when_handshake_not_observed() {
+        // Connection picked up mid-stream: no SYNs seen, raw value shown.
+        let mut a = TcpAnalytics::new();
+        recv(&mut a, 1, 1, 100);
+        assert_eq!(a.last_window_shift, 0);
+        assert_eq!(a.last_window_bytes(), 65535);
     }
 
     #[test]

--- a/crates/rustnet-core/src/network/parser.rs
+++ b/crates/rustnet-core/src/network/parser.rs
@@ -17,7 +17,7 @@ const AMBIGUOUS_ENDPOINT_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const AMBIGUOUS_ENDPOINT_REFRESH_MAX_INTERVAL: Duration = Duration::from_secs(60);
 
 // Re-export TCP types
-pub use crate::network::protocol::tcp::{TcpFlags, TcpHeaderInfo};
+pub use crate::network::protocol::tcp::{SynWindowScale, TcpFlags, TcpHeaderInfo};
 
 /// Result of parsing a packet
 #[derive(Debug)]

--- a/crates/rustnet-core/src/network/protocol/tcp.rs
+++ b/crates/rustnet-core/src/network/protocol/tcp.rs
@@ -28,6 +28,61 @@ pub struct TcpHeaderInfo {
     pub window: u16,      // Window size
     pub flags: TcpFlags,  // TCP flags
     pub payload_len: u32, // Actual TCP payload length (not including headers)
+    /// Window-scale verdict from the SYN's options (RFC 7323). Only ever
+    /// `Some` on a SYN segment; the option is illegal elsewhere.
+    pub window_scale: Option<SynWindowScale>,
+}
+
+/// What a SYN's options said about window scaling. `Absent` is a proven
+/// negative (the options were walked completely and carried no window-scale
+/// option), which is different from `Unknown` (truncated or malformed
+/// options), where no conclusion may be drawn: treating an unexamined SYN
+/// as a refusal would permanently disable scaling for the connection even
+/// when a complete retransmitted SYN later shows the option.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SynWindowScale {
+    /// The SYN offered window scaling with this shift.
+    Present(u8),
+    /// The options were fully examined and carry no window-scale option.
+    Absent,
+    /// The options could not be fully examined (capture truncation or a
+    /// malformed option); nothing can be concluded.
+    Unknown,
+}
+
+/// Highest shift RFC 7323 permits; larger advertised values are clamped.
+const MAX_WINDOW_SCALE: u8 = 14;
+
+/// Extract the window-scale verdict (option kind 3) from a SYN's option bytes.
+fn parse_window_scale(options: &[u8]) -> SynWindowScale {
+    let mut i = 0;
+    while i < options.len() {
+        match options[i] {
+            0 => return SynWindowScale::Absent, // End of option list
+            1 => i += 1,                        // NOP
+            kind => {
+                let Some(&len) = options.get(i + 1) else {
+                    return SynWindowScale::Unknown; // kind byte without length
+                };
+                let len = len as usize;
+                if len < 2 || i + len > options.len() {
+                    return SynWindowScale::Unknown; // Malformed, stop walking
+                }
+                if kind == 3 {
+                    // Kind 3 is exactly three bytes (RFC 7323); any other
+                    // length is a malformed option (RFC 9293) and proves
+                    // nothing, so it must not end the walk in Absent.
+                    return if len == 3 {
+                        SynWindowScale::Present(options[i + 2].min(MAX_WINDOW_SCALE))
+                    } else {
+                        SynWindowScale::Unknown
+                    };
+                }
+                i += len;
+            }
+        }
+    }
+    SynWindowScale::Absent
 }
 
 /// Parse TCP flags from the flags byte
@@ -81,12 +136,28 @@ pub(crate) fn parse(
     }
     let tcp_payload_len = transport_data.len().saturating_sub(tcp_header_len) as u32;
 
+    // The window-scale option only appears on SYN segments. A capture
+    // truncated before the declared data offset (snaplen) cannot prove the
+    // option absent, so it yields Unknown rather than Absent.
+    let window_scale = if tcp_flags.syn {
+        Some(if transport_data.len() < tcp_header_len {
+            SynWindowScale::Unknown
+        } else if tcp_header_len > 20 {
+            parse_window_scale(&transport_data[20..tcp_header_len])
+        } else {
+            SynWindowScale::Absent
+        })
+    } else {
+        None
+    };
+
     let tcp_header = TcpHeaderInfo {
         seq,
         ack,
         window,
         flags: tcp_flags,
         payload_len: tcp_payload_len,
+        window_scale,
     };
 
     // Log TCP flags for debugging
@@ -146,5 +217,52 @@ mod tests {
         let flags = parse_tcp_flags(0x11); // FIN + ACK
         assert!(flags.fin);
         assert!(flags.ack);
+    }
+
+    #[test]
+    fn window_scale_option_parsed() {
+        // MSS (kind 2, len 4), NOP, window scale (kind 3, len 3, shift 7)
+        let options = [2, 4, 0x05, 0xb4, 1, 3, 3, 7];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Present(7));
+    }
+
+    #[test]
+    fn window_scale_proven_absent() {
+        // MSS only, then end-of-options: a complete walk is a proven negative.
+        let options = [2, 4, 0x05, 0xb4, 0, 0, 0, 0];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Absent);
+        // Fully walked without hitting end-of-list is also proven.
+        let options = [2, 4, 0x05, 0xb4];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Absent);
+    }
+
+    #[test]
+    fn window_scale_clamped_to_rfc_max() {
+        let options = [3, 3, 60];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Present(14));
+    }
+
+    #[test]
+    fn window_scale_unknown_on_malformed_options() {
+        // Malformed options prove nothing: they must not read as a refusal.
+        // Option claims a length running past the buffer
+        let options = [2, 40, 0x05];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Unknown);
+        // Zero-length option must not loop forever
+        let options = [5, 0, 3, 3, 7];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Unknown);
+        // Truncated: kind byte with no length byte
+        let options = [3];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Unknown);
+    }
+
+    #[test]
+    fn window_scale_with_illegal_length_is_unknown() {
+        // Kind 3 is exactly three bytes; other lengths are malformed and
+        // must not read as a proven absence.
+        let options = [3, 2];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Unknown);
+        let options = [3, 4, 7, 0];
+        assert_eq!(parse_window_scale(&options), SynWindowScale::Unknown);
     }
 }

--- a/crates/rustnet-core/src/network/tracker.rs
+++ b/crates/rustnet-core/src/network/tracker.rs
@@ -1126,6 +1126,7 @@ mod tests {
                 window: 65_535,
                 flags: TcpFlags { syn, ack, fin, rst },
                 payload_len: 0,
+                window_scale: None,
             },
         );
         packet.is_outgoing = is_outgoing;

--- a/crates/rustnet-core/src/network/types/rates.rs
+++ b/crates/rustnet-core/src/network/types/rates.rs
@@ -269,8 +269,21 @@ pub struct TcpAnalytics {
     pub out_of_order_count: u64,
     pub fast_retransmit_count: u64,
 
-    // Window tracking
+    // Window tracking. The header field is 16 bits; the real window is that
+    // value shifted by the sender's window-scale option from its SYN
+    // (RFC 7323). Scaling is only in effect when both SYNs offered it, so
+    // both shifts are tracked and a SYN without the option disables scaling.
     pub last_window_size: u16,
+    /// Shift that applies to `last_window_size` (0 when scaling is off,
+    /// unknown, or the segment was a SYN, whose window is never scaled).
+    pub last_window_shift: u8,
+    /// Window-scale shift advertised by the local side's SYN.
+    pub window_scale_out: Option<u8>,
+    /// Window-scale shift advertised by the remote side's SYN.
+    pub window_scale_in: Option<u8>,
+    /// A SYN was observed without the window-scale option, so scaling is
+    /// disabled for the whole connection.
+    pub window_scaling_disabled: bool,
 
     // Continuous RTT estimation. One outbound segment is timed at a time:
     // (sequence end of the timed bytes, capture time it left this host).
@@ -296,8 +309,38 @@ impl TcpAnalytics {
             out_of_order_count: 0,
             fast_retransmit_count: 0,
             last_window_size: 0,
+            last_window_shift: 0,
+            window_scale_out: None,
+            window_scale_in: None,
+            window_scaling_disabled: false,
             rtt_probe: None,
             smoothed_rtt: None,
+        }
+    }
+
+    /// Last advertised window in bytes, with the sender's window-scale
+    /// shift applied when the handshake negotiated one. Falls back to the
+    /// raw header value when the handshake was not observed.
+    pub fn last_window_bytes(&self) -> u64 {
+        (self.last_window_size as u64) << self.last_window_shift
+    }
+
+    /// Shift applying to a non-SYN segment sent in the given direction:
+    /// the sender's own advertised shift, but only when both sides offered
+    /// the option (RFC 7323) and neither SYN explicitly lacked it.
+    pub(crate) fn window_shift_for(&self, is_outgoing: bool) -> u8 {
+        if self.window_scaling_disabled {
+            return 0;
+        }
+        match (self.window_scale_out, self.window_scale_in) {
+            (Some(out), Some(inn)) => {
+                if is_outgoing {
+                    out
+                } else {
+                    inn
+                }
+            }
+            _ => 0,
         }
     }
 }

--- a/src/app/capture.rs
+++ b/src/app/capture.rs
@@ -838,6 +838,7 @@ mod connection_lifecycle_tests {
             window: 65_535,
             flags,
             payload_len: 0,
+            window_scale: None,
         });
         packet
     }

--- a/src/app/pcapng_export.rs
+++ b/src/app/pcapng_export.rs
@@ -472,6 +472,7 @@ mod pcapng_export_tests {
                 rst: false,
             },
             payload_len: 0,
+            window_scale: None,
         });
         let outcome = tracker.ingest_at(&packet, std::time::SystemTime::now());
         let key = outcome.key;

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -1757,7 +1757,7 @@ pub(in crate::ui) fn draw_connection_details(
                 "Fast Retransmits",
                 counters.map(|a| a.fast_retransmit_count),
             ),
-            ("Window Size", counters.map(|a| a.last_window_size as u64)),
+            ("Window Size", counters.map(|a| a.last_window_bytes())),
         ] {
             details.field(
                 label,


### PR DESCRIPTION
- Parse the window-scale option from SYN segments
- Track per-direction shifts and apply the sender's shift to the Details Window Size, which previously showed the raw 16-bit field (understated by up to 2^14)
- Tri-state option parse: Present / Absent (options fully examined) / Unknown (truncated capture, malformed option, or kind-3 with an illegal length); only a proven Absent disables scaling, so a complete retransmitted SYN can still enable it
- Raw value still shown when the handshake was not observed or either side declined scaling