### PR TITLE
feat(dpi): detect WireGuard and OpenVPN

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,6 +109,7 @@ Multiple worker threads (up to 4 by default, based on CPU cores) that parse pack
   - QUIC protocol with CONNECTION_CLOSE frame detection
   - MQTT with packet types, version, and client identifier
   - BitTorrent handshakes and DHT messages
+  - WireGuard and OpenVPN tunnel traffic
   - STUN for WebRTC and NAT traversal
   - NTP with version, mode, and stratum
   - mDNS and LLMNR for local name resolution

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -109,6 +109,7 @@ flowchart LR
   - 带 CONNECTION_CLOSE 帧检测的 QUIC 协议
   - 带报文类型、版本和客户端标识符的 MQTT
   - BitTorrent 握手和 DHT 消息
+  - WireGuard 和 OpenVPN 隧道流量
   - 用于 WebRTC 和 NAT 穿越的 STUN
   - 带版本、模式和 stratum 的 NTP
   - 用于本地名称解析的 mDNS 和 LLMNR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **VPN Traffic Detection**: identify WireGuard and OpenVPN connections through
+  packet signatures, including OpenVPN over UDP and TCP
 - **Host Socket Inventory**: the new Host tab shows TCP LISTEN sockets, UDP
   BOUND endpoints, TCP state totals, observed RTT, process owners, and the
   detailed interface table on Linux, macOS, FreeBSD, and Windows

--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@ RustNet は、各接続を所有するプロセス、通信量、状態、アプ
 ## 主な機能
 
 - TCP、UDP、QUIC 接続とプロセスの対応付け。詳細には PID、実行ファイル、ユーザー/グループ名、照合の信頼度、全プラットフォーム共通の親プロセスチェーン（上限あり）を表示
-- HTTP、TLS/SNI、DNS、SSH、QUIC などの深層パケット解析
+- HTTP、TLS/SNI、DNS、SSH、QUIC、WireGuard、OpenVPN などの深層パケット解析
 - TCP、QUIC ハンドシェイク、DNS 応答、ICMP エコーの往復時間（RTT）と、TCP の再送・順序入れ替わりをリアルタイム表示
 - Host タブに TCP LISTEN ソケット、UDP BOUND エンドポイント、TCP 状態集計、観測 RTT、所有プロセス、インターフェース統計を表示
 - `port:`、`process:`、`sni:`、`state:` などのフィルター

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ## Features
 
 - **Per-process attribution**: Every TCP, UDP, and QUIC connection mapped to its owning process, via eBPF on Linux, PKTAP on macOS, ETW with an automatic IP Helper fallback on Windows, and native APIs on FreeBSD. Details include PID, executable, user/group names, match confidence, and a capped parent-process chain on every platform. Wireshark and tcpdump can't do this; `netstat` / `ss` can't show live state.
-- **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, FTP, QUIC, MQTT, BitTorrent, STUN, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS, without external dissectors.
+- **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, FTP, QUIC, MQTT, BitTorrent, WireGuard, OpenVPN, STUN, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS, without external dissectors.
 - **Annotated PCAPNG export**: `--pcapng-export` writes a Wireshark-ready capture with process, PID, direction, DPI/SNI, and GeoIP embedded as per-packet comments. Open it in Wireshark and every packet already names its owning process, with no post-processing. Classic `--pcap-export` with a JSONL sidecar for offline correlation is also available.
 - **Security sandboxing**: Landlock (Linux 5.13+), Seatbelt (macOS), token privilege drop + job-object child-process block (Windows). Drops privileges immediately after libpcap initializes. See [SECURITY.md](SECURITY.md).
 - **Network analytics**: Real-time round-trip times for TCP, QUIC handshakes, DNS responses, and ICMP echo, plus TCP retransmission, out-of-order, and fast-retransmit detection.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@
 ## 功能特性
 
 - **进程级归属识别**：每一条 TCP、UDP、QUIC 连接都能追溯到所属进程。Linux 使用 eBPF，macOS 使用 PKTAP，Windows 使用 ETW 并在不可用时自动回退到 IP Helper，FreeBSD 则走原生 API。详情会显示 PID、可执行文件、用户/组名称、匹配可信度，以及每个平台都提供的父进程链（有层级上限）。Wireshark 与 tcpdump 做不到这一点；`netstat` / `ss` 也无法展示实时状态。
-- **深度包检测**：无需外部解析器即可识别 HTTP、带 SNI 的 HTTPS/TLS、DNS、SSH、FTP、QUIC、MQTT、BitTorrent、STUN、NTP、mDNS、LLMNR、DHCP、SNMP、SSDP 及 NetBIOS。
+- **深度包检测**：无需外部解析器即可识别 HTTP、带 SNI 的 HTTPS/TLS、DNS、SSH、FTP、QUIC、MQTT、BitTorrent、WireGuard、OpenVPN、STUN、NTP、mDNS、LLMNR、DHCP、SNMP、SSDP 及 NetBIOS。
 - **带注释的 PCAPNG 导出**：`--pcapng-export` 可写出能直接用 Wireshark 打开的捕获文件，并将进程、PID、方向、DPI/SNI 和 GeoIP 作为逐包注释嵌入。每个数据包都会直接标明所属进程，无需后处理。也可使用经典的 `--pcap-export` 配合 JSONL sidecar 进行离线关联。
 - **安全沙箱**：Linux 5.13+ 使用 Landlock，macOS 使用 Seatbelt，Windows 通过 token 降权 + job-object 阻止子进程创建。libpcap 初始化完成后立即丢弃特权。详见 [SECURITY.zh-CN.md](SECURITY.zh-CN.md)。
 - **网络分析**：实时统计 TCP、QUIC 握手、DNS 响应及 ICMP 回显的往返时延，并检测 TCP 重传、乱序包和快重传。

--- a/crates/rustnet-core/README.md
+++ b/crates/rustnet-core/README.md
@@ -13,7 +13,8 @@ to analyze.
 - **Packet parsing** for Ethernet, Linux SLL/SLL2, PKTAP, raw IP, and TUN/TAP
   link layers, plus IPv4/IPv6, TCP, UDP, ICMP, and IGMP.
 - **Deep packet inspection** for HTTP, HTTPS/TLS (SNI extraction), DNS, SSH,
-  QUIC, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, NetBIOS, and more.
+  QUIC, WireGuard, OpenVPN, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, NetBIOS, and
+  more.
 - **Connection merging** — fold parsed packets into long-lived connection
   state with protocol-aware lifecycle tracking and TCP analytics
   (retransmissions, out-of-order, fast-retransmit).

--- a/crates/rustnet-core/assets/services
+++ b/crates/rustnet-core/assets/services
@@ -11605,3 +11605,4 @@ pmwebapi        44323/tcp               # Performance Co-Pilot client HTTP API
 cloudcheck-ping 45514/udp               # ASSIA CloudCheck WiFi Management keepalive
 cloudcheck      45514/tcp               # ASSIA CloudCheck WiFi Management System
 spremotetablet  46998/tcp               # Capture handwritten signatures
+wireguard       51820/udp               # WireGuard

--- a/crates/rustnet-core/src/network/dpi/mod.rs
+++ b/crates/rustnet-core/src/network/dpi/mod.rs
@@ -13,12 +13,14 @@ mod mdns;
 mod mqtt;
 mod netbios;
 mod ntp;
+mod openvpn;
 mod quic;
 mod snmp;
 mod ssdp;
 mod ssh;
 mod stun;
 mod tls_common;
+mod wireguard;
 
 pub(crate) use cipher_suites::{format_cipher_suite, is_secure_cipher_suite};
 pub(crate) use quic::try_extract_tls_from_reassembler;
@@ -42,6 +44,7 @@ const PORT_MDNS: u16 = 5353;
 const PORT_STUN: u16 = 3478;
 const PORT_STUN_TLS: u16 = 5349;
 const PORT_LLMNR: u16 = 5355;
+const PORT_OPENVPN: u16 = 1194;
 
 /// Result of DPI analysis
 #[derive(Debug, Clone)]
@@ -119,6 +122,18 @@ pub(crate) fn analyze_tcp_packet(
     {
         return Some(DpiResult {
             application: ApplicationProtocol::Ftp(ftp_result),
+        });
+    }
+
+    // 7. OpenVPN over TCP uses a two-byte length prefix. On its registered
+    // port we accept all current packet opcodes; elsewhere the analyzer only
+    // accepts a distinctive hard-reset exchange.
+    if let Some(openvpn_result) = openvpn::analyze_openvpn_tcp(
+        payload,
+        local_port == PORT_OPENVPN || remote_port == PORT_OPENVPN,
+    ) {
+        return Some(DpiResult {
+            application: ApplicationProtocol::OpenVpn(openvpn_result),
         });
     }
 
@@ -257,7 +272,25 @@ pub(crate) fn analyze_udp_packet(
         });
     }
 
-    // 12. BitTorrent DHT / uTP (no port gating — signature-based)
+    // 12. WireGuard (fixed message types, reserved bytes, and lengths)
+    if let Some(wireguard_result) = wireguard::analyze_wireguard(payload) {
+        return Some(DpiResult {
+            application: ApplicationProtocol::WireGuard(wireguard_result),
+        });
+    }
+
+    // 13. OpenVPN. The registered port permits all structurally plausible
+    // opcodes; alternate ports require a distinctive hard-reset exchange.
+    if let Some(openvpn_result) = openvpn::analyze_openvpn_udp(
+        payload,
+        local_port == PORT_OPENVPN || remote_port == PORT_OPENVPN,
+    ) {
+        return Some(DpiResult {
+            application: ApplicationProtocol::OpenVpn(openvpn_result),
+        });
+    }
+
+    // 14. BitTorrent DHT / uTP (no port gating, signature-based)
     if let Some(bt_result) = bittorrent::analyze_udp_bittorrent(payload) {
         return Some(DpiResult {
             application: ApplicationProtocol::BitTorrent(bt_result),
@@ -265,4 +298,55 @@ pub(crate) fn analyze_udp_packet(
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::types::{OpenVpnPacketType, WireGuardPacketType};
+
+    #[test]
+    fn dispatches_wireguard_before_bittorrent() {
+        let mut payload = vec![0x5a; 148];
+        payload[..4].copy_from_slice(&[1, 0, 0, 0]);
+
+        let result = analyze_udp_packet(&payload, 50_000, 51_820, true).unwrap();
+        let ApplicationProtocol::WireGuard(info) = result.application else {
+            panic!("expected WireGuard classification");
+        };
+        assert_eq!(info.packet_type, WireGuardPacketType::HandshakeInitiation);
+    }
+
+    #[test]
+    fn dispatches_openvpn_udp_on_registered_port() {
+        let mut payload = vec![0x5a; 20];
+        payload[0] = 9 << 3;
+
+        let result = analyze_udp_packet(&payload, 50_000, PORT_OPENVPN, true).unwrap();
+        let ApplicationProtocol::OpenVpn(info) = result.application else {
+            panic!("expected OpenVPN classification");
+        };
+        assert_eq!(info.packet_type, OpenVpnPacketType::DataV2);
+    }
+
+    #[test]
+    fn dispatches_openvpn_tcp_frame() {
+        let mut packet = vec![0x5a; 14];
+        packet[0] = 7 << 3;
+        packet[9..].fill(0);
+        let mut frame = Vec::with_capacity(16);
+        frame.extend_from_slice(&14u16.to_be_bytes());
+        frame.extend_from_slice(&packet);
+
+        let result = analyze_tcp_packet(&frame, 50_000, PORT_OPENVPN, true).unwrap();
+        assert!(matches!(
+            result.application,
+            ApplicationProtocol::OpenVpn(_)
+        ));
+    }
+
+    #[test]
+    fn registered_port_alone_does_not_classify_random_udp() {
+        assert!(analyze_udp_packet(b"not an OpenVPN packet", 50_000, PORT_OPENVPN, true).is_none());
+    }
 }

--- a/crates/rustnet-core/src/network/dpi/openvpn.rs
+++ b/crates/rustnet-core/src/network/dpi/openvpn.rs
@@ -1,0 +1,197 @@
+use crate::network::types::{OpenVpnInfo, OpenVpnPacketType};
+
+const OPCODE_SHIFT: u8 = 3;
+const KEY_ID_MASK: u8 = 0x07;
+const SESSION_ID_LEN: usize = 8;
+const CONTROL_HEADER_LEN: usize = 1 + SESSION_ID_LEN;
+const DATA_V1_MIN_LEN: usize = 1 + 16;
+const DATA_V2_MIN_LEN: usize = 1 + 3 + 16;
+
+/// Analyze one OpenVPN UDP packet.
+///
+/// On the registered port, the opcode and minimum packet shape provide a
+/// useful classification without pretending to decrypt the payload. Away
+/// from that port, only the highly distinctive plaintext or tls-auth V2 hard
+/// reset exchange is accepted. A tls-crypt packet on an alternate port is
+/// intentionally not guessed from its first random-looking byte alone.
+pub(super) fn analyze_openvpn_udp(
+    payload: &[u8],
+    uses_registered_port: bool,
+) -> Option<OpenVpnInfo> {
+    analyze_packet(payload, uses_registered_port)
+}
+
+/// Analyze an OpenVPN packet carried in its two-byte TCP length frame.
+pub(super) fn analyze_openvpn_tcp(
+    payload: &[u8],
+    uses_registered_port: bool,
+) -> Option<OpenVpnInfo> {
+    let declared_len = usize::from(u16::from_be_bytes([*payload.first()?, *payload.get(1)?]));
+    if declared_len == 0 || payload.len() < declared_len + 2 {
+        return None;
+    }
+
+    analyze_packet(&payload[2..2 + declared_len], uses_registered_port)
+}
+
+fn analyze_packet(payload: &[u8], uses_registered_port: bool) -> Option<OpenVpnInfo> {
+    let header = *payload.first()?;
+    let opcode = header >> OPCODE_SHIFT;
+    let key_id = header & KEY_ID_MASK;
+    let packet_type = OpenVpnPacketType::from_opcode(opcode)?;
+
+    let plausible = match packet_type {
+        OpenVpnPacketType::DataV1 => payload.len() >= DATA_V1_MIN_LEN,
+        OpenVpnPacketType::DataV2 => payload.len() >= DATA_V2_MIN_LEN,
+        _ => {
+            payload.len() >= CONTROL_HEADER_LEN
+                && payload[1..CONTROL_HEADER_LEN].iter().any(|byte| *byte != 0)
+        }
+    };
+    if !plausible {
+        return None;
+    }
+
+    if !uses_registered_port && !is_distinctive_hard_reset(payload, packet_type, key_id) {
+        return None;
+    }
+
+    Some(OpenVpnInfo {
+        packet_type,
+        key_id,
+    })
+}
+
+fn is_distinctive_hard_reset(payload: &[u8], packet_type: OpenVpnPacketType, key_id: u8) -> bool {
+    if key_id != 0 {
+        return false;
+    }
+
+    match packet_type {
+        // An unwrapped client reset, and a tls-auth client reset after its
+        // HMAC fields, both end in an empty ACK array and message ID zero.
+        OpenVpnPacketType::ControlHardResetClientV2 => {
+            payload.len() >= CONTROL_HEADER_LEN + 5 && payload.ends_with(&[0; 5])
+        }
+        // The unwrapped server reset ACKs client packet zero, carries the
+        // client's non-zero session ID, and sends its own message ID zero.
+        OpenVpnPacketType::ControlHardResetServerV2 => {
+            payload.len() >= 26
+                && payload[9] == 1
+                && payload[10..14] == [0; 4]
+                && payload[14..22].iter().any(|byte| *byte != 0)
+                && payload[22..26] == [0; 4]
+        }
+        _ => false,
+    }
+}
+
+impl OpenVpnPacketType {
+    fn from_opcode(opcode: u8) -> Option<Self> {
+        match opcode {
+            3 => Some(Self::ControlSoftReset),
+            4 => Some(Self::Control),
+            5 => Some(Self::Ack),
+            6 => Some(Self::DataV1),
+            7 => Some(Self::ControlHardResetClientV2),
+            8 => Some(Self::ControlHardResetServerV2),
+            9 => Some(Self::DataV2),
+            10 => Some(Self::ControlHardResetClientV3),
+            11 => Some(Self::ControlWithWrappedKey),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn control_packet(opcode: u8, key_id: u8, len: usize) -> Vec<u8> {
+        let mut payload = vec![0x5a; len];
+        payload[0] = (opcode << OPCODE_SHIFT) | key_id;
+        payload
+    }
+
+    fn client_reset_v2() -> Vec<u8> {
+        let mut payload = control_packet(7, 0, 14);
+        payload[9..].fill(0);
+        payload
+    }
+
+    #[test]
+    fn recognizes_registered_port_udp_packets() {
+        let control = control_packet(4, 3, CONTROL_HEADER_LEN);
+        let info = analyze_openvpn_udp(&control, true).unwrap();
+        assert_eq!(info.packet_type, OpenVpnPacketType::Control);
+        assert_eq!(info.key_id, 3);
+
+        let data_v1 = control_packet(6, 1, DATA_V1_MIN_LEN);
+        assert_eq!(
+            analyze_openvpn_udp(&data_v1, true).unwrap().packet_type,
+            OpenVpnPacketType::DataV1
+        );
+
+        let data_v2 = control_packet(9, 7, DATA_V2_MIN_LEN);
+        assert_eq!(
+            analyze_openvpn_udp(&data_v2, true).unwrap().packet_type,
+            OpenVpnPacketType::DataV2
+        );
+    }
+
+    #[test]
+    fn recognizes_complete_tcp_frame() {
+        let packet = client_reset_v2();
+        let mut frame = Vec::with_capacity(packet.len() + 2);
+        frame.extend_from_slice(&(packet.len() as u16).to_be_bytes());
+        frame.extend_from_slice(&packet);
+
+        let info = analyze_openvpn_tcp(&frame, false).unwrap();
+        assert_eq!(
+            info.packet_type,
+            OpenVpnPacketType::ControlHardResetClientV2
+        );
+
+        frame[1] += 1;
+        assert!(analyze_openvpn_tcp(&frame, true).is_none());
+    }
+
+    #[test]
+    fn alternate_port_requires_distinctive_reset() {
+        assert!(analyze_openvpn_udp(&client_reset_v2(), false).is_some());
+
+        let mut tls_auth_reset = control_packet(7, 0, 42);
+        let len = tls_auth_reset.len();
+        tls_auth_reset[len - 5..].fill(0);
+        assert!(analyze_openvpn_udp(&tls_auth_reset, false).is_some());
+
+        assert!(analyze_openvpn_udp(&control_packet(4, 0, 32), false).is_none());
+        assert!(analyze_openvpn_udp(&control_packet(7, 1, 14), false).is_none());
+    }
+
+    #[test]
+    fn recognizes_unwrapped_server_reset_off_port() {
+        let mut payload = control_packet(8, 0, 26);
+        payload[9] = 1;
+        payload[10..14].fill(0);
+        payload[14..22].copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        payload[22..26].fill(0);
+        assert!(analyze_openvpn_udp(&payload, false).is_some());
+
+        payload[10] = 1;
+        assert!(analyze_openvpn_udp(&payload, false).is_none());
+    }
+
+    #[test]
+    fn rejects_invalid_packets() {
+        assert!(analyze_openvpn_udp(&[], true).is_none());
+        assert!(analyze_openvpn_udp(&control_packet(2, 0, 32), true).is_none());
+
+        let mut zero_session = control_packet(7, 0, 14);
+        zero_session[1..CONTROL_HEADER_LEN].fill(0);
+        assert!(analyze_openvpn_udp(&zero_session, true).is_none());
+
+        assert!(analyze_openvpn_udp(&control_packet(6, 0, DATA_V1_MIN_LEN - 1), true).is_none());
+        assert!(analyze_openvpn_udp(&control_packet(9, 0, DATA_V2_MIN_LEN - 1), true).is_none());
+    }
+}

--- a/crates/rustnet-core/src/network/dpi/wireguard.rs
+++ b/crates/rustnet-core/src/network/dpi/wireguard.rs
@@ -1,0 +1,73 @@
+use crate::network::types::{WireGuardInfo, WireGuardPacketType};
+
+const HANDSHAKE_INITIATION_LEN: usize = 148;
+const HANDSHAKE_RESPONSE_LEN: usize = 92;
+const COOKIE_REPLY_LEN: usize = 64;
+const TRANSPORT_HEADER_LEN: usize = 16;
+const AUTH_TAG_LEN: usize = 16;
+
+/// Identify a WireGuard UDP message from its fixed wire shape.
+///
+/// Every message starts with a little-endian type word whose upper three
+/// bytes are reserved and zero. Handshake and cookie messages have fixed
+/// lengths. Transport messages contain a 16-byte header followed by a
+/// possibly empty, block-padded ciphertext and a 16-byte authentication tag.
+pub(super) fn analyze_wireguard(payload: &[u8]) -> Option<WireGuardInfo> {
+    if payload.get(1..4)? != [0, 0, 0] {
+        return None;
+    }
+
+    let packet_type = match (payload[0], payload.len()) {
+        (1, HANDSHAKE_INITIATION_LEN) => WireGuardPacketType::HandshakeInitiation,
+        (2, HANDSHAKE_RESPONSE_LEN) => WireGuardPacketType::HandshakeResponse,
+        (3, COOKIE_REPLY_LEN) => WireGuardPacketType::CookieReply,
+        (4, len) if len >= TRANSPORT_HEADER_LEN + AUTH_TAG_LEN && len.is_multiple_of(16) => {
+            WireGuardPacketType::TransportData
+        }
+        _ => return None,
+    };
+
+    Some(WireGuardInfo { packet_type })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(message_type: u8, len: usize) -> Vec<u8> {
+        let mut payload = vec![0x5a; len];
+        payload[..4].copy_from_slice(&[message_type, 0, 0, 0]);
+        payload
+    }
+
+    #[test]
+    fn recognizes_all_message_types() {
+        let cases = [
+            (1, 148, WireGuardPacketType::HandshakeInitiation),
+            (2, 92, WireGuardPacketType::HandshakeResponse),
+            (3, 64, WireGuardPacketType::CookieReply),
+            (4, 32, WireGuardPacketType::TransportData),
+            (4, 1440, WireGuardPacketType::TransportData),
+        ];
+
+        for (message_type, len, expected) in cases {
+            let info = analyze_wireguard(&message(message_type, len)).unwrap();
+            assert_eq!(info.packet_type, expected);
+        }
+    }
+
+    #[test]
+    fn rejects_reserved_bytes_and_wrong_lengths() {
+        let mut reserved = message(1, HANDSHAKE_INITIATION_LEN);
+        reserved[2] = 1;
+        assert!(analyze_wireguard(&reserved).is_none());
+
+        assert!(analyze_wireguard(&message(1, HANDSHAKE_INITIATION_LEN - 1)).is_none());
+        assert!(analyze_wireguard(&message(2, HANDSHAKE_RESPONSE_LEN + 1)).is_none());
+        assert!(analyze_wireguard(&message(3, COOKIE_REPLY_LEN - 1)).is_none());
+        assert!(analyze_wireguard(&message(4, 31)).is_none());
+        assert!(analyze_wireguard(&message(4, 33)).is_none());
+        assert!(analyze_wireguard(&message(5, 64)).is_none());
+        assert!(analyze_wireguard(&[]).is_none());
+    }
+}

--- a/crates/rustnet-core/src/network/services.rs
+++ b/crates/rustnet-core/src/network/services.rs
@@ -90,6 +90,7 @@ impl ServiceLookup {
         lookup.add_service(587, Protocol::Tcp, "submission");
         lookup.add_service(993, Protocol::Tcp, "imaps");
         lookup.add_service(995, Protocol::Tcp, "pop3s");
+        lookup.add_service(1194, Protocol::Tcp, "openvpn");
         lookup.add_service(1433, Protocol::Tcp, "mssql");
         lookup.add_service(3306, Protocol::Tcp, "mysql");
         lookup.add_service(3389, Protocol::Tcp, "rdp");
@@ -111,6 +112,7 @@ impl ServiceLookup {
         lookup.add_service(1194, Protocol::Udp, "openvpn");
         lookup.add_service(4500, Protocol::Udp, "ipsec-nat");
         lookup.add_service(5060, Protocol::Udp, "sip");
+        lookup.add_service(51820, Protocol::Udp, "wireguard");
 
         lookup
     }
@@ -144,5 +146,17 @@ mod tests {
         assert_eq!(lookup.lookup(443, Protocol::Tcp), Some("https"));
         assert_eq!(lookup.lookup(22, Protocol::Tcp), Some("ssh"));
         assert_eq!(lookup.lookup(53, Protocol::Udp), Some("dns"));
+        assert_eq!(lookup.lookup(1194, Protocol::Tcp), Some("openvpn"));
+        assert_eq!(lookup.lookup(1194, Protocol::Udp), Some("openvpn"));
+        assert_eq!(lookup.lookup(51820, Protocol::Udp), Some("wireguard"));
+    }
+
+    #[test]
+    fn test_embedded_vpn_services() {
+        let lookup = ServiceLookup::from_embedded().unwrap();
+
+        assert_eq!(lookup.lookup(1194, Protocol::Tcp), Some("openvpn"));
+        assert_eq!(lookup.lookup(1194, Protocol::Udp), Some("openvpn"));
+        assert_eq!(lookup.lookup(51820, Protocol::Udp), Some("wireguard"));
     }
 }

--- a/crates/rustnet-core/src/network/types/connection.rs
+++ b/crates/rustnet-core/src/network/types/connection.rs
@@ -44,7 +44,9 @@ impl AppProtocolDistribution {
                 | ApplicationProtocol::BitTorrent(_)
                 | ApplicationProtocol::Stun(_)
                 | ApplicationProtocol::Mqtt(_)
-                | ApplicationProtocol::Ftp(_) => self.other_count += 1,
+                | ApplicationProtocol::Ftp(_)
+                | ApplicationProtocol::WireGuard(_)
+                | ApplicationProtocol::OpenVpn(_) => self.other_count += 1,
             }
         } else {
             self.other_count += 1;
@@ -470,6 +472,8 @@ impl Connection {
                         }
                         ApplicationProtocol::Mqtt(_) => Cow::Borrowed("MQTT_UDP"),
                         ApplicationProtocol::Ftp(_) => Cow::Borrowed("FTP_UDP"),
+                        ApplicationProtocol::WireGuard(_) => Cow::Borrowed("WIREGUARD"),
+                        ApplicationProtocol::OpenVpn(_) => Cow::Borrowed("OPENVPN"),
                     }
                 } else {
                     // Regular UDP without DPI classification
@@ -591,6 +595,8 @@ impl Connection {
                         ApplicationProtocol::Stun(_) => Duration::from_secs(30),
                         ApplicationProtocol::Mqtt(_) => Duration::from_secs(120),
                         ApplicationProtocol::Ftp(_) => Duration::from_secs(60),
+                        ApplicationProtocol::WireGuard(_) => Duration::from_secs(300),
+                        ApplicationProtocol::OpenVpn(_) => Duration::from_secs(300),
                     }
                 } else {
                     // Regular UDP without DPI classification

--- a/crates/rustnet-core/src/network/types/protocol_info.rs
+++ b/crates/rustnet-core/src/network/types/protocol_info.rs
@@ -144,6 +144,67 @@ pub struct MqttInfo {
     pub qos: Option<u8>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireGuardPacketType {
+    HandshakeInitiation,
+    HandshakeResponse,
+    CookieReply,
+    TransportData,
+}
+
+impl fmt::Display for WireGuardPacketType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            WireGuardPacketType::HandshakeInitiation => "Handshake Initiation",
+            WireGuardPacketType::HandshakeResponse => "Handshake Response",
+            WireGuardPacketType::CookieReply => "Cookie Reply",
+            WireGuardPacketType::TransportData => "Transport Data",
+        };
+        f.write_str(name)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WireGuardInfo {
+    pub packet_type: WireGuardPacketType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenVpnPacketType {
+    ControlSoftReset,
+    Control,
+    Ack,
+    DataV1,
+    DataV2,
+    ControlHardResetClientV2,
+    ControlHardResetServerV2,
+    ControlHardResetClientV3,
+    ControlWithWrappedKey,
+}
+
+impl fmt::Display for OpenVpnPacketType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            OpenVpnPacketType::ControlSoftReset => "Control Soft Reset",
+            OpenVpnPacketType::Control => "Control",
+            OpenVpnPacketType::Ack => "ACK",
+            OpenVpnPacketType::DataV1 => "Data v1",
+            OpenVpnPacketType::DataV2 => "Data v2",
+            OpenVpnPacketType::ControlHardResetClientV2 => "Client Hard Reset v2",
+            OpenVpnPacketType::ControlHardResetServerV2 => "Server Hard Reset v2",
+            OpenVpnPacketType::ControlHardResetClientV3 => "Client Hard Reset v3",
+            OpenVpnPacketType::ControlWithWrappedKey => "Control with Wrapped Key",
+        };
+        f.write_str(name)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenVpnInfo {
+    pub packet_type: OpenVpnPacketType,
+    pub key_id: u8,
+}
+
 #[derive(Debug, Clone)]
 pub enum ApplicationProtocol {
     Http(HttpInfo),
@@ -162,6 +223,8 @@ pub enum ApplicationProtocol {
     Stun(StunInfo),
     Mqtt(MqttInfo),
     Ftp(FtpInfo),
+    WireGuard(WireGuardInfo),
+    OpenVpn(OpenVpnInfo),
 }
 
 impl ApplicationProtocol {
@@ -179,11 +242,13 @@ impl ApplicationProtocol {
             ApplicationProtocol::Mqtt(_) => "MQTT",
             ApplicationProtocol::NetBios(_) => "NetBIOS",
             ApplicationProtocol::Ntp(_) => "NTP",
+            ApplicationProtocol::OpenVpn(_) => "OpenVPN",
             ApplicationProtocol::Quic(_) => "QUIC",
             ApplicationProtocol::Snmp(_) => "SNMP",
             ApplicationProtocol::Ssh(_) => "SSH",
             ApplicationProtocol::Ssdp(_) => "SSDP",
             ApplicationProtocol::Stun(_) => "STUN",
+            ApplicationProtocol::WireGuard(_) => "WireGuard",
         }
     }
 
@@ -363,6 +428,8 @@ impl std::fmt::Display for ApplicationProtocol {
                     }
                 }
             },
+            ApplicationProtocol::WireGuard(_) => write!(f, "WireGuard"),
+            ApplicationProtocol::OpenVpn(_) => write!(f, "OpenVPN"),
         }
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -529,6 +529,18 @@ impl ConnectionFilter {
                     return true;
                 }
             }
+            ApplicationProtocol::WireGuard(info) => {
+                if match_text(&info.packet_type.to_string(), fv) {
+                    return true;
+                }
+            }
+            ApplicationProtocol::OpenVpn(info) => {
+                if match_text(&info.packet_type.to_string(), fv)
+                    || match_text(&info.key_id.to_string(), fv)
+                {
+                    return true;
+                }
+            }
         }
 
         false

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2448,10 +2448,11 @@ mod snapshot_tests {
             ApplicationProtocol, BitTorrentInfo, BitTorrentType, DhcpInfo, DhcpMessageType,
             DnsInfo, DnsQueryType, FtpInfo, FtpMessageType, HttpInfo, HttpVersion, HttpsInfo,
             LlmnrInfo, MdnsInfo, MqttInfo, MqttPacketType, MqttVersion, NetBiosInfo, NetBiosOpcode,
-            NetBiosResponseStatus, NetBiosService, NtpInfo, NtpMode, QuicConnectionState, QuicInfo,
-            QuicPacketType, SnmpInfo, SnmpPduType, SnmpVersion, SsdpInfo, SsdpMethod,
-            SshConnectionState, SshInfo, SshVersion, StunInfo, StunMessageClass, StunMethod,
-            TlsInfo, TlsVersion,
+            NetBiosResponseStatus, NetBiosService, NtpInfo, NtpMode, OpenVpnInfo,
+            OpenVpnPacketType, QuicConnectionState, QuicInfo, QuicPacketType, SnmpInfo,
+            SnmpPduType, SnmpVersion, SsdpInfo, SsdpMethod, SshConnectionState, SshInfo,
+            SshVersion, StunInfo, StunMessageClass, StunMethod, TlsInfo, TlsVersion, WireGuardInfo,
+            WireGuardPacketType,
         };
 
         let tls_info = TlsInfo {
@@ -2573,6 +2574,13 @@ mod snapshot_tests {
                 server_software: Some("vsftpd 3.0.5".to_string()),
                 system_type: Some("UNIX".to_string()),
             }),
+            ApplicationProtocol::WireGuard(WireGuardInfo {
+                packet_type: WireGuardPacketType::HandshakeInitiation,
+            }),
+            ApplicationProtocol::OpenVpn(OpenVpnInfo {
+                packet_type: OpenVpnPacketType::ControlHardResetClientV2,
+                key_id: 0,
+            }),
         ];
 
         let mut seen = std::collections::HashSet::new();
@@ -2601,11 +2609,13 @@ mod snapshot_tests {
                 ApplicationProtocol::Stun(_) => {}
                 ApplicationProtocol::Mqtt(_) => {}
                 ApplicationProtocol::Ftp(_) => {}
+                ApplicationProtocol::WireGuard(_) => {}
+                ApplicationProtocol::OpenVpn(_) => {}
             }
         }
         assert_eq!(
             seen.len(),
-            16,
+            18,
             "fixture list out of sync with ApplicationProtocol: update the \
              variants vec (and this count) alongside the match above"
         );

--- a/src/ui/tabs/details.rs
+++ b/src/ui/tabs/details.rs
@@ -1492,6 +1492,15 @@ pub(in crate::ui) fn draw_connection_details(
                     ("QoS", info.qos.map(|q| q.to_string())),
                 ]);
             }
+            crate::network::types::ApplicationProtocol::WireGuard(info) => {
+                details.app_rows(&[("Packet Type", Some(info.packet_type.to_string()))]);
+            }
+            crate::network::types::ApplicationProtocol::OpenVpn(info) => {
+                details.app_rows(&[
+                    ("Packet Type", Some(info.packet_type.to_string())),
+                    ("Key ID", Some(info.key_id.to_string())),
+                ]);
+            }
         }
     } else if let ProtocolState::Arp(arp_info) = &conn.protocol_state {
         details.section_styled("Application: ARP", theme::bold_fg(non_dpi_app_color()));


### PR DESCRIPTION
## Summary

- Detect WireGuard from fixed UDP message shapes.
- Detect OpenVPN over UDP and TCP with conservative alternate-port matching.
- Add protocol details, services, tests, changelog, and documentation.

## Verification

Formatting, Clippy, tests, and the release build pass.

## Note

Fully encrypted tls-crypt traffic on nonstandard ports stays unclassified to avoid false positives.