### PR TITLE
fix(windows): accept friendly interface names for -i

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,6 +2645,7 @@ dependencies = [
  "anyhow",
  "log",
  "pcap",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/USAGE.md
+++ b/USAGE.md
@@ -136,6 +136,11 @@ rustnet -i eth0          # Monitor Ethernet interface
 rustnet -i wlan0         # Monitor WiFi interface
 rustnet -i en0           # Monitor macOS primary interface
 
+# Windows: use the adapter's friendly name; it is resolved to the
+# \Device\NPF_{GUID} device automatically
+rustnet -i Ethernet
+rustnet -i "Wi-Fi"
+
 # Monitor VPN and tunnel interfaces (TUN/TAP support)
 rustnet -i utun0         # macOS VPN tunnel (TUN, Layer 3)
 rustnet -i tun0          # Linux/BSD VPN tunnel (TUN, Layer 3)

--- a/USAGE.zh-CN.md
+++ b/USAGE.zh-CN.md
@@ -136,6 +136,11 @@ rustnet -i eth0          # 监控以太网接口
 rustnet -i wlan0         # 监控 WiFi 接口
 rustnet -i en0           # 监控 macOS 主接口
 
+# Windows：可直接使用适配器的友好名称，会自动解析为
+# \Device\NPF_{GUID} 设备
+rustnet -i Ethernet
+rustnet -i "Wi-Fi"
+
 # 监控 VPN 和隧道接口（TUN/TAP 支持）
 rustnet -i utun0         # macOS VPN 隧道（TUN，Layer 3）
 rustnet -i tun0          # Linux/BSD VPN 隧道（TUN，Layer 3）

--- a/crates/rustnet-capture/Cargo.toml
+++ b/crates/rustnet-capture/Cargo.toml
@@ -25,3 +25,10 @@ path = "src/lib.rs"
 anyhow.workspace = true
 log.workspace = true
 pcap = "2.4.0"
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+] }

--- a/crates/rustnet-capture/src/lib.rs
+++ b/crates/rustnet-capture/src/lib.rs
@@ -356,6 +356,56 @@ pub fn validate_interface(interface_name: &Option<String>) -> Result<()> {
     Ok(())
 }
 
+/// Resolve a Windows interface alias ("Ethernet", "Wi-Fi") to the
+/// `\Device\NPF_{GUID}` name Npcap registers the adapter under, via the
+/// interface table's Alias and InterfaceGuid columns. `None` when no
+/// interface carries that alias.
+#[cfg(windows)]
+fn windows_alias_to_npf_name(alias: &str) -> Option<String> {
+    use windows::Win32::NetworkManagement::IpHelper::{FreeMibTable, GetIfTable2, MIB_IF_TABLE2};
+
+    let alias_lower = alias.to_lowercase();
+    // SAFETY: GetIfTable2 allocates the table, which is freed with
+    // FreeMibTable on every path; rows are only read within NumEntries.
+    unsafe {
+        let mut table: *mut MIB_IF_TABLE2 = std::ptr::null_mut();
+        if GetIfTable2(&mut table).is_err() {
+            return None;
+        }
+        let table_ref = table.as_ref()?;
+
+        let mut guid = None;
+        for i in 0..table_ref.NumEntries as usize {
+            let row = &*table_ref.Table.as_ptr().add(i);
+            let row_alias = String::from_utf16_lossy(&row.Alias)
+                .trim_end_matches('\0')
+                .to_lowercase();
+            if row_alias == alias_lower {
+                guid = Some(row.InterfaceGuid);
+                break;
+            }
+        }
+        FreeMibTable(table as *const _);
+
+        guid.map(|g| {
+            format!(
+                "\\Device\\NPF_{{{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}}}",
+                g.data1,
+                g.data2,
+                g.data3,
+                g.data4[0],
+                g.data4[1],
+                g.data4[2],
+                g.data4[3],
+                g.data4[4],
+                g.data4[5],
+                g.data4[6],
+                g.data4[7],
+            )
+        })
+    }
+}
+
 /// Find a capture device by name or return the default
 fn find_capture_device(interface_name: &Option<String>) -> Result<Device> {
     match interface_name {
@@ -393,8 +443,27 @@ fn find_capture_device(interface_name: &Option<String>) -> Result<Device> {
                 return Ok(device.clone());
             }
 
-            // List available interfaces for error message
-            let available: Vec<String> = devices.iter().map(|d| d.name.clone()).collect();
+            // Windows: pcap device names are `\Device\NPF_{GUID}`, which
+            // nobody types. Resolve a friendly alias ("Ethernet", "Wi-Fi")
+            // to its adapter GUID and retry against the NPF name.
+            #[cfg(windows)]
+            if let Some(npf_name) = windows_alias_to_npf_name(name) {
+                let npf_lower = npf_name.to_lowercase();
+                if let Some(device) = devices.iter().find(|d| d.name.to_lowercase() == npf_lower) {
+                    log::info!("Resolved interface alias '{}' to '{}'", name, device.name);
+                    return Ok(device.clone());
+                }
+            }
+
+            // List available interfaces for the error message, with the
+            // human-readable description where the backend provides one.
+            let available: Vec<String> = devices
+                .iter()
+                .map(|d| match &d.desc {
+                    Some(desc) => format!("{} ({})", d.name, desc),
+                    None => d.name.clone(),
+                })
+                .collect();
 
             Err(anyhow!(
                 "Interface '{}' not found. Available interfaces: {}",


### PR DESCRIPTION
- -i Ethernet / -i "Wi-Fi" failed because only \\Device\\NPF_{GUID} names were matched; the alias is now resolved to its adapter GUID via GetIfTable2 and retried
- The not-found error now lists device descriptions instead of bare GUID paths

Cross-checked (check + clippy) for windows targets; needs runtime verification on a Windows host.