### PR TITLE
fix(ui): Graph tab degrades gracefully on small terminals

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2404,6 +2404,29 @@ mod snapshot_tests {
         });
     }
 
+    /// A stock 80x24 terminal cannot hold all three Graph sections; the
+    /// fixed-height rows drop from the bottom up so the waves and the
+    /// health row render at full height instead of all three squeezed.
+    #[test]
+    fn graph_tab_small_terminal_drops_bottom_sections() {
+        let app = test_app();
+        app.set_connections_snapshot_for_test(sample_connections());
+        app.set_traffic_history_for_test(TrafficHistory::new(60));
+
+        let ui_state = UIState {
+            selected_tab: 3, // Graph
+            ..Default::default()
+        };
+        let connections = app.get_connections();
+        let output = render_app(&app, &ui_state, &connections, None, 80, 24);
+
+        insta::with_settings!({
+            filters => time_filters(),
+        }, {
+            insta::assert_snapshot!(output);
+        });
+    }
+
     #[test]
     fn loading_screen_via_app() {
         let app = App::new(test_config()).expect("App::new");

--- a/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__graph_tab_small_terminal_drops_bottom_sections.snap
+++ b/src/ui/snapshots/rustnet_monitor__ui__snapshot_tests__graph_tab_small_terminal_drops_bottom_sections.snap
@@ -1,0 +1,29 @@
+---
+source: src/ui/mod.rs
+assertion_line: 2426
+expression: output
+---
+ rustnet    1 Overview   2 Details   3 Activity   4 Graph   5 Host        ● eth0
+──────────────────────────────────────────────────━━━━━━━───────────────────────
+▎ Traffic Over Time (60s)                               ▎ Connection Lifecycle  
+Waiting for traffic data...                             Waiting for connection d
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+▎ Observed Network Health   ▎ TCP Counters              ▎ Observed TCP States   
+Waiting for health data...    Retransmits         0          ESTAB ███████    2 
+                              Out of Order        0      TIME_WAIT ███    1     
+                              Fast Retrans        0                             
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+ esc back                                                        h help  q quit

--- a/src/ui/tabs/graph.rs
+++ b/src/ui/tabs/graph.rs
@@ -123,14 +123,29 @@ pub(in crate::ui) fn draw_graph_tab(
     // and distribution rows hold a handful of lines each, so they get
     // fixed heights and the wave panels absorb the rest — percentage
     // sizing left a large hole between sections on tall terminals.
+    //
+    // The three sections plus spacing need 32 rows. Smaller terminals
+    // (a stock 80x24 leaves ~20 content rows) drop the fixed-height rows
+    // from the bottom up instead of rendering all three squeezed beyond
+    // recognition: first the distribution row, then the health row, so
+    // the waves always keep their minimum height.
+    const WAVE_MIN_ROWS: u16 = 8;
+    const HEALTH_ROWS: u16 = 10;
+    const DISTRIBUTION_ROWS: u16 = 12;
+    let show_distribution = area.height >= WAVE_MIN_ROWS + 1 + HEALTH_ROWS + 1 + DISTRIBUTION_ROWS;
+    let show_health = area.height >= WAVE_MIN_ROWS + 1 + HEALTH_ROWS;
+
+    let mut constraints = vec![Constraint::Min(WAVE_MIN_ROWS)]; // Traffic + connections waves
+    if show_health {
+        constraints.push(Constraint::Length(HEALTH_ROWS)); // Network health + TCP counters/states
+    }
+    if show_distribution {
+        constraints.push(Constraint::Length(DISTRIBUTION_ROWS)); // App distribution + top processes
+    }
     let main_chunks = Layout::default()
         .direction(Direction::Vertical)
         .spacing(1)
-        .constraints([
-            Constraint::Min(8),     // Traffic + connections waves
-            Constraint::Length(10), // Network health + TCP counters/states
-            Constraint::Length(12), // App distribution + top processes
-        ])
+        .constraints(constraints)
         .split(area);
 
     let top_chunks = Layout::default()
@@ -139,29 +154,33 @@ pub(in crate::ui) fn draw_graph_tab(
         .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
         .split(main_chunks[0]);
 
-    let health_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .spacing(2)
-        .constraints([
-            Constraint::Percentage(35),
-            Constraint::Percentage(35),
-            Constraint::Percentage(30),
-        ])
-        .split(main_chunks[1]);
-
-    let bottom_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .spacing(2)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(main_chunks[2]);
-
     draw_traffic_chart(f, &traffic_history, top_chunks[0]);
     draw_connection_lifecycle(f, &traffic_history, top_chunks[1]);
-    draw_health_chart(f, &traffic_history, health_chunks[0]);
-    draw_tcp_counters(f, app, health_chunks[1]);
-    draw_tcp_states(f, &analytics.tcp_state_counts, health_chunks[2]);
-    draw_app_distribution(f, &analytics.app_distribution, bottom_chunks[0]);
-    draw_top_processes(f, &analytics.process_traffic, bottom_chunks[1]);
+
+    if show_health {
+        let health_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .spacing(2)
+            .constraints([
+                Constraint::Percentage(35),
+                Constraint::Percentage(35),
+                Constraint::Percentage(30),
+            ])
+            .split(main_chunks[1]);
+        draw_health_chart(f, &traffic_history, health_chunks[0]);
+        draw_tcp_counters(f, app, health_chunks[1]);
+        draw_tcp_states(f, &analytics.tcp_state_counts, health_chunks[2]);
+    }
+
+    if show_distribution {
+        let bottom_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .spacing(2)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(main_chunks[2]);
+        draw_app_distribution(f, &analytics.app_distribution, bottom_chunks[0]);
+        draw_top_processes(f, &analytics.process_traffic, bottom_chunks[1]);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
The Graph tab layout needs 32 rows, so a stock 80x24 terminal squeezed all three sections beyond recognition. The fixed-height rows now drop from the bottom up (distribution first, then health), keeping the waves at full height. Snapshot test at 80x24 added.