### PR TITLE
fix(windows): embed UTF-8 active-code-page manifest

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,9 +13,31 @@ fn main() -> Result<()> {
     #[cfg(target_os = "windows")]
     download_windows_npcap_sdk()?;
 
+    embed_windows_manifest();
+
     println!("cargo:rerun-if-changed=src/cli.rs");
 
     Ok(())
+}
+
+/// Embed the UTF-8 active-code-page application manifest on MSVC Windows
+/// targets, the only Windows toolchain releases ship. Two plain linker
+/// flags, no build dependency; see the manifest file for why it exists.
+/// The GNU toolchain would need a compiled resource object instead and is
+/// deliberately left as-is (no manifest, today's behavior).
+fn embed_windows_manifest() {
+    let target = env::var("TARGET").unwrap_or_default();
+    if !target.contains("windows-msvc") {
+        return;
+    }
+    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap_or_default())
+        .join("resources/packaging/windows/rustnet.exe.manifest");
+    println!("cargo:rerun-if-changed={}", manifest.display());
+    println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
+    println!(
+        "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
+        manifest.display()
+    );
 }
 
 include!("src/cli.rs");

--- a/resources/packaging/windows/rustnet.exe.manifest
+++ b/resources/packaging/windows/rustnet.exe.manifest
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Declares UTF-8 as the process's active code page (Windows 10 1903+).
+     Npcap returns device descriptions and error strings in the ANSI code
+     page; on systems where that page is not UTF-8 (e.g. CP936), the pcap
+     crate's strict UTF-8 decoding would otherwise fail on any non-ASCII
+     text, breaking device listing and masking capture errors. -->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
On non-UTF-8 system code pages (e.g. CP936), Npcap returns ANSI-encoded device descriptions and error strings that the pcap crate strict-decodes as UTF-8, breaking device listing. Embed an application manifest declaring UTF-8 as the active code page (Windows 10 1903+).

No new dependency: a checked-in manifest file plus /MANIFEST:EMBED and /MANIFESTINPUT linker flags, applied only to windows-msvc targets (the only Windows toolchain releases ship).

Compile-verified only; needs a run on a real Windows host with a non-UTF-8 locale.