### PR TITLE
Remove uid/gid values from log output

### DIFF
--- a/crates/rustnet-host/src/linux/enhanced.rs
+++ b/crates/rustnet-host/src/linux/enhanced.rs
@@ -201,17 +201,8 @@ impl EnhancedLinuxProcessLookup {
         let ppid = resolve_parent_pid(info.pid);
 
         debug!(
-            "eBPF attribution: TGID {}, PPID {:?}, TID {}, UID {}, GID {}, eBPF comm {}, resolved {}, exe {:?}, {} match, observed {}ns (monotonic)",
-            info.pid,
-            ppid,
-            info.tid,
-            info.uid,
-            info.gid,
-            info.comm,
-            name,
-            executable,
-            quality,
-            info.timestamp
+            "eBPF attribution: TGID {}, PPID {:?}, TID {}, eBPF comm {}, resolved {}, exe {:?}, {} match, observed {}ns (monotonic)",
+            info.pid, ppid, info.tid, info.comm, name, executable, quality, info.timestamp
         );
 
         let mut attribution = ProcessAttribution::new(info.pid, name, quality)

--- a/crates/rustnet-sandbox/src/linux/mod.rs
+++ b/crates/rustnet-sandbox/src/linux/mod.rs
@@ -194,11 +194,9 @@ pub(crate) fn apply(config: &SandboxConfig) -> anyhow::Result<SandboxReport> {
                     target.uid, target.gid
                 ));
                 log::info!(
-                    "Dropped root privileges to uid {} gid {} (verified); \
+                    "Dropped root privileges to the target uid/gid (verified); \
                      procfs process attribution is now limited to that user's \
-                     processes (eBPF attribution unaffected)",
-                    target.uid,
-                    target.gid
+                     processes (eBPF attribution unaffected)"
                 );
             }
             Err(e) => {
@@ -319,11 +317,9 @@ pub(crate) fn apply(config: &SandboxConfig) -> anyhow::Result<SandboxReport> {
                 uid_dropped = true;
                 drop_message = format!("; root dropped to uid {} gid {}", target.uid, target.gid);
                 log::info!(
-                    "Dropped root privileges to uid {} gid {} (verified); \
+                    "Dropped root privileges to the target uid/gid (verified); \
                      procfs process attribution is now limited to that user's \
-                     processes",
-                    target.uid,
-                    target.gid
+                     processes"
                 );
             }
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,8 +507,8 @@ fn chown_to_uid_drop_target(
         && let Err(e) = rustnet_sandbox::privdrop::chown_to_target(file, target)
     {
         warn!(
-            "Failed to chown {} file '{}' to uid {}: {} (the file may not be writable after the root uid drop)",
-            label, path, target.uid, e
+            "Failed to chown {} file '{}' to the uid-drop target: {} (the file may not be writable after the root uid drop)",
+            label, path, e
         );
     }
 }


### PR DESCRIPTION
- Fixes the three open code scanning alerts (rust/cleartext-logging): uid/gid values were written to log output in the chown warning, the privilege-drop info logs, and the eBPF attribution debug log.
- The sandbox status UI still shows the drop target; only log lines changed.