### PR TITLE
feat: headless mode with a JSONL event stream

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ This document describes the technical architecture and implementation details of
 
 ## Crate Structure
 
-RustNet is a Cargo workspace of five crates. The analysis logic, capture backend, process attribution, and sandboxing each live in their own reusable library crate; the binary composes them into the TUI application.
+RustNet is a Cargo workspace of five crates. The analysis logic, capture backend, process attribution, and sandboxing each live in their own reusable library crate; the binary composes them into the application.
 
 | Crate | Type | Responsibility |
 | --- | --- | --- |
@@ -24,9 +24,11 @@ RustNet is a Cargo workspace of five crates. The analysis logic, capture backend
 | [`rustnet-capture`](crates/rustnet-capture) | library | libpcap/Npcap packet-capture backend: device selection, BPF filters, macOS PKTAP, TUN/TAP, and a raw-frame `PacketReader`. |
 | [`rustnet-host`](crates/rustnet-host) | library | Per-connection process attribution plus a host TCP/UDP socket inventory: eBPF/procfs on Linux, PKTAP/lsof on macOS, ETW/IP Helper on Windows, and `sockstat` on FreeBSD. Owns the eBPF build tooling and bundled `vmlinux.h`. |
 | [`rustnet-sandbox`](crates/rustnet-sandbox) | library | Post-initialization sandboxing and root privilege dropping behind one `apply_sandbox` entry point: Landlock + capability drops on Linux, Seatbelt on macOS, restricted token + job object on Windows, and the shared uid drop on Linux/macOS/FreeBSD. Depends on no other workspace crate. |
-| `rustnet-monitor` (binary `rustnet`) | binary | The user-facing application: CLI, TUI, and the app event loop. Dogfoods `ConnectionTracker` as the single source of truth. |
+| `rustnet-monitor` (binary `rustnet`) | binary | The user-facing application: CLI, the shared bootstrap, the TUI and headless front-ends, and the app event loop. Dogfoods `ConnectionTracker` as the single source of truth. |
 
 The package is named `rustnet-monitor` because the `rustnet` crate name is taken on crates.io; the installed binary is `rustnet`.
+
+The binary has two front-ends over one bootstrap sequence. `src/bootstrap.rs` runs the front-end independent startup (logging, privilege check, config, output files, sandbox policy) and the two-phase privileged launch (open capture and load eBPF, wait for readiness, apply the sandbox and drop uid on the main thread, then spawn the worker threads); `main.rs` only picks the front-end. `src/tui.rs` drives the terminal UI on top of it, and `src/headless/` (`--headless`) streams the connection events as JSON lines to stdout instead. The JSONL wire structs shared by `--headless`, `--json-log`, and the PCAP sidecar live in `src/headless/events.rs`, and the line sinks (file and queued stdout) in `src/headless/sink.rs`.
 
 ### Dependency Graph
 
@@ -46,7 +48,7 @@ flowchart TD
     HOST --> CORE
 ```
 
-The graph is acyclic: `rustnet-core` has no workspace dependencies, `rustnet-capture` and `rustnet-host` depend only on it, and `rustnet-sandbox` depends on no workspace crate at all. Keeping `rustnet-core` a leaf lets it be published and reused independently -- a headless front-end (e.g. a Prometheus exporter) can pair `rustnet-capture` + `rustnet-core` without the TUI; [`examples/headless.rs`](examples/headless.rs) shows the full pairing including `rustnet-host` and `rustnet-sandbox`.
+The graph is acyclic: `rustnet-core` has no workspace dependencies, `rustnet-capture` and `rustnet-host` depend only on it, and `rustnet-sandbox` depends on no workspace crate at all. Keeping `rustnet-core` a leaf lets it be published and reused independently -- an external headless tool (e.g. a Prometheus exporter) can pair `rustnet-capture` + `rustnet-core` without the TUI; [`examples/headless.rs`](examples/headless.rs) shows the full pairing including `rustnet-host` and `rustnet-sandbox`. The binary's own `--headless` front-end lives in `src/headless/` and uses the full `rustnet-monitor` pipeline.
 
 ### Re-export Facade
 

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -16,7 +16,7 @@
 
 ## Crate 结构<a id="crate-structure"></a>
 
-RustNet 是一个由五个 crate 组成的 Cargo 工作区。分析逻辑、捕获后端、进程归属和沙箱各自位于独立的可复用库 crate 中；二进制 crate 将它们组合成 TUI 应用。
+RustNet 是一个由五个 crate 组成的 Cargo 工作区。分析逻辑、捕获后端、进程归属和沙箱各自位于独立的可复用库 crate 中；二进制 crate 将它们组合成应用。
 
 | Crate | 类型 | 职责 |
 | --- | --- | --- |
@@ -24,9 +24,11 @@ RustNet 是一个由五个 crate 组成的 Cargo 工作区。分析逻辑、捕�
 | [`rustnet-capture`](crates/rustnet-capture) | 库 | 基于 libpcap/Npcap 的数据包捕获后端：设备选择、BPF 过滤器、macOS PKTAP、TUN/TAP，以及原始帧 `PacketReader`。 |
 | [`rustnet-host`](crates/rustnet-host) | 库 | 按连接进程归属及主机 TCP/UDP 套接字清单：Linux 上的 eBPF/procfs、macOS 上的 PKTAP/lsof、Windows 上的 ETW/IP Helper，以及 FreeBSD 上的 `sockstat`。负责 eBPF 构建工具链及内置的 `vmlinux.h`。 |
 | [`rustnet-sandbox`](crates/rustnet-sandbox) | 库 | 初始化完成后的沙箱与 root 权限降级，统一入口 `apply_sandbox`：Linux 上的 Landlock + 能力降级、macOS 上的 Seatbelt、Windows 上的受限令牌 + 作业对象，以及 Linux/macOS/FreeBSD 共享的 uid 降级。不依赖任何其他工作区 crate。 |
-| `rustnet-monitor`（二进制 `rustnet`） | 二进制 | 面向用户的应用：CLI、TUI 和应用事件循环。以 `ConnectionTracker` 作为唯一数据来源（dogfooding）。 |
+| `rustnet-monitor`（二进制 `rustnet`） | 二进制 | 面向用户的应用：CLI、共享的引导启动流程、TUI 与无头前端，以及应用事件循环。以 `ConnectionTracker` 作为唯一数据来源（dogfooding）。 |
 
 包名为 `rustnet-monitor`，因为 `rustnet` 这个 crate 名称在 crates.io 上已被占用；安装后的二进制文件名为 `rustnet`。
+
+二进制文件在同一套引导启动流程之上提供两个前端。`src/bootstrap.rs` 负责与前端无关的启动步骤（日志、权限检查、配置、输出文件、沙箱策略）以及两阶段的特权启动（打开捕获并加载 eBPF，等待就绪，在主线程上应用沙箱并降低 uid，然后生成工作线程）；`main.rs` 只负责选择前端。`src/tui.rs` 在其之上驱动终端 UI，而 `src/headless/`（`--headless`）则改为将连接事件以 JSON 行的形式流式输出到 stdout。`--headless`、`--json-log` 和 PCAP sidecar 共用的 JSONL 线格式结构体位于 `src/headless/events.rs`，行输出 sink（文件和带队列的 stdout）位于 `src/headless/sink.rs`。
 
 ### 依赖关系图
 
@@ -46,7 +48,7 @@ flowchart TD
     HOST --> CORE
 ```
 
-依赖关系是无环的：`rustnet-core` 没有任何工作区内依赖，`rustnet-capture` 和 `rustnet-host` 都仅依赖它，而 `rustnet-sandbox` 不依赖任何工作区 crate。让 `rustnet-core` 保持为叶子节点，使其可以独立发布和复用 —— 无界面的前端（例如 Prometheus 导出器）可以仅组合 `rustnet-capture` + `rustnet-core` 而无需 TUI；[`examples/headless.rs`](examples/headless.rs) 展示了包含 `rustnet-host` 与 `rustnet-sandbox` 的完整组合。
+依赖关系是无环的：`rustnet-core` 没有任何工作区内依赖，`rustnet-capture` 和 `rustnet-host` 都仅依赖它，而 `rustnet-sandbox` 不依赖任何工作区 crate。让 `rustnet-core` 保持为叶子节点，使其可以独立发布和复用 —— 外部的无头工具（例如 Prometheus 导出器）可以仅组合 `rustnet-capture` + `rustnet-core` 而无需 TUI；[`examples/headless.rs`](examples/headless.rs) 展示了包含 `rustnet-host` 与 `rustnet-sandbox` 的完整组合。二进制文件自带的 `--headless` 前端位于 `src/headless/`，使用完整的 `rustnet-monitor` 管线。
 
 ### 重导出门面
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Headless Mode**: `rustnet --headless` runs the full capture pipeline
+  without a terminal and streams `startup`, `new_connection`, and
+  `connection_closed` events as JSON lines to stdout, with `--log-level`
+  output going to stderr. `--snapshot-interval SECONDS` adds periodic
+  `snapshot` events with the whole connection table, and `--filter QUERY`
+  restricts the stream using the interactive filter syntax (#9)
 - **Inline Connection Health**: connection rows now show compact TCP
   retransmit/out-of-order, QUIC Retry/version, and transactional UDP
   retry/timeout badges, with a severity-first Health sort. The Details

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -582,6 +582,9 @@ docker run --rm -it --net=host ghcr.io/domcyrus/rustnet:latest -i eth0
 docker run --rm -it --privileged --net=host \
   ghcr.io/domcyrus/rustnet:latest
 
+# Headless JSONL stream (no TTY needed, so no -it)
+docker run --rm --net=host ghcr.io/domcyrus/rustnet:latest --headless | jq .
+
 # View available options
 docker run --rm ghcr.io/domcyrus/rustnet:latest --help
 ```

--- a/INSTALL.zh-CN.md
+++ b/INSTALL.zh-CN.md
@@ -579,6 +579,9 @@ docker run --rm -it --net=host ghcr.io/domcyrus/rustnet:latest -i eth0
 docker run --rm -it --privileged --net=host \
   ghcr.io/domcyrus/rustnet:latest
 
+# 无头 JSONL 流（不需要 TTY，因此无需 -it）
+docker run --rm --net=host ghcr.io/domcyrus/rustnet:latest --headless | jq .
+
 # 查看可用选项
 docker run --rm ghcr.io/domcyrus/rustnet:latest --help
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,6 +24,7 @@ RustNet は、各接続を所有するプロセス、通信量、状態、アプ
 - Host タブに TCP LISTEN ソケット、UDP BOUND エンドポイント、TCP 状態集計、観測 RTT、所有プロセス、インターフェース統計を表示
 - `port:`、`process:`、`sni:`、`state:` などのフィルター
 - 注釈付き PCAPNG、PCAP と JSONL sidecar、JSON ログの出力
+- ヘッドレスモード: `--headless` は端末を使わずに同じパイプラインを実行し、`startup`、`new_connection`、`connection_closed`、および任意の `snapshot` イベントを JSON Lines として標準出力に出力します。`--filter` には対話型フィルターと同じ構文を使用できます。`jq` やログシッパーにパイプしたり、サービスマネージャー配下で実行したりできます。詳細は [USAGE.md](USAGE.md#headless-mode) を参照してください
 - ローカル GeoIP データベースによる国、ASN、都市情報
 - ARP トラフィックから受動的に学習した LAN 機器・ゲートウェイの MAC アドレスとベンダー表示（内蔵 IEEE OUI データベース）
 - Linux Landlock、macOS Seatbelt、Windows の権限削減によるサンドボックス
@@ -97,6 +98,7 @@ rustnet --no-resolve-dns                # 逆引き DNS を無効化
 rustnet --no-dpi                        # 深層パケット解析を無効化
 rustnet --theme tokyo-night             # カラーテーマ（muted［既定］、vivid、catppuccin-mocha、tokyo-night、gruvbox、nord）
 rustnet --pcapng-export capture.pcapng  # 注釈付き PCAPNG を出力
+rustnet --headless --filter 'port:443' | jq .  # TUI なしの JSONL イベントストリーム
 ```
 
 テーマと各色の上書きは `~/.config/rustnet/config.toml` でも設定できます（`--theme` が優先）。詳細は [USAGE.md](USAGE.md#--theme-preset) を参照してください。

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - **Per-process attribution**: Every TCP, UDP, and QUIC connection mapped to its owning process, via eBPF on Linux, PKTAP on macOS, ETW with an automatic IP Helper fallback on Windows, and native APIs on FreeBSD. Details include PID, executable, user/group names, match confidence, and a capped parent-process chain on every platform. Wireshark and tcpdump can't do this; `netstat` / `ss` can't show live state.
 - **Deep packet inspection**: Identify HTTP, HTTPS/TLS with SNI, DNS, SSH, FTP, QUIC, MQTT, BitTorrent, WireGuard, OpenVPN, STUN, NTP, mDNS, LLMNR, DHCP, SNMP, SSDP, and NetBIOS, without external dissectors.
 - **Annotated PCAPNG export**: `--pcapng-export` writes a Wireshark-ready capture with process, PID, direction, DPI/SNI, and GeoIP embedded as per-packet comments. Open it in Wireshark and every packet already names its owning process, with no post-processing. Classic `--pcap-export` with a JSONL sidecar for offline correlation is also available.
+- **Headless mode**: `--headless` runs the same pipeline without a terminal and streams `startup`, `new_connection`, `connection_closed`, and optional `snapshot` events as JSON lines to stdout, with `--filter` using the interactive filter syntax. Pipe it into `jq` or a log shipper, or run it under a service manager. See [USAGE.md](USAGE.md#headless-mode).
 - **Security sandboxing**: Landlock (Linux 5.13+), Seatbelt (macOS), token privilege drop + job-object child-process block (Windows). Drops privileges immediately after libpcap initializes. See [SECURITY.md](SECURITY.md).
 - **Network analytics**: Real-time round-trip times for TCP, QUIC handshakes, DNS responses, and ICMP echo, plus TCP retransmission, out-of-order, and fast-retransmit detection. Protocol-aware health badges surface TCP issues, explicit QUIC Retry/version events, and retries/timeouts for transaction-based UDP, with severity-first sorting in the Overview table.
 - **Smart connection lifecycle**: Protocol-aware timeouts; idle rows get a yellow-to-red stripe and removal countdown and soften toward gray. Toggle `t` to keep historic (closed) connections visible for forensics.
@@ -192,6 +193,7 @@ rustnet --no-resolve-dns     # Disable reverse DNS lookups (enabled by default)
 rustnet -r 500               # Set refresh interval (ms)
 rustnet --theme tokyo-night  # Theme: muted (default), vivid, catppuccin-mocha, tokyo-night, gruvbox, nord
 rustnet --pcapng-export capture.pcapng  # Annotated PCAPNG for Wireshark
+rustnet --headless --filter 'port:443' | jq .  # JSONL event stream, no TUI
 ```
 
 The theme and per-color overrides can also be set in `~/.config/rustnet/config.toml`; `--theme` takes precedence. See [USAGE.md](USAGE.md#--theme-preset) for the schema.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 - **进程级归属识别**：每一条 TCP、UDP、QUIC 连接都能追溯到所属进程。Linux 使用 eBPF，macOS 使用 PKTAP，Windows 使用 ETW 并在不可用时自动回退到 IP Helper，FreeBSD 则走原生 API。详情会显示 PID、可执行文件、用户/组名称、匹配可信度，以及每个平台都提供的父进程链（有层级上限）。Wireshark 与 tcpdump 做不到这一点；`netstat` / `ss` 也无法展示实时状态。
 - **深度包检测**：无需外部解析器即可识别 HTTP、带 SNI 的 HTTPS/TLS、DNS、SSH、FTP、QUIC、MQTT、BitTorrent、WireGuard、OpenVPN、STUN、NTP、mDNS、LLMNR、DHCP、SNMP、SSDP 及 NetBIOS。
 - **带注释的 PCAPNG 导出**：`--pcapng-export` 可写出能直接用 Wireshark 打开的捕获文件，并将进程、PID、方向、DPI/SNI 和 GeoIP 作为逐包注释嵌入。每个数据包都会直接标明所属进程，无需后处理。也可使用经典的 `--pcap-export` 配合 JSONL sidecar 进行离线关联。
+- **无头模式**：`--headless` 在没有终端的情况下运行同一套流水线，并将 `startup`、`new_connection`、`connection_closed` 以及可选的 `snapshot` 事件以 JSON 行的形式输出到 stdout，`--filter` 使用与交互式过滤器相同的语法。可将其通过管道送入 `jq` 或日志采集器，或在服务管理器下运行。详见 [USAGE.zh-CN.md](USAGE.zh-CN.md#headless-mode)。
 - **安全沙箱**：Linux 5.13+ 使用 Landlock，macOS 使用 Seatbelt，Windows 通过 token 降权 + job-object 阻止子进程创建。libpcap 初始化完成后立即丢弃特权。详见 [SECURITY.zh-CN.md](SECURITY.zh-CN.md)。
 - **网络分析**：实时统计 TCP、QUIC 握手、DNS 响应及 ICMP 回显的往返时延，并检测 TCP 重传、乱序包和快重传。概览表格通过按协议显示的健康徽标，呈现 TCP 问题、明确可见的 QUIC Retry/版本协商事件，以及事务型 UDP 的重试/超时，并按严重程度排序。
 - **智能连接生命周期**：按协议设置超时，空闲连接行会显示由黄变红的左侧条纹和移除倒计时，并逐渐柔化为灰色。按 `t` 可保留历史（已关闭）连接以便事后追溯。
@@ -192,6 +193,7 @@ rustnet --no-resolve-dns     # 关闭反向 DNS 解析(默认开启)
 rustnet -r 500               # 设置刷新间隔(毫秒)
 rustnet --theme tokyo-night  # 主题：muted(默认)、vivid、catppuccin-mocha、tokyo-night、gruvbox、nord
 rustnet --pcapng-export capture.pcapng  # 导出带注释的 PCAPNG
+rustnet --headless --filter 'port:443' | jq .  # JSONL 事件流，无 TUI
 ```
 
 主题及各颜色的覆盖也可在 `~/.config/rustnet/config.toml` 中设置；`--theme` 优先。配置格式见 [USAGE.zh-CN.md](USAGE.zh-CN.md#--theme-preset)。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -334,9 +334,12 @@ The library crates now cover the whole privileged pipeline: capture
 (`rustnet-capture`), parsing + connection tracking + interface stats
 (`rustnet-core`), process attribution (`rustnet-host`), and sandboxing +
 uid drop (`rustnet-sandbox`). `examples/headless.rs` is a compiling,
-runnable proof of that pairing. What a full headless front-end (Prometheus
-exporter, JSON streamer) still cannot get from the crates, from an audit of
-the binary:
+runnable proof of that pairing, and the binary now ships its own headless
+front-end: `rustnet --headless` streams `startup`, `new_connection`,
+`connection_closed`, and optional `snapshot` events as JSONL to stdout, with
+`--filter` and `--snapshot-interval` (`src/headless/`). What an external
+headless front-end (Prometheus exporter, JSON streamer) still cannot get
+from the crates, from an audit of the binary:
 
 Code that could move into a crate:
 
@@ -347,8 +350,9 @@ Code that could move into a crate:
 - [ ] Process-grouping aggregation (currently in `src/ui/state.rs`) into
   `rustnet-core`, since per-process rollups are exporter material.
 - [ ] Optional `serde` derives for `Connection` and the DPI types behind a
-  `rustnet-core` feature; today JSON output is hand-built in
-  `src/app/logging.rs` and unavailable to library consumers.
+  `rustnet-core` feature. The JSON output is now built from serde structs
+  (`src/headless/events.rs`), but those live in the binary and are
+  unavailable to library consumers.
 - [ ] The capture-privileges preflight check (`src/network/privileges.rs`)
   into `rustnet-capture` (its Windows probe already uses the pcap crate).
 
@@ -358,9 +362,10 @@ Composition APIs that exist only as binary wiring:
   DPI workers, batching, backpressure, `catch_unwind`) that `src/app`
   hand-builds.
 - [ ] The two-phase privileged start contract (open capture + load eBPF,
-  wait for readiness, sandbox, then spawn workers) as an API instead of
-  main.rs choreography; the ordering is documented in `rustnet-sandbox` but
-  each front-end still re-implements the sequence.
+  wait for readiness, sandbox, then spawn workers) as a crate API. The
+  binary already runs it as one sequence shared by both front-ends,
+  `src/bootstrap.rs` (`prepare` + `Prepared::launch`) used by `src/tui.rs`
+  and `src/headless/`, but it is still binary-internal.
 - [ ] A published-snapshot policy layer (service-name enrichment, localhost
   and PTR-lookup filtering, historic merge, sorting) over
   `ConnectionTracker::snapshot`.
@@ -371,6 +376,17 @@ Composition APIs that exist only as binary wiring:
   write-once policy, GeoIP refresh) as reusable helpers.
 - [ ] Health/degradation status types (capture failure retention, PKTAP
   degradation mapping) shared between front-ends.
+
+Headless follow-ups:
+
+- [ ] Prometheus/HTTP metrics endpoint on top of the event stream.
+- [ ] Move `ConnectionFilter`, the privileges preflight, and Kubernetes
+  resolution into the crates (the items above) so external front-ends can
+  reuse them.
+- [ ] launchd plist for running `--headless` as a macOS service.
+- [ ] Windows console control handler, so Ctrl+C and console close end the
+  stream through the regular shutdown path as the Unix signals do.
+- [ ] VHS demo of the headless stream for the README.
 
 ### macOS Privilege Separation (pktap without root)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -84,32 +84,58 @@ rustnet --help
 Usage: rustnet [OPTIONS]
 
 Options:
-  -i, --interface <INTERFACE>            Network interface to monitor
-      --no-localhost                     Filter out localhost connections (default: filtered)
-      --show-localhost                   Show localhost connections (overrides default filtering)
-  -r, --refresh-interval <MILLISECONDS>  UI refresh interval in milliseconds [default: 500]
-      --no-dpi                           Disable deep packet inspection
-      --no-resolve-dns                   Disable reverse DNS lookups (enabled by default)
-      --show-ptr-lookups                 Show PTR lookup connections (hidden by default)
-  -l, --log-level <LEVEL>                Set the log level (if not provided, no logging will be enabled)
-      --json-log <FILE>                  Enable JSON logging of connection events to specified file
-      --pcap-export <FILE>               Export captured packets to PCAP file for Wireshark analysis
-      --pcapng-export <FILE>             Export captured packets to annotated PCAPNG file for Wireshark analysis
-      --no-color                         Disable all colors in the UI (also respects NO_COLOR env var)
-      --theme <PRESET>                   Color theme: muted (default), vivid, catppuccin-mocha,
-                                         tokyo-night, gruvbox, nord. Overrides the theme set in the
-                                         config file (~/.config/rustnet/config.toml)
-      --geoip-country <PATH>             Path to GeoLite2-Country.mmdb (auto-discovered if not specified)
-      --geoip-asn <PATH>                 Path to GeoLite2-ASN.mmdb (auto-discovered if not specified)
-      --geoip-city <PATH>                Path to GeoLite2-City.mmdb (auto-discovered if not specified)
-      --no-geoip                         Disable GeoIP lookups entirely
-  -f, --bpf-filter <FILTER>              BPF filter expression for packet capture
-      --no-sandbox                       Disable Landlock sandboxing (Linux only)
-      --sandbox-strict                   Require full sandbox enforcement or exit (Linux only)
-      --no-uid-drop                      Keep running as root instead of dropping to
-                                         SUDO_UID/SUDO_GID (or nobody) after initialization (Linux, macOS, and FreeBSD)
-  -h, --help                             Print help
-  -V, --version                          Print version
+  -i, --interface <INTERFACE>
+          Network interface to monitor
+      --no-localhost
+          Filter out localhost connections
+      --show-localhost
+          Show localhost connections (overrides default filtering)
+  -r, --refresh-interval <MILLISECONDS>
+          UI refresh interval in milliseconds [default: 500]
+      --no-dpi
+          Disable deep packet inspection
+  -l, --log-level <LEVEL>
+          Set the log level (if not provided, no logging will be enabled)
+      --json-log <FILE>
+          Enable JSON logging of connection events to specified file
+      --headless
+          Run without the terminal UI and stream connection events as JSON lines to stdout (log output goes to stderr)
+      --snapshot-interval <SECONDS>
+          Emit a snapshot event with the full connection table every SECONDS seconds (headless only)
+      --filter <QUERY>
+          Only stream connections matching QUERY, using the same syntax as the interactive / filter (headless only)
+      --pcap-export <FILE>
+          Export captured packets to PCAP file for Wireshark analysis
+      --pcapng-export <FILE>
+          Export captured packets to annotated PCAPNG file for Wireshark analysis
+  -f, --bpf-filter <FILTER>
+          BPF filter expression for packet capture (e.g., "tcp port 443"). Note: Using a BPF filter disables PKTAP (process info falls back to lsof)
+      --no-resolve-dns
+          Disable reverse DNS resolution for IP addresses (enabled by default; shows hostnames instead of IPs)
+      --show-ptr-lookups
+          Show PTR lookup connections in UI (hidden by default when DNS resolution is enabled)
+      --no-color
+          Disable all colors in the UI (also respects NO_COLOR env var)
+      --theme <PRESET>
+          Color theme: muted (default), vivid, catppuccin-mocha, tokyo-night, gruvbox, nord. Overrides the theme set in the config file (~/.config/rustnet/config.toml) [possible values: muted, vivid, catppuccin-mocha, tokyo-night, gruvbox, nord]
+      --geoip-country <PATH>
+          Path to GeoLite2-Country.mmdb database. Auto-discovered from: ./resources/geoip2, $XDG_DATA_HOME/rustnet/geoip, ~/.local/share/rustnet/geoip, /usr/share/GeoIP, /usr/local/share/GeoIP, /opt/homebrew/share/GeoIP, /var/lib/GeoIP
+      --geoip-asn <PATH>
+          Path to GeoLite2-ASN.mmdb database (same search paths as --geoip-country)
+      --geoip-city <PATH>
+          Path to GeoLite2-City.mmdb database (same search paths as --geoip-country; superset of Country: provides city name and postal code in addition to country)
+      --no-geoip
+          Disable GeoIP lookups entirely
+      --no-sandbox
+          Disable sandboxing (on Linux, PR_SET_NO_NEW_PRIVS is still set)
+      --sandbox-strict
+          Require full sandbox enforcement or exit
+      --no-uid-drop
+          Keep running as root instead of dropping to SUDO_UID/SUDO_GID (or nobody) after initialization. Keeping root lets the lsof fallback attribute other users' processes when PKTAP is unavailable
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 Builds compiled with the optional `kubernetes` feature (including the official Docker image) additionally expose `--kubernetes <MODE>`. See [`--kubernetes`](#--kubernetes-mode-optional-feature) below.
@@ -321,7 +347,33 @@ Enable logging with the specified level. Logging is **disabled by default**.
 - `debug` - Detailed debugging information
 - `trace` - Very verbose output (includes packet-level details)
 
-Log files are created in the `logs/` directory with timestamp: `rustnet_YYYY-MM-DD_HH-MM-SS.log`
+Log files are created in the `logs/` directory with timestamp: `rustnet_YYYY-MM-DD_HH-MM-SS.log`. In [headless mode](#headless-mode) the log goes to stderr instead.
+
+#### `--headless`
+
+Run without the terminal UI and stream connection events as JSON lines to stdout. Startup, sandboxing, uid drop, and enrichment are the same as in the TUI; only the output differs. With `--log-level`, log lines go to stderr instead of a file under `logs/`. See [Headless Mode](#headless-mode) for the event format.
+
+```bash
+# Stream every connection event, pretty-printed
+sudo rustnet --headless | jq .
+```
+
+#### `--snapshot-interval <SECONDS>`
+
+Headless only. Emit a `snapshot` event with the full connection table every `SECONDS` seconds (a positive integer), in addition to the per-connection events. The first snapshot is written after one full interval. Requires `--headless`.
+
+```bash
+sudo rustnet --headless --snapshot-interval 10
+```
+
+#### `--filter <QUERY>`
+
+Headless only. Stream only the connections matching `QUERY`, using the same syntax as the interactive `/` filter (see [Filtering](#filtering)): keyword terms such as `port:443` or `process:curl`, free text, and `/regex/` values, combined with spaces (AND). The query is checked before capture starts; a keyword with no value (`port:`) or an invalid regex exits with an error. Requires `--headless`.
+
+```bash
+sudo rustnet --headless --filter 'port:443'
+sudo rustnet --headless --filter 'proto:udp dport:53'
+```
 
 #### `--kubernetes <MODE>` (optional feature)
 
@@ -338,7 +390,7 @@ When active, RustNet maps each connection's PID to its pod UID and container ID 
 Attribution is surfaced in:
 
 - The **Details tab**, as a "Kubernetes" section showing pod name, namespace, pod UID, container name, and container ID
-- **JSON logs** (`--json-log`) and the `--pcap-export` sidecar JSONL, as a `kubernetes` object per connection event
+- **JSON logs** (`--json-log`), the `--headless` event stream and its `snapshot` records, and the `--pcap-export` sidecar JSONL, as a `kubernetes` object per connection event
 - **PCAPNG packet comments** (`--pcapng-export`), as `pod=`, `ns=`, `pod_uid=`, `container=`, and `container_id=` fields
 - The `pod:`, `ns:`, and `container:` [filter keywords](#keyword-filters)
 
@@ -1242,9 +1294,83 @@ When reporting issues:
 
 For performance issues, trace-level logging provides the most detail but generates large log files quickly.
 
+### Headless Mode
+
+`--headless` runs the capture pipeline without the terminal UI and streams connection events to stdout as JSON lines (JSONL, one object per line). It is meant for piping into `jq` or a log shipper, and for running under a service manager or in a container where there is no TTY.
+
+```bash
+# Pretty-print every event
+sudo rustnet --headless | jq .
+
+# Destination IPs of HTTPS connections only
+sudo rustnet --headless --filter 'port:443' | jq -r '.destination_ip'
+
+# Process and bytes sent for every closed connection, log output discarded
+sudo rustnet --headless 2>/dev/null | jq -c 'select(.event=="connection_closed") | {process_name,bytes_sent}'
+```
+
+**Startup:** headless mode goes through the same startup sequence as the TUI: privilege check, capture and eBPF initialization, sandboxing, and the root uid drop, followed by the same process attribution, DPI, DNS, and GeoIP enrichment. No terminal is touched. stdout carries only events; the privilege banner and, with `--log-level`, the log lines go to stderr instead of a file under `logs/`, so `rustnet --headless 2>/dev/null` is a clean JSONL stream. Options that only affect the UI (`--theme`, `--no-color`) have no effect.
+
+**Event types:**
+
+| Event | When | Fields |
+|-------|------|--------|
+| `startup` | Once, as the first line, after the capture device is open and the sandbox is applied | See below |
+| `new_connection` | A connection is first seen | Same as [JSON Logging](#json-logging) |
+| `connection_closed` | A connection is cleaned up after becoming inactive | Same as [JSON Logging](#json-logging), including `bytes_sent`, `bytes_received`, and `duration_secs` |
+| `snapshot` | Every `--snapshot-interval` seconds | See below |
+
+Every line has `timestamp` (RFC3339 UTC) and `event`. The `new_connection` and `connection_closed` lines are the same as the ones `--json-log` writes; their fields are documented under [JSON Logging](#json-logging). A `new_connection` line is emitted when the first packet of a connection is seen, before process attribution, GeoIP, or DPI details are usually available, so consumers that need `pid` or `process_name` should use `connection_closed` or `snapshot` events, or match the lines on their 5-tuple (`protocol`, `source_ip`, `source_port`, `destination_ip`, `destination_port`).
+
+`startup` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | string | RFC3339 UTC timestamp |
+| `event` | string | `startup` |
+| `version` | string | RustNet version |
+| `pid` | number | Process ID of this RustNet instance |
+| `interface` | string | Capture interface (omitted if unknown) |
+| `link_type` | string | Link layer of the capture: `Ethernet`, `RawIp`, `LinuxSll`, `LinuxSll2`, `Pktap`, `Tun`, `Tap`, or `Unknown` |
+| `sandbox` | string | Sandbox status: `Fully enforced`, `Partially enforced`, `Not applied`, or `Error` (Linux, Windows, and macOS builds with the `macos-sandbox` feature) |
+| `process_detection` | string | Process attribution method in use: `eBPF fentry/fexit + procfs`, `eBPF kprobe + procfs`, or `procfs` on Linux; `pktap` or `lsof` on macOS; `windows-etw+iphlpapi` or `windows-iphlpapi` on Windows; `sockstat` on FreeBSD. The value is the one reported at startup, so it can be `initializing...` if attribution was not ready within the startup wait |
+| `filter` | string | The `--filter` query (omitted when none) |
+| `snapshot_interval_secs` | number | The `--snapshot-interval` value (omitted when none) |
+
+`snapshot` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | string | RFC3339 UTC timestamp |
+| `event` | string | `snapshot` |
+| `connections` | array | One object per connection currently in the table, with the same fields as a `new_connection` line minus `timestamp` and `event` |
+
+The snapshot table is the one the TUI shows: localhost connections are excluded unless `--show-localhost` is given, DNS PTR lookups are hidden unless `--show-ptr-lookups` is given, and it is refreshed every `--refresh-interval` milliseconds. The first snapshot is written after one full interval so it reflects real traffic rather than an empty table.
+
+**Filtering:** `--filter QUERY` restricts `new_connection`, `connection_closed`, and the `snapshot` table to connections matching `QUERY`; the `startup` line is always written. The syntax is that of the interactive `/` filter (see [Filtering](#filtering)): keyword terms, free text, and `/regex/` values, combined with spaces (AND). The query is checked before capture starts, so a keyword with no value (`port:`) or an invalid regex fails immediately with an error on stderr.
+
+```bash
+# DNS traffic from any process
+sudo rustnet --headless --filter 'proto:udp dport:53'
+
+# Firefox connections to any github.com host
+sudo rustnet --headless --filter 'process:firefox sni:/github\.com$/'
+```
+
+**Backpressure:** stdout is written by a dedicated thread through a queue of 10,000 lines. If the consumer falls behind, events are dropped rather than stalling packet processing; the number of dropped lines is logged as a warning (visible with `--log-level warn` or higher).
+
+**Exiting:**
+
+- `SIGINT` (Ctrl+C), `SIGTERM`, or `SIGHUP` stops the stream, writes out the queued lines, and exits with status 0. On Windows the console control handler is not wired yet, so Ctrl+C or closing the console ends the process without draining the queued lines.
+- When the consumer closes the pipe (for example `rustnet --headless | head -n 20`), the next write fails and RustNet exits with status 0.
+- A packet capture failure exits with status 1 with the error on stderr.
+- An unknown option, a `--snapshot-interval` or `--filter` without `--headless`, or an invalid `--filter` query exits with an error before capture starts.
+
+**Combining with other outputs:** `--json-log FILE` still works alongside `--headless` and receives every `new_connection` and `connection_closed` event, unfiltered; `--filter` only applies to stdout. `--pcap-export` and `--pcapng-export` work as in the TUI.
+
 ### JSON Logging
 
-The `--json-log` option enables structured JSON logging of connection events to a file. Each line is a separate JSON object (JSONL format).
+The `--json-log` option enables structured JSON logging of connection events to a file. Each line is a separate JSON object (JSONL format). To stream the same events to stdout instead of a file, see [Headless Mode](#headless-mode).
 
 ```bash
 # Enable JSON logging
@@ -1282,7 +1408,7 @@ sudo rustnet -i eth0 --json-log ~/network-events.json
 **Example output:**
 
 ```json
-{"timestamp":"2025-01-15T10:30:00Z","event":"new_connection","protocol":"TCP","source_ip":"192.168.1.100","source_port":54321,"destination_ip":"93.184.216.34","destination_port":443,"pid":1234,"process_name":"curl","service_name":"https","direction":"outgoing","dpi_protocol":"HTTPS","dpi_domain":"example.com"}
+{"timestamp":"2025-01-15T10:30:00Z","event":"new_connection","protocol":"TCP","source_ip":"192.168.1.100","source_port":54321,"destination_ip":"93.184.216.34","destination_port":443,"pid":1234,"process_name":"curl","service_name":"https","direction":"outgoing","dpi_protocol":"HTTPS (example.com)","dpi_domain":"example.com"}
 {"timestamp":"2025-01-15T10:30:05Z","event":"connection_closed","protocol":"TCP","source_ip":"192.168.1.100","source_port":54321,"destination_ip":"93.184.216.34","destination_port":443,"pid":1234,"process_name":"curl","service_name":"https","direction":"outgoing","bytes_sent":1024,"bytes_received":4096,"duration_secs":5}
 ```
 

--- a/USAGE.zh-CN.md
+++ b/USAGE.zh-CN.md
@@ -84,32 +84,58 @@ rustnet --help
 Usage: rustnet [OPTIONS]
 
 Options:
-  -i, --interface <INTERFACE>            要监控的网络接口
-      --no-localhost                     过滤掉 localhost 连接（默认：已过滤）
-      --show-localhost                   显示 localhost 连接（覆盖默认过滤）
-  -r, --refresh-interval <MILLISECONDS>  UI 刷新间隔，单位为毫秒 [默认：500]
-      --no-dpi                           禁用深度包检测
-      --no-resolve-dns                   禁用反向 DNS 查找（默认启用）
-      --show-ptr-lookups                 显示 PTR 查找连接（默认隐藏）
-  -l, --log-level <LEVEL>                设置日志级别（如果未提供，则不启用日志）
-      --json-log <FILE>                  将连接事件以 JSON 格式记录到指定文件
-      --pcap-export <FILE>               将捕获的数据包导出到 PCAP 文件供 Wireshark 分析
-      --pcapng-export <FILE>             将捕获的数据包导出为带注释的 PCAPNG 文件供 Wireshark 分析
-      --no-color                         禁用 UI 中的所有颜色（同时尊重 NO_COLOR 环境变量）
-      --theme <PRESET>                   颜色主题：muted（默认）、vivid、catppuccin-mocha、
-                                         tokyo-night、gruvbox、nord。优先于配置文件
-                                         （~/.config/rustnet/config.toml）中设置的主题
-      --geoip-country <PATH>             GeoLite2-Country.mmdb 的路径（未指定时自动发现）
-      --geoip-asn <PATH>                 GeoLite2-ASN.mmdb 的路径（未指定时自动发现）
-      --geoip-city <PATH>                GeoLite2-City.mmdb 的路径（未指定时自动发现）
-      --no-geoip                         完全禁用 GeoIP 查询
-  -f, --bpf-filter <FILTER>              用于数据包捕获的 BPF 过滤器表达式
-      --no-sandbox                       禁用 Landlock 沙箱（仅限 Linux）
-      --sandbox-strict                   要求完整沙箱强制执行，否则退出（仅限 Linux）
-      --no-uid-drop                      初始化后保持 root 运行，不降权到
-                                         SUDO_UID/SUDO_GID（或 nobody）（仅限 Linux、macOS 和 FreeBSD）
-  -h, --help                             打印帮助
-  -V, --version                          打印版本
+  -i, --interface <INTERFACE>
+          要监控的网络接口
+      --no-localhost
+          过滤掉 localhost 连接
+      --show-localhost
+          显示 localhost 连接（覆盖默认过滤）
+  -r, --refresh-interval <MILLISECONDS>
+          UI 刷新间隔，单位为毫秒 [默认：500]
+      --no-dpi
+          禁用深度包检测
+  -l, --log-level <LEVEL>
+          设置日志级别（如果未提供，则不启用日志）
+      --json-log <FILE>
+          将连接事件以 JSON 格式记录到指定文件
+      --headless
+          不启动终端 UI，将连接事件以 JSON 行的形式流式输出到 stdout（日志输出到 stderr）
+      --snapshot-interval <SECONDS>
+          每隔 SECONDS 秒发出一个包含完整连接表的 snapshot 事件（仅限无头模式）
+      --filter <QUERY>
+          仅输出匹配 QUERY 的连接，语法与交互式 / 过滤器相同（仅限无头模式）
+      --pcap-export <FILE>
+          将捕获的数据包导出到 PCAP 文件供 Wireshark 分析
+      --pcapng-export <FILE>
+          将捕获的数据包导出为带注释的 PCAPNG 文件供 Wireshark 分析
+  -f, --bpf-filter <FILTER>
+          用于数据包捕获的 BPF 过滤器表达式（例如 "tcp port 443"）。注意：使用 BPF 过滤器会禁用 PKTAP（进程信息回退到 lsof）
+      --no-resolve-dns
+          禁用 IP 地址的反向 DNS 解析（默认启用；显示主机名而非 IP）
+      --show-ptr-lookups
+          在 UI 中显示 PTR 查找连接（启用 DNS 解析时默认隐藏）
+      --no-color
+          禁用 UI 中的所有颜色（同时尊重 NO_COLOR 环境变量）
+      --theme <PRESET>
+          颜色主题：muted（默认）、vivid、catppuccin-mocha、tokyo-night、gruvbox、nord。优先于配置文件（~/.config/rustnet/config.toml）中设置的主题 [可选值：muted、vivid、catppuccin-mocha、tokyo-night、gruvbox、nord]
+      --geoip-country <PATH>
+          GeoLite2-Country.mmdb 数据库的路径。自动从以下位置发现：./resources/geoip2、$XDG_DATA_HOME/rustnet/geoip、~/.local/share/rustnet/geoip、/usr/share/GeoIP、/usr/local/share/GeoIP、/opt/homebrew/share/GeoIP、/var/lib/GeoIP
+      --geoip-asn <PATH>
+          GeoLite2-ASN.mmdb 数据库的路径（搜索路径与 --geoip-country 相同）
+      --geoip-city <PATH>
+          GeoLite2-City.mmdb 数据库的路径（搜索路径与 --geoip-country 相同；是 Country 的超集：除国家外还提供城市名和邮政编码）
+      --no-geoip
+          完全禁用 GeoIP 查询
+      --no-sandbox
+          禁用沙箱（在 Linux 上仍会设置 PR_SET_NO_NEW_PRIVS）
+      --sandbox-strict
+          要求完整沙箱强制执行，否则退出
+      --no-uid-drop
+          初始化后保持 root 运行，不降权到 SUDO_UID/SUDO_GID（或 nobody）。保持 root 可让 lsof 回退方案在 PKTAP 不可用时归属其他用户的进程
+  -h, --help
+          打印帮助
+  -V, --version
+          打印版本
 ```
 
 使用可选 `kubernetes` feature 编译的版本（包括官方 Docker 镜像）还会提供 `--kubernetes <MODE>`。详见下文的 [`--kubernetes`](#--kubernetes-mode-optional-feature)。
@@ -313,7 +339,33 @@ rustnet --bpf-filter "not port 22"
 - `debug` —— 详细的调试信息
 - `trace` —— 非常详细的输出（包含数据包级详情）
 
-日志文件创建于 `logs/` 目录，带时间戳：`rustnet_YYYY-MM-DD_HH-MM-SS.log`
+日志文件创建于 `logs/` 目录，带时间戳：`rustnet_YYYY-MM-DD_HH-MM-SS.log`。在[无头模式](#headless-mode)下，日志改为输出到 stderr。
+
+#### `--headless`<a id="--headless"></a>
+
+不启动终端 UI，将连接事件以 JSON 行的形式流式输出到 stdout。启动流程、沙箱、uid 降权和数据富化与 TUI 完全相同，仅输出方式不同。配合 `--log-level` 时，日志行输出到 stderr，而不是写入 `logs/` 下的文件。事件格式详见[无头模式](#headless-mode)。
+
+```bash
+# 流式输出所有连接事件，并漂亮打印
+sudo rustnet --headless | jq .
+```
+
+#### `--snapshot-interval <SECONDS>`<a id="--snapshot-interval-seconds"></a>
+
+仅限无头模式。在逐连接事件之外，每隔 `SECONDS` 秒（正整数）发出一个包含完整连接表的 `snapshot` 事件。第一个快照在经过一个完整间隔后写出。需要 `--headless`。
+
+```bash
+sudo rustnet --headless --snapshot-interval 10
+```
+
+#### `--filter <QUERY>`<a id="--filter-query"></a>
+
+仅限无头模式。仅流式输出匹配 `QUERY` 的连接，语法与交互式 `/` 过滤器相同（见[过滤](#filtering)）：关键字项（如 `port:443` 或 `process:curl`）、自由文本，以及 `/regex/` 值，用空格组合（AND）。查询在捕获开始前进行检查；没有值的关键字（`port:`）或无效的正则表达式会报错退出。需要 `--headless`。
+
+```bash
+sudo rustnet --headless --filter 'port:443'
+sudo rustnet --headless --filter 'proto:udp dport:53'
+```
 
 #### `--kubernetes <MODE>`（可选 feature）<a id="--kubernetes-mode-optional-feature"></a>
 
@@ -330,7 +382,7 @@ rustnet --bpf-filter "not port 22"
 归属信息会出现在：
 
 - **详情标签页**的 Kubernetes 区域，包括 pod 名、namespace、pod UID、container 名和 container ID
-- **JSON 日志**（`--json-log`）和 `--pcap-export` sidecar JSONL 中，每个连接事件包含一个 `kubernetes` 对象
+- **JSON 日志**（`--json-log`）、`--headless` 事件流及其 `snapshot` 记录，以及 `--pcap-export` sidecar JSONL 中，每个连接事件包含一个 `kubernetes` 对象
 - **PCAPNG 数据包注释**（`--pcapng-export`）中，使用 `pod=`、`ns=`、`pod_uid=`、`container=` 和 `container_id=` 字段
 - `pod:`、`ns:` 和 `container:` [过滤关键字](#keyword-filters)
 
@@ -1210,9 +1262,83 @@ du -sh logs/
 
 对于性能问题，trace 级别日志提供最详细的细节，但会快速生成大量日志文件。
 
+### 无头模式<a id="headless-mode"></a>
+
+`--headless` 在不启动终端 UI 的情况下运行捕获管线，并将连接事件以 JSON 行（JSONL，每行一个对象）的形式流式输出到 stdout。它适用于通过管道交给 `jq` 或日志采集器处理，以及在没有 TTY 的服务管理器或容器中运行。
+
+```bash
+# 漂亮打印所有事件
+sudo rustnet --headless | jq .
+
+# 仅输出 HTTPS 连接的目的 IP
+sudo rustnet --headless --filter 'port:443' | jq -r '.destination_ip'
+
+# 每个已关闭连接的进程和发送字节数，丢弃日志输出
+sudo rustnet --headless 2>/dev/null | jq -c 'select(.event=="connection_closed") | {process_name,bytes_sent}'
+```
+
+**启动：** 无头模式经历与 TUI 相同的启动流程：权限检查、捕获和 eBPF 初始化、沙箱，以及 root uid 降权，随后是同样的进程归属、DPI、DNS 和 GeoIP 富化。不会触碰终端。stdout 只承载事件；权限提示横幅，以及配合 `--log-level` 时的日志行，都输出到 stderr 而不是 `logs/` 下的文件，因此 `rustnet --headless 2>/dev/null` 是一条干净的 JSONL 流。仅影响 UI 的选项（`--theme`、`--no-color`）不起作用。
+
+**事件类型：**
+
+| 事件 | 时机 | 字段 |
+|-------|------|--------|
+| `startup` | 仅一次，作为第一行，在捕获设备打开且沙箱应用之后 | 见下文 |
+| `new_connection` | 首次检测到某个连接时 | 与 [JSON 日志](#json-logging)相同 |
+| `connection_closed` | 连接在变为不活跃后被清理时 | 与 [JSON 日志](#json-logging)相同，包含 `bytes_sent`、`bytes_received` 和 `duration_secs` |
+| `snapshot` | 每隔 `--snapshot-interval` 秒 | 见下文 |
+
+每一行都包含 `timestamp`（RFC3339 UTC）和 `event`。`new_connection` 和 `connection_closed` 行与 `--json-log` 写入的内容相同；其字段在 [JSON 日志](#json-logging)中有说明。`new_connection` 行在看到连接的第一个数据包时即写出，此时进程归属、GeoIP 和 DPI 详情通常尚不可用，因此需要 `pid` 或 `process_name` 的消费者应使用 `connection_closed` 或 `snapshot` 事件，或按五元组（`protocol`、`source_ip`、`source_port`、`destination_ip`、`destination_port`）匹配各行。
+
+`startup` 字段：
+
+| 字段 | 类型 | 描述 |
+|-------|------|-------------|
+| `timestamp` | string | RFC3339 UTC 时间戳 |
+| `event` | string | `startup` |
+| `version` | string | RustNet 版本 |
+| `pid` | number | 此 RustNet 实例的进程 ID |
+| `interface` | string | 捕获接口（未知时省略） |
+| `link_type` | string | 捕获的链路层：`Ethernet`、`RawIp`、`LinuxSll`、`LinuxSll2`、`Pktap`、`Tun`、`Tap` 或 `Unknown` |
+| `sandbox` | string | 沙箱状态：`Fully enforced`、`Partially enforced`、`Not applied` 或 `Error`（Linux、Windows，以及启用 `macos-sandbox` feature 的 macOS 构建） |
+| `process_detection` | string | 正在使用的进程归属方法：Linux 为 `eBPF fentry/fexit + procfs`、`eBPF kprobe + procfs` 或 `procfs`；macOS 为 `pktap` 或 `lsof`；Windows 为 `windows-etw+iphlpapi` 或 `windows-iphlpapi`；FreeBSD 为 `sockstat`。该值为启动时报告的值，若进程归属在启动等待时间内尚未就绪，则可能为 `initializing...` |
+| `filter` | string | `--filter` 查询（未指定时省略） |
+| `snapshot_interval_secs` | number | `--snapshot-interval` 的值（未指定时省略） |
+
+`snapshot` 字段：
+
+| 字段 | 类型 | 描述 |
+|-------|------|-------------|
+| `timestamp` | string | RFC3339 UTC 时间戳 |
+| `event` | string | `snapshot` |
+| `connections` | array | 当前连接表中每个连接一个对象，字段与 `new_connection` 行相同，但不含 `timestamp` 和 `event` |
+
+快照中的表就是 TUI 显示的那张表：除非指定 `--show-localhost`，否则排除 localhost 连接；除非指定 `--show-ptr-lookups`，否则隐藏 DNS PTR 查找；并且每隔 `--refresh-interval` 毫秒刷新一次。第一个快照在经过一个完整间隔后写出，以便反映真实流量而非空表。
+
+**过滤：** `--filter QUERY` 将 `new_connection`、`connection_closed` 和 `snapshot` 表限制为匹配 `QUERY` 的连接；`startup` 行始终写出。语法与交互式 `/` 过滤器相同（见[过滤](#filtering)）：关键字项、自由文本，以及 `/regex/` 值，用空格组合（AND）。查询在捕获开始前进行检查，因此没有值的关键字（`port:`）或无效的正则表达式会立即失败，并在 stderr 上输出错误。
+
+```bash
+# 任意进程的 DNS 流量
+sudo rustnet --headless --filter 'proto:udp dport:53'
+
+# Firefox 到任意 github.com 主机的连接
+sudo rustnet --headless --filter 'process:firefox sni:/github\.com$/'
+```
+
+**背压：** stdout 由一个专用线程通过容量为 10,000 行的队列写入。如果消费者跟不上，事件会被丢弃，而不是阻塞数据包处理；丢弃的行数会以警告形式记录到日志（使用 `--log-level warn` 或更高级别可见）。
+
+**退出：**
+
+- `SIGINT`（Ctrl+C）、`SIGTERM` 或 `SIGHUP` 会停止流，写出队列中的行，并以状态码 0 退出。Windows 上尚未接入控制台控制处理程序，因此 Ctrl+C 或关闭控制台会直接结束进程，不会写出队列中的行。
+- 当消费者关闭管道时（例如 `rustnet --headless | head -n 20`），下一次写入失败，RustNet 以状态码 0 退出。
+- 数据包捕获失败时以状态码 1 退出，并在 stderr 上输出错误。
+- 未知选项、未配合 `--headless` 使用的 `--snapshot-interval` 或 `--filter`，或无效的 `--filter` 查询，会在捕获开始前报错退出。
+
+**与其他输出组合：** `--json-log FILE` 仍可与 `--headless` 一同使用，并接收所有 `new_connection` 和 `connection_closed` 事件，不受过滤影响；`--filter` 仅作用于 stdout。`--pcap-export` 和 `--pcapng-export` 与 TUI 中的行为相同。
+
 ### JSON 日志<a id="json-logging"></a>
 
-`--json-log` 选项启用将连接事件以结构化 JSON 格式记录到文件。每行是一个独立的 JSON 对象（JSONL 格式）。
+`--json-log` 选项启用将连接事件以结构化 JSON 格式记录到文件。每行是一个独立的 JSON 对象（JSONL 格式）。若要将同样的事件流式输出到 stdout 而非文件，请参阅[无头模式](#headless-mode)。
 
 ```bash
 # 启用 JSON 日志
@@ -1250,7 +1376,7 @@ sudo rustnet -i eth0 --json-log ~/network-events.json
 **示例输出：**<a id="example-output"></a>
 
 ```json
-{"timestamp":"2025-01-15T10:30:00Z","event":"new_connection","protocol":"TCP","source_ip":"192.168.1.100","source_port":54321,"destination_ip":"93.184.216.34","destination_port":443,"pid":1234,"process_name":"curl","service_name":"https","direction":"outgoing","dpi_protocol":"HTTPS","dpi_domain":"example.com"}
+{"timestamp":"2025-01-15T10:30:00Z","event":"new_connection","protocol":"TCP","source_ip":"192.168.1.100","source_port":54321,"destination_ip":"93.184.216.34","destination_port":443,"pid":1234,"process_name":"curl","service_name":"https","direction":"outgoing","dpi_protocol":"HTTPS (example.com)","dpi_domain":"example.com"}
 {"timestamp":"2025-01-15T10:30:05Z","event":"connection_closed","protocol":"TCP","source_ip":"192.168.1.100","source_port":54321,"destination_ip":"93.184.216.34","destination_port":443,"pid":1234,"process_name":"curl","service_name":"https","direction":"outgoing","bytes_sent":1024,"bytes_received":4096,"duration_secs":5}
 ```
 

--- a/examples/k8s_resolver_check.rs
+++ b/examples/k8s_resolver_check.rs
@@ -26,19 +26,9 @@ fn main() {
         Some(info) => {
             println!("--- resolver output ---");
             println!("{info:#?}");
-            // Mirror the JSON shape that log_connection_event would emit.
-            let mut obj = serde_json::Map::new();
-            if let Some(v) = info.pod_uid {
-                obj.insert("pod_uid".into(), serde_json::json!(v));
-            }
-            if let Some(v) = info.container_id {
-                obj.insert("container_id".into(), serde_json::json!(v));
-            }
-            if let Some(v) = info.cgroup_path {
-                obj.insert("cgroup_path".into(), serde_json::json!(v));
-            }
+            let block = rustnet_monitor::headless::events::KubernetesRecord::from_info(&info);
             println!("--- JSONL 'kubernetes' block ---");
-            println!("{}", serde_json::to_string(&obj).unwrap());
+            println!("{}", serde_json::to_string(&block).unwrap());
         }
         None => {
             println!("--- resolver returned None (no kubepods cgroup) ---");

--- a/src/app/capture.rs
+++ b/src/app/capture.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
+use crate::headless::sink::{EventSink, FileSink};
 use crate::network::{
     capture::{CaptureConfig, CapturedPacket, PacketReader, setup_packet_capture},
     dns::DnsResolver,
@@ -17,7 +18,7 @@ use crate::network::{
     tracker::{ConnectionTracker, IngestOutcome},
 };
 
-use super::logging::{JsonLineWriter, log_connection_closed, log_connection_event};
+use super::logging::{log_connection_closed, log_new_connection};
 use super::pcapng_export::{PcapngRecord, send_pcapng_record};
 use super::state::App;
 use super::types::AppStats;
@@ -501,7 +502,7 @@ impl App {
         let stats = Arc::clone(&self.stats);
         let linktype_storage = Arc::clone(&self.linktype);
         let capture_status = Arc::clone(&self.capture_status);
-        let json_log_file = self.json_log_file.clone();
+        let event_sinks = self.event_sinks.clone();
         let pcap_sidecar_file = self.pcap_sidecar_file.clone();
         let dns_resolver = self.dns_resolver.clone();
         let oui_lookup = self.oui_lookup.clone();
@@ -590,8 +591,8 @@ impl App {
                                     parsed,
                                     packet_timestamp,
                                     &stats,
-                                    &json_log_file,
-                                    &pcap_sidecar_file,
+                                    &event_sinks,
+                                    pcap_sidecar_file.as_deref(),
                                     dns_resolver.as_deref(),
                                 );
                                 parsed_count += 1;
@@ -671,8 +672,8 @@ fn update_connection(
     parsed: ParsedPacket,
     now: SystemTime,
     stats: &AppStats,
-    json_log_file: &Option<Arc<JsonLineWriter>>,
-    pcap_sidecar_file: &Option<Arc<JsonLineWriter>>,
+    event_sinks: &[Arc<dyn EventSink>],
+    pcap_sidecar: Option<&FileSink>,
     dns_resolver: Option<&DnsResolver>,
 ) -> IngestOutcome {
     let outcome = tracker.ingest_at(&parsed, now);
@@ -712,13 +713,7 @@ fn update_connection(
         stats
             .total_connections_archived
             .fetch_add(1, Ordering::Relaxed);
-        log_connection_closed(
-            conn,
-            now,
-            json_log_file.as_deref(),
-            pcap_sidecar_file.as_deref(),
-            dns_resolver,
-        );
+        log_connection_closed(conn, now, event_sinks, pcap_sidecar, dns_resolver);
         debug!(
             "Archived prior connection generation before creating a new one: {}",
             outcome.key
@@ -730,10 +725,10 @@ fn update_connection(
             .total_connections_created
             .fetch_add(1, Ordering::Relaxed);
         debug!("New connection detected: {}", outcome.key);
-        if let Some(writer) = json_log_file
+        if !event_sinks.is_empty()
             && let Some(conn) = tracker.connections().get(&outcome.key)
         {
-            log_connection_event(writer, "new_connection", conn.value(), None, dns_resolver);
+            log_new_connection(event_sinks, conn.value(), dns_resolver);
         }
     }
 
@@ -837,23 +832,19 @@ mod connection_lifecycle_tests {
         }
     }
 
-    fn json_writer(path: &Path) -> Arc<JsonLineWriter> {
+    fn json_writer(path: &Path) -> FileSink {
         let file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(path)
             .unwrap();
-        Arc::new(JsonLineWriter::new(
-            file,
-            path.to_string_lossy().into_owned(),
-        ))
+        FileSink::new(file, path.to_string_lossy().into_owned())
     }
 
     #[test]
     fn lifecycle_counters_record_new_and_replaced_generations() {
         let tracker = ConnectionTracker::new();
         let stats = AppStats::default();
-        let no_log = None;
         let started = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
 
         update_connection(
@@ -861,8 +852,8 @@ mod connection_lifecycle_tests {
             tcp_packet(flags(true, false)),
             started,
             &stats,
-            &no_log,
-            &no_log,
+            &[],
+            None,
             None,
         );
         update_connection(
@@ -870,8 +861,8 @@ mod connection_lifecycle_tests {
             tcp_packet(flags(false, true)),
             started + Duration::from_secs(1),
             &stats,
-            &no_log,
-            &no_log,
+            &[],
+            None,
             None,
         );
         update_connection(
@@ -879,8 +870,8 @@ mod connection_lifecycle_tests {
             tcp_packet(flags(true, false)),
             started + Duration::from_secs(2),
             &stats,
-            &no_log,
-            &no_log,
+            &[],
+            None,
             None,
         );
 
@@ -893,8 +884,8 @@ mod connection_lifecycle_tests {
         let dir = ScratchDir::new("lifecycle", "writers");
         let events_path = dir.path().join("events.jsonl");
         let sidecar_path = dir.path().join("capture.pcap.connections.jsonl");
-        let events = Some(json_writer(&events_path));
-        let sidecar = Some(json_writer(&sidecar_path));
+        let events: Vec<Arc<dyn EventSink>> = vec![Arc::new(json_writer(&events_path))];
+        let sidecar = json_writer(&sidecar_path);
         let tracker = ConnectionTracker::new();
         let stats = AppStats::default();
         let started = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
@@ -905,7 +896,7 @@ mod connection_lifecycle_tests {
             started,
             &stats,
             &events,
-            &sidecar,
+            Some(&sidecar),
             None,
         );
         update_connection(
@@ -914,7 +905,7 @@ mod connection_lifecycle_tests {
             started + Duration::from_secs(1),
             &stats,
             &events,
-            &sidecar,
+            Some(&sidecar),
             None,
         );
         update_connection(
@@ -923,7 +914,7 @@ mod connection_lifecycle_tests {
             started + Duration::from_secs(2),
             &stats,
             &events,
-            &sidecar,
+            Some(&sidecar),
             None,
         );
 

--- a/src/app/enrichment.rs
+++ b/src/app/enrichment.rs
@@ -424,14 +424,8 @@ impl App {
 #[cfg(test)]
 mod process_enrichment_tests {
     use super::process_enrichment_complete;
-    use crate::app::logging::process_lineage_json;
     use crate::network::types::UNKNOWN_PROCESS_NAME;
-    use crate::network::types::{
-        Connection, MatchQuality, ProcessAncestor, ProcessLineage, Protocol, ProtocolState,
-        TcpState,
-    };
-    use serde_json::json;
-    use std::path::PathBuf;
+    use crate::network::types::{Connection, MatchQuality, Protocol, ProtocolState, TcpState};
 
     fn connection() -> Connection {
         Connection::new(
@@ -474,31 +468,5 @@ mod process_enrichment_tests {
         conn.attribution_quality = Some(MatchQuality::Unspecified);
 
         assert!(!process_enrichment_complete(&conn));
-    }
-
-    #[test]
-    fn lineage_json_preserves_process_identity_fields() {
-        let lineage = ProcessLineage {
-            ancestors: vec![ProcessAncestor {
-                pid: 1,
-                name: "systemd".to_string(),
-                executable: Some(PathBuf::from("/usr/lib/systemd/systemd")),
-                started_at_unix_ms: Some(1_700_000_000_000),
-            }],
-            truncated: true,
-        };
-
-        assert_eq!(
-            process_lineage_json(&lineage),
-            json!({
-                "ancestors": [{
-                    "pid": 1,
-                    "name": "systemd",
-                    "executable": "/usr/lib/systemd/systemd",
-                    "started_at_unix_ms": 1_700_000_000_000_u64,
-                }],
-                "truncated": true,
-            })
-        );
     }
 }

--- a/src/app/logging.rs
+++ b/src/app/logging.rs
@@ -1,340 +1,47 @@
 //! JSONL event and PCAP-sidecar emission shared by the packet, cleanup, and
 //! shutdown paths.
 
-use log::warn;
-use serde_json::{Map, Value, json};
-use std::fs::File;
-use std::io::Write;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::SystemTime;
 
+use crate::headless::events::{ConnectionEvent, PcapSidecarRecord};
+use crate::headless::sink::{EventSink, FileSink, json_line, write_connection_event};
 use crate::network::dns::DnsResolver;
-use crate::network::geoip::GeoIpInfo;
-use crate::network::types::{AddrKind, ApplicationProtocol, Connection, ProcessLineage, Protocol};
+use crate::network::types::Connection;
 
-pub(super) fn process_lineage_json(lineage: &ProcessLineage) -> Value {
-    let ancestors: Vec<Value> = lineage
-        .ancestors
-        .iter()
-        .map(|ancestor| {
-            let mut value = Map::new();
-            value.insert("pid".to_string(), json!(ancestor.pid));
-            value.insert("name".to_string(), json!(ancestor.name));
-            if let Some(executable) = &ancestor.executable {
-                value.insert(
-                    "executable".to_string(),
-                    json!(executable.display().to_string()),
-                );
-            }
-            if let Some(started_at_unix_ms) = ancestor.started_at_unix_ms {
-                value.insert("started_at_unix_ms".to_string(), json!(started_at_unix_ms));
-            }
-            Value::Object(value)
-        })
-        .collect();
-    json!({
-        "ancestors": ancestors,
-        "truncated": lineage.truncated,
-    })
-}
-
-/// A JSONL writer opened before sandboxing and uid drop.
-///
-/// Keeping the descriptor open is required for paths such as `/root`: after
-/// dropping to the invoking user or `nobody`, the process may no longer be able
-/// to traverse the parent directory even when the file itself was chowned.
-pub(super) struct JsonLineWriter {
-    file: Mutex<File>,
-    path: String,
-    failure_reported: AtomicBool,
-}
-
-impl JsonLineWriter {
-    pub(super) fn new(file: File, path: String) -> Self {
-        Self {
-            file: Mutex::new(file),
-            path,
-            failure_reported: AtomicBool::new(false),
-        }
-    }
-
-    pub(super) fn write(&self, value: &serde_json::Value) {
-        let result = serde_json::to_string(value)
-            .map_err(std::io::Error::other)
-            .and_then(|json| {
-                let mut file = self
-                    .file
-                    .lock()
-                    .map_err(|_| std::io::Error::other("JSONL writer lock poisoned"))?;
-                writeln!(file, "{json}")
-            });
-
-        if let Err(e) = result
-            && !self.failure_reported.swap(true, Ordering::Relaxed)
-        {
-            warn!(
-                "Failed to write JSONL output '{}': {}. Further write errors will be suppressed.",
-                self.path, e
-            );
-        }
-    }
-}
-
-/// Address-kind and gateway markers, parameterized on the two key vocabularies
-/// (`source_`/`destination_` in the event log, `local_`/`remote_` in the
-/// sidecar). Only emitted for broadcast/multicast endpoints, keeping unicast
-/// records (and consumers of older logs) unchanged.
-fn add_addr_kind_fields(
-    event: &mut Value,
+/// Emit the `new_connection` event to every sink that accepts the
+/// connection.
+pub(super) fn log_new_connection(
+    sinks: &[Arc<dyn EventSink>],
     conn: &Connection,
-    local_key: &str,
-    remote_key: &str,
-    gateway_key: &str,
+    dns_resolver: Option<&DnsResolver>,
 ) {
-    if conn.local_addr_kind != AddrKind::Unicast {
-        event[local_key] = json!(conn.local_addr_kind.as_token());
-    }
-    if conn.remote_addr_kind != AddrKind::Unicast {
-        event[remote_key] = json!(conn.remote_addr_kind.as_token());
-    }
-    if conn.remote_is_gateway {
-        event[gateway_key] = json!(true);
-    }
-}
-
-/// Rich process-attribution fields shared by the event log and the sidecar:
-/// ppid, executable, uid/gid, match quality, lineage, the RTT estimate, and
-/// Kubernetes attribution. Both outputs are per connection, not per packet, so
-/// the verbose executable path costs nothing here (unlike a PCAPNG packet
-/// comment).
-fn add_process_fields(event: &mut Value, conn: &Connection) {
-    if let Some(ppid) = conn.process_ppid {
-        event["process_ppid"] = json!(ppid);
-    }
-    if let Some(executable) = &conn.executable {
-        event["process_executable"] = json!(executable.display().to_string());
-    }
-    if let Some(uid) = conn.process_uid {
-        event["process_uid"] = json!(uid);
-    }
-    if let Some(gid) = conn.process_gid {
-        event["process_gid"] = json!(gid);
-    }
-    if let Some(quality) = conn.attribution_quality {
-        event["attribution_match"] = json!(quality.as_token());
-    }
-    if let Some(lineage) = &conn.process_lineage {
-        event["process_lineage"] = process_lineage_json(lineage);
-    }
-
-    // Round-trip estimate: smoothed TCP data RTT, a handshake RTT, or the
-    // latest ICMP echo RTT. One decimal of milliseconds.
-    if let Some(rtt) = conn.current_rtt() {
-        event["rtt_ms"] = json!((rtt.as_secs_f64() * 10_000.0).round() / 10.0);
-    }
-
-    #[cfg(feature = "kubernetes")]
-    if let Some(k8s) = kubernetes_json(conn) {
-        event["kubernetes"] = k8s;
-    }
-}
-
-/// The six-field Kubernetes walk; `None` when no field is populated.
-#[cfg(feature = "kubernetes")]
-fn kubernetes_json(conn: &Connection) -> Option<Value> {
-    let k8s = conn.k8s_info.as_ref()?;
-    let mut obj = Map::new();
-    if let Some(v) = &k8s.pod_uid {
-        obj.insert("pod_uid".into(), json!(v));
-    }
-    if let Some(v) = &k8s.pod_name {
-        obj.insert("pod_name".into(), json!(v));
-    }
-    if let Some(v) = &k8s.pod_namespace {
-        obj.insert("pod_namespace".into(), json!(v));
-    }
-    if let Some(v) = &k8s.container_id {
-        obj.insert("container_id".into(), json!(v));
-    }
-    if let Some(v) = &k8s.container_name {
-        obj.insert("container_name".into(), json!(v));
-    }
-    if let Some(v) = &k8s.cgroup_path {
-        obj.insert("cgroup_path".into(), json!(v));
-    }
-    (!obj.is_empty()).then_some(Value::Object(obj))
-}
-
-/// GeoIP fields, added only when they have actual values.
-///
-/// Key order is irrelevant: `serde_json::Map` is a BTreeMap (no
-/// `preserve_order` feature), so output is sorted.
-fn add_geoip_fields(event: &mut Value, geoip: &GeoIpInfo) {
-    if let Some(ref cc) = geoip.country_code {
-        event["geoip_country_code"] = json!(cc);
-    }
-    if let Some(ref name) = geoip.country_name {
-        event["geoip_country_name"] = json!(name);
-    }
-    if let Some(asn) = geoip.asn {
-        event["geoip_asn"] = json!(asn);
-    }
-    if let Some(ref org) = geoip.as_org {
-        event["geoip_as_org"] = json!(org);
-    }
-    if let Some(ref city) = geoip.city {
-        event["geoip_city"] = json!(city);
-    }
-    if let Some(ref postal) = geoip.postal_code {
-        event["geoip_postal_code"] = json!(postal);
-    }
+    write_connection_event(sinks, conn, || {
+        ConnectionEvent::new_connection(conn, dns_resolver)
+    });
 }
 
 /// Record a closed (archived or timed-out) connection: the
-/// `connection_closed` JSONL event when JSON logging is enabled and the PCAP
-/// sidecar line when PCAP export is enabled. The duration is measured from
-/// the connection's `created_at` up to `now`.
+/// `connection_closed` event on every sink and the PCAP sidecar line when
+/// PCAP export is enabled. The duration is measured from the connection's
+/// `created_at` up to `now`.
 pub(super) fn log_connection_closed(
     conn: &Connection,
     now: SystemTime,
-    json_log: Option<&JsonLineWriter>,
-    pcap_sidecar: Option<&JsonLineWriter>,
+    sinks: &[Arc<dyn EventSink>],
+    pcap_sidecar: Option<&FileSink>,
     dns_resolver: Option<&DnsResolver>,
 ) {
-    let duration_secs = now
-        .duration_since(conn.created_at)
-        .map(|duration| duration.as_secs())
-        .ok();
-    if let Some(writer) = json_log {
-        log_connection_event(
-            writer,
-            "connection_closed",
-            conn,
-            duration_secs,
-            dns_resolver,
-        );
-    }
-    if let Some(writer) = pcap_sidecar {
-        log_pcap_connection(writer, conn);
-    }
-}
-
-/// Log a connection event as JSON.
-pub(super) fn log_connection_event(
-    writer: &JsonLineWriter,
-    event_type: &str,
-    conn: &Connection,
-    duration_secs: Option<u64>,
-    dns_resolver: Option<&DnsResolver>,
-) {
-    let mut event = json!({
-        "timestamp": chrono::Utc::now().to_rfc3339(),
-        "event": event_type,
-        "protocol": conn.protocol.to_string(),
-        "source_ip": conn.local_addr.ip().to_string(),
-        "source_port": conn.local_addr.port(),
-        "destination_ip": conn.remote_addr.ip().to_string(),
-        "destination_port": conn.remote_addr.port(),
+    write_connection_event(sinks, conn, || {
+        ConnectionEvent::connection_closed(conn, now, dns_resolver)
     });
-
-    add_addr_kind_fields(
-        &mut event,
-        conn,
-        "source_addr_kind",
-        "destination_addr_kind",
-        "destination_is_gateway",
-    );
-
-    // ARP connections are skipped: DNS lookups generate ARP traffic, so
-    // resolving them would feed back on itself.
-    if let Some(resolver) = dns_resolver.filter(|_| conn.protocol != Protocol::Arp) {
-        if let Some(hostname) = resolver.get_hostname(&conn.remote_addr.ip()) {
-            event["destination_hostname"] = json!(hostname);
-        }
-        if let Some(hostname) = resolver.get_hostname(&conn.local_addr.ip()) {
-            event["source_hostname"] = json!(hostname);
-        }
+    if let Some(sidecar) = pcap_sidecar {
+        log_pcap_connection(sidecar, conn);
     }
-
-    if let Some(pid) = conn.pid {
-        event["pid"] = json!(pid);
-    }
-    if let Some(process_name) = &conn.process_name {
-        event["process_name"] = json!(process_name);
-    }
-    add_process_fields(&mut event, conn);
-
-    if let Some(service_name) = &conn.service_name {
-        event["service_name"] = json!(service_name);
-    }
-
-    // Direction is only known for TCP when the handshake was observed.
-    if let Some(is_outgoing) = conn.connection_direction {
-        event["direction"] = json!(if is_outgoing { "outgoing" } else { "incoming" });
-    }
-
-    if let Some(dpi) = &conn.dpi_info {
-        event["dpi_protocol"] = json!(dpi.application.to_string());
-
-        if let Some(domain) = dpi_domain(&dpi.application) {
-            event["dpi_domain"] = json!(domain);
-        }
-    }
-
-    if let Some(ref geoip) = conn.geoip_info {
-        add_geoip_fields(&mut event, geoip);
-    }
-
-    if event_type == "connection_closed" {
-        event["bytes_sent"] = json!(conn.bytes_sent);
-        event["bytes_received"] = json!(conn.bytes_received);
-        if let Some(duration) = duration_secs {
-            event["duration_secs"] = json!(duration);
-        }
-    }
-
-    writer.write(&event);
 }
 
-/// Log a connection to the PCAP sidecar (JSONL).
-pub(super) fn log_pcap_connection(writer: &JsonLineWriter, conn: &Connection) {
-    let mut event = json!({
-        "timestamp": chrono::Utc::now().to_rfc3339(),
-        "protocol": conn.protocol.to_string(),
-        "local_addr": conn.local_addr.to_string(),
-        "remote_addr": conn.remote_addr.to_string(),
-        "pid": conn.pid,
-        "process_name": conn.process_name,
-        "first_seen": conn.created_at,
-        "last_seen": conn.last_activity,
-        "bytes_sent": conn.bytes_sent,
-        "bytes_received": conn.bytes_received,
-        "state": conn.state(),
-    });
-
-    add_addr_kind_fields(
-        &mut event,
-        conn,
-        "local_addr_kind",
-        "remote_addr_kind",
-        "remote_is_gateway",
-    );
-
-    add_process_fields(&mut event, conn);
-
-    if let Some(ref geoip) = conn.geoip_info {
-        add_geoip_fields(&mut event, geoip);
-    }
-
-    writer.write(&event);
-}
-
-/// Domain reported for a connection: DNS query name, or the hostname from
-/// the payload (SNI or HTTP Host) for other protocols.
-pub(super) fn dpi_domain(application: &ApplicationProtocol) -> Option<&str> {
-    match application {
-        ApplicationProtocol::Dns(info) => info.query_name.as_deref(),
-        _ => application.hostname(),
+pub(super) fn log_pcap_connection(sidecar: &FileSink, conn: &Connection) {
+    if let Some(line) = json_line(&PcapSidecarRecord::from_connection(conn)) {
+        sidecar.write_line(&line);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,6 +12,7 @@ mod sampling;
 mod state;
 mod types;
 
+pub(crate) use sampling::sleep_unless_stopped;
 pub use state::App;
 pub(crate) use types::ConnectionCounts;
 pub use types::{AppOutputHandles, AppStats, Config, UNKNOWN_PROCESS_GROUP, process_group_label};

--- a/src/app/pcapng_export.rs
+++ b/src/app/pcapng_export.rs
@@ -13,12 +13,12 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
 use crate::export::pcapng::{self, PcapngWriter};
+use crate::headless::events::dpi_domain;
 use crate::network::capture::CaptureConfig;
 use crate::network::tracker::ConnectionTracker;
 use crate::network::types::{Connection, ConnectionKey};
 
 use super::capture::{LinktypeWait, wait_for_linktype};
-use super::logging::dpi_domain;
 use super::state::App;
 use super::types::AppStats;
 use super::{MAX_PCAPNG_QUEUE, MAX_PCAPNG_RETRY_BYTES, MAX_PCAPNG_RETRY_RECORDS};

--- a/src/app/sampling.rs
+++ b/src/app/sampling.rs
@@ -27,7 +27,7 @@ use super::{LIVE_RATE_INTERVAL, MIN_RATE_SAMPLE_SECONDS, TRAFFIC_HISTORY_CAPACIT
 const STOP_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Sleep for `interval`, returning early once shutdown is requested.
-fn sleep_unless_stopped(should_stop: &AtomicBool, interval: Duration) {
+pub(crate) fn sleep_unless_stopped(should_stop: &AtomicBool, interval: Duration) {
     let deadline = Instant::now() + interval;
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
@@ -426,7 +426,7 @@ impl App {
     }
 
     pub(super) fn start_cleanup_thread(&self, tracker: Arc<ConnectionTracker>) -> Result<()> {
-        let json_log_file = self.json_log_file.clone();
+        let event_sinks = self.event_sinks.clone();
         let pcap_sidecar_file = self.pcap_sidecar_file.clone();
         let dns_resolver = self.dns_resolver.clone();
         let stats = Arc::clone(&self.stats);
@@ -450,7 +450,7 @@ impl App {
                     log_connection_closed(
                         conn,
                         now,
-                        json_log_file.as_deref(),
+                        &event_sinks,
                         pcap_sidecar_file.as_deref(),
                         dns_resolver.as_deref(),
                     );

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -16,6 +16,7 @@ use std::time::SystemTime;
 use std::time::{Duration, Instant};
 
 use crate::filter::ConnectionFilter;
+use crate::headless::sink::{EventSink, FileSink};
 #[cfg(test)]
 use crate::network::parser::ParsedPacket;
 use crate::network::{
@@ -32,7 +33,7 @@ use crate::network::{
 };
 
 use super::capture::CaptureStatus;
-use super::logging::{JsonLineWriter, log_pcap_connection};
+use super::logging::log_pcap_connection;
 use super::types::{
     AppOutputHandles, AppStats, Config, ConnRateHistory, ConnRateHistorySnapshot, ConnectionCounts,
     ProcessDetectionStatus,
@@ -145,11 +146,12 @@ pub struct App {
     /// the sandbox is applied so they inherit it). Taken by `start_workers`.
     pub(super) packet_rx: Option<Receiver<Vec<CapturedPacket>>>,
 
-    /// JSONL outputs opened before sandboxing and uid drop. Worker threads
-    /// share these handles so they never need to traverse the configured path
-    /// after privileges have been reduced.
-    pub(super) json_log_file: Option<Arc<JsonLineWriter>>,
-    pub(super) pcap_sidecar_file: Option<Arc<JsonLineWriter>>,
+    /// Connection-event sinks: the `--json-log` file and any stream the
+    /// front-end added. Worker threads share these handles so they never
+    /// need to traverse a configured path after privileges have been reduced.
+    pub(super) event_sinks: Vec<Arc<dyn EventSink>>,
+    /// The PCAP sidecar JSONL, opened before sandboxing and uid drop.
+    pub(super) pcap_sidecar_file: Option<Arc<FileSink>>,
 
     /// Pre-created PCAPNG output file. Held until worker startup so the writer
     /// thread can use the exact file handle allowed by the sandbox.
@@ -218,28 +220,34 @@ impl App {
 
     pub fn new_with_output_handles(
         config: Config,
-        mut output_handles: AppOutputHandles,
+        output_handles: AppOutputHandles,
     ) -> Result<Self> {
-        if config.json_log_file.is_some() != output_handles.json_log.is_some() {
+        let AppOutputHandles {
+            json_log,
+            pcap_sidecar,
+            pcapng_export,
+            mut event_sinks,
+        } = output_handles;
+        if config.json_log_file.is_some() != json_log.is_some() {
             anyhow::bail!("JSON logging requires exactly one matching pre-opened output handle");
         }
-        if config.pcap_export_file.is_some() != output_handles.pcap_sidecar.is_some() {
+        if config.pcap_export_file.is_some() != pcap_sidecar.is_some() {
             anyhow::bail!(
                 "PCAP export requires exactly one matching pre-opened sidecar output handle"
             );
         }
-        if config.pcapng_export_file.is_some() != output_handles.pcapng_export.is_some() {
+        if config.pcapng_export_file.is_some() != pcapng_export.is_some() {
             anyhow::bail!("PCAPNG export requires exactly one matching pre-opened output handle");
         }
 
-        let json_log_file = output_handles.json_log.take().map(|file| {
-            Arc::new(JsonLineWriter::new(
+        if let Some(file) = json_log {
+            event_sinks.push(Arc::new(FileSink::new(
                 file,
                 config.json_log_file.clone().unwrap_or_default(),
-            ))
-        });
-        let pcap_sidecar_file = output_handles.pcap_sidecar.take().map(|file| {
-            Arc::new(JsonLineWriter::new(
+            )));
+        }
+        let pcap_sidecar_file = pcap_sidecar.map(|file| {
+            Arc::new(FileSink::new(
                 file,
                 config
                     .pcap_export_file
@@ -301,9 +309,9 @@ impl App {
             dns_resolver,
             geoip_resolver,
             packet_rx: None,
-            json_log_file,
+            event_sinks,
             pcap_sidecar_file,
-            pcapng_export_file: output_handles.pcapng_export.take(),
+            pcapng_export_file: pcapng_export,
             sandbox_info: Arc::new(RwLock::new(SandboxReport::default())),
             workers: Mutex::new(Vec::new()),
         })
@@ -362,6 +370,10 @@ impl App {
     /// untrusted-input DPI parsers inside the Landlock domain on Linux.
     pub fn start_workers(&mut self) -> Result<()> {
         let tracker = Arc::clone(&self.tracker);
+
+        for sink in &self.event_sinks {
+            sink.start();
+        }
 
         let pcapng_tx = self.start_pcapng_export_thread(tracker.clone())?;
 
@@ -779,33 +791,48 @@ impl App {
         }
 
         self.join_workers();
+
+        // Producers are gone, so the sinks' writer threads see the complete
+        // event stream before they drain and exit.
+        let mut sink_threads: Vec<JoinHandle<()>> = self
+            .event_sinks
+            .iter()
+            .filter_map(|sink| sink.shutdown())
+            .collect();
+        join_with_timeout(&mut sink_threads);
     }
 
     fn join_workers(&self) {
         let mut workers = self.workers.lock().unwrap_or_else(PoisonError::into_inner);
-        let deadline = Instant::now() + WORKER_JOIN_TIMEOUT;
-        loop {
-            for handle in workers.extract_if(.., |handle| handle.is_finished()) {
-                let name = thread_label(&handle);
-                if handle.join().is_err() {
-                    warn!("Worker thread {name} panicked");
-                }
+        join_with_timeout(&mut workers);
+    }
+}
+
+/// Join every finished thread, waiting at most [`WORKER_JOIN_TIMEOUT`] for
+/// the rest; whatever is still running is detached.
+fn join_with_timeout(threads: &mut Vec<JoinHandle<()>>) {
+    let deadline = Instant::now() + WORKER_JOIN_TIMEOUT;
+    loop {
+        for handle in threads.extract_if(.., |handle| handle.is_finished()) {
+            let name = thread_label(&handle);
+            if handle.join().is_err() {
+                warn!("Worker thread {name} panicked");
             }
-            if workers.is_empty() || Instant::now() >= deadline {
-                break;
-            }
-            thread::sleep(Duration::from_millis(10));
         }
-        if !workers.is_empty() {
-            let names: Vec<String> = workers.iter().map(thread_label).collect();
-            warn!(
-                "Worker threads still running after {:?}, exiting without them: {}",
-                WORKER_JOIN_TIMEOUT,
-                names.join(", ")
-            );
-            // Dropping the handles detaches the threads; process exit reaps them.
-            workers.clear();
+        if threads.is_empty() || Instant::now() >= deadline {
+            break;
         }
+        thread::sleep(Duration::from_millis(10));
+    }
+    if !threads.is_empty() {
+        let names: Vec<String> = threads.iter().map(thread_label).collect();
+        warn!(
+            "Worker threads still running after {:?}, exiting without them: {}",
+            WORKER_JOIN_TIMEOUT,
+            names.join(", ")
+        );
+        // Dropping the handles detaches the threads; process exit reaps them.
+        threads.clear();
     }
 }
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -4,10 +4,11 @@
 
 use std::collections::{HashSet, VecDeque};
 use std::fs::File;
-use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
 use std::time::{Instant, SystemTime};
 
+use crate::headless::sink::EventSink;
 use crate::network::types::{Connection, GraphScale, Protocol, UNKNOWN_PROCESS_NAME};
 
 /// Process detection status information for UI display
@@ -113,11 +114,15 @@ impl Default for Config {
     }
 }
 
+/// Output descriptors opened by the front-end before sandboxing and uid
+/// drop, plus any extra connection-event sinks (a stdout stream, for
+/// instance) that receive the same events as `json_log`.
 #[derive(Default)]
 pub struct AppOutputHandles {
     pub json_log: Option<File>,
     pub pcap_sidecar: Option<File>,
     pub pcapng_export: Option<File>,
+    pub event_sinks: Vec<Arc<dyn EventSink>>,
 }
 
 /// Group label shown for connections without a resolved process name.

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -10,11 +10,22 @@ use simplelog::{ConfigBuilder, WriteLogger};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::app::{App, AppOutputHandles, Config};
+use crate::headless::sink::EventSink;
 use crate::network;
+
+/// Which front-end is starting. Decides where diagnostics go: the TUI owns
+/// the terminal, so its log goes to `logs/`; the headless stream owns
+/// stdout, so its log goes to stderr and no log directory is needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Frontend {
+    Tui,
+    Headless,
+}
 
 /// Everything resolved before the application starts: the [`Config`], the
 /// retained output descriptors, and the sandbox policy. The privileged
@@ -29,9 +40,9 @@ pub struct Prepared {
 
 /// Run the unprivileged startup steps: Npcap delay-load (Windows), logging,
 /// the privilege check (its banner goes to stderr), the [`Config`], the uid
-/// drop target, the output files, and the sandbox policy.
-/// `show_startup_splash` is forwarded to [`Config::show_startup_splash`].
-pub fn prepare(matches: &ArgMatches, show_startup_splash: bool) -> Result<Prepared> {
+/// drop target, the output files, and the sandbox policy. Only the TUI gets
+/// the startup splash.
+pub fn prepare(matches: &ArgMatches, frontend: Frontend) -> Result<Prepared> {
     // Clap handles --help and --version before this point, so both remain
     // available even when Npcap is not installed. The Npcap DLLs are
     // delay-loaded so Windows can enter main() before resolving those imports.
@@ -42,14 +53,14 @@ pub fn prepare(matches: &ArgMatches, show_startup_splash: bool) -> Result<Prepar
         let log_level = log_level_str
             .parse::<LevelFilter>()
             .map_err(|_| anyhow::anyhow!("Invalid log level: {}", log_level_str))?;
-        setup_logging(log_level)?;
+        setup_logging(log_level, frontend)?;
     }
 
     // Check privileges before any front-end takes over the terminal, so the
     // error message stays visible.
     check_privileges_early()?;
 
-    let config = build_config(matches, show_startup_splash);
+    let config = build_config(matches, frontend == Frontend::Tui);
 
     // Resolve the identity to drop root to after privileged init (Linux,
     // macOS, and FreeBSD): the invoking sudo user, or nobody when started as
@@ -121,7 +132,7 @@ pub fn prepare(matches: &ArgMatches, show_startup_splash: bool) -> Result<Prepar
         output_handles.pcapng_export = Some(file);
     }
 
-    let (read_paths, write_paths) = sandbox_paths(matches, &config);
+    let (read_paths, write_paths) = sandbox_paths(matches, &config, frontend);
     let sandbox_config = SandboxConfig {
         mode: SandboxMode::from_flags(
             matches.get_flag("no-sandbox"),
@@ -146,11 +157,24 @@ pub fn prepare(matches: &ArgMatches, show_startup_splash: bool) -> Result<Prepar
 }
 
 impl Prepared {
+    /// Add a destination for the connection events, alongside `--json-log`.
+    pub(crate) fn add_event_sink(&mut self, sink: Arc<dyn EventSink>) {
+        self.output_handles.event_sinks.push(sink);
+    }
+
     /// Start the privileged subsystems, wait for them, apply the sandbox on
     /// the calling thread, then start the worker threads and install the
     /// shutdown signal handlers. Must run on the main thread: the sandbox
     /// restrictions are per-thread state that the workers inherit from it.
     pub(crate) fn launch(self) -> Result<App> {
+        self.launch_with(|_| {})
+    }
+
+    /// [`launch`](Self::launch) with a hook that runs once the capture
+    /// device is open and the sandbox is applied, but before any worker
+    /// thread exists: nothing has been emitted to the event sinks yet, so
+    /// a line written from the hook is the first one in every stream.
+    pub(crate) fn launch_with(self, before_workers: impl FnOnce(&App)) -> Result<App> {
         let mut app = App::new_with_output_handles(self.config, self.output_handles)?;
         let (process_ready_rx, capture_ready_rx) = app.start()?;
         info!("Application started");
@@ -185,6 +209,8 @@ impl Prepared {
                 app.set_sandbox_info(SandboxReport::from_error(&e));
             }
         }
+
+        before_workers(&app);
 
         // Now that the sandbox has been applied on the main thread, start the worker
         // threads (DPI packet processors, enrichment, snapshot, cleanup, collectors).
@@ -294,7 +320,11 @@ fn build_config(matches: &ArgMatches, show_startup_splash: bool) -> Config {
 }
 
 /// The filesystem paths the sandbox must keep readable and writable.
-fn sandbox_paths(matches: &ArgMatches, config: &Config) -> (Vec<PathBuf>, Vec<PathBuf>) {
+fn sandbox_paths(
+    matches: &ArgMatches,
+    config: &Config,
+    frontend: Frontend,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
     // Collect read paths (GeoIP databases). Exclude the bare current-directory
     // entry: a Landlock PathBeneath rule on "." grants recursive read access to
     // the entire CWD subtree (e.g. all of $HOME when rustnet is launched from
@@ -361,7 +391,7 @@ fn sandbox_paths(matches: &ArgMatches, config: &Config) -> (Vec<PathBuf>, Vec<Pa
     // every configured output file (JSON log, PCAP export + its sidecar
     // JSONL, PCAPNG export). Ignored by backends without filesystem rules.
     let mut write_paths: Vec<PathBuf> = Vec::new();
-    if matches.get_one::<String>("log-level").is_some() {
+    if frontend == Frontend::Tui && matches.get_one::<String>("log-level").is_some() {
         write_paths.push(PathBuf::from("logs"));
     }
     if let Some(json_log_path) = &config.json_log_file {
@@ -378,7 +408,36 @@ fn sandbox_paths(matches: &ArgMatches, config: &Config) -> (Vec<PathBuf>, Vec<Pa
     (read_paths, write_paths)
 }
 
-fn setup_logging(level: LevelFilter) -> Result<()> {
+/// Install the logger: a timestamped file under `logs/` for the TUI, stderr
+/// for the headless stream (stdout carries the events).
+fn setup_logging(level: LevelFilter, frontend: Frontend) -> Result<()> {
+    // `target` names the emitting subsystem (e.g. `network::dpi::dns`); the
+    // banner below identifies the binary.
+    let config = ConfigBuilder::new()
+        .set_target_level(LevelFilter::Error)
+        .build();
+
+    match frontend {
+        Frontend::Tui => WriteLogger::init(level, config, open_log_file()?)?,
+        Frontend::Headless => WriteLogger::init(level, config, io::stderr())?,
+    }
+
+    // Startup banner: one identifying header so a user grepping a
+    // long-lived log file can immediately see which binary, which
+    // version, and which pid produced these lines. The `pkg_name` is
+    // the cargo package name (`rustnet-monitor`), not `argv[0]`, so it
+    // stays correct when the binary is renamed or symlinked.
+    info!(
+        "{} v{} starting (pid {})",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+        std::process::id()
+    );
+
+    Ok(())
+}
+
+fn open_log_file() -> Result<fs::File> {
     // The log directory is resolved relative to the current working directory.
     // rustnet typically runs as root, so a pre-planted symlink at `logs/` (e.g.
     // `logs -> /etc`) would let an attacker who controls the launch directory
@@ -412,29 +471,7 @@ fn setup_logging(level: LevelFilter) -> Result<()> {
 
     // The path is predictable (timestamped), so it gets the same
     // symlink-refusing, private-mode open as the other output files.
-    let log_file = open_private(&log_file_path, false)?;
-
-    // `target` names the emitting subsystem (e.g. `network::dpi::dns`); the
-    // banner below identifies the binary.
-    let config = ConfigBuilder::new()
-        .set_target_level(LevelFilter::Error)
-        .build();
-
-    WriteLogger::init(level, config, log_file)?;
-
-    // Startup banner: one identifying header so a user grepping a
-    // long-lived log file can immediately see which binary, which
-    // version, and which pid produced these lines. The `pkg_name` is
-    // the cargo package name (`rustnet-monitor`), not `argv[0]`, so it
-    // stays correct when the binary is renamed or symlinked.
-    info!(
-        "{} v{} starting (pid {})",
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION"),
-        std::process::id()
-    );
-
-    Ok(())
+    Ok(open_private(&log_file_path, false)?)
 }
 
 /// Wait up to 10 s for a background subsystem to signal that its

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,29 @@ pub fn build_cli() -> Command {
                 .required(false),
         )
         .arg(
+            Arg::new("headless")
+                .long("headless")
+                .help("Run without the terminal UI and stream connection events as JSON lines to stdout (log output goes to stderr)")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("snapshot-interval")
+                .long("snapshot-interval")
+                .value_name("SECONDS")
+                .help("Emit a snapshot event with the full connection table every SECONDS seconds (headless only)")
+                .value_parser(clap::value_parser!(u64).range(1..))
+                .requires("headless")
+                .required(false),
+        )
+        .arg(
+            Arg::new("filter")
+                .long("filter")
+                .value_name("QUERY")
+                .help("Only stream connections matching QUERY, using the same syntax as the interactive / filter (headless only)")
+                .requires("headless")
+                .required(false),
+        )
+        .arg(
             Arg::new("pcap-export")
                 .long("pcap-export")
                 .value_name("FILE")
@@ -234,6 +257,46 @@ mod tests {
             .expect("default CLI arguments should parse");
 
         assert_eq!(matches.get_one::<u64>("refresh-interval"), Some(&500));
+    }
+
+    #[test]
+    fn headless_only_flags_require_headless() {
+        for args in [
+            ["rustnet", "--snapshot-interval", "5"],
+            ["rustnet", "--filter", "port:443"],
+        ] {
+            let err = build_cli()
+                .try_get_matches_from(args)
+                .expect_err("headless-only flag without --headless must be rejected");
+            assert!(
+                err.to_string().contains("--headless"),
+                "error should name --headless: {err}"
+            );
+        }
+
+        let matches = build_cli()
+            .try_get_matches_from([
+                "rustnet",
+                "--headless",
+                "--snapshot-interval",
+                "5",
+                "--filter",
+                "port:443",
+            ])
+            .expect("headless flags should parse together");
+        assert!(matches.get_flag("headless"));
+        assert_eq!(matches.get_one::<u64>("snapshot-interval"), Some(&5));
+        assert_eq!(
+            matches.get_one::<String>("filter").map(String::as_str),
+            Some("port:443")
+        );
+
+        assert!(
+            build_cli()
+                .try_get_matches_from(["rustnet", "--headless", "--snapshot-interval", "0"])
+                .is_err(),
+            "a zero-second snapshot interval must be rejected"
+        );
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -7,6 +7,7 @@
 
 use crate::network::types::{ApplicationProtocol, Connection, ProtocolState};
 use regex_lite::Regex;
+use std::fmt;
 
 /// How to match a text field (case-insensitive for literals; regex handles its own flags)
 #[derive(Debug, Clone)]
@@ -69,13 +70,44 @@ pub struct ConnectionFilter {
     criteria: Vec<FilterCriteria>,
 }
 
+/// A mistake in a filter query that the interactive parser tolerates (it
+/// runs on every keystroke) but a query given once, up front, should not
+/// silently get past.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterError {
+    /// A known keyword with nothing after the colon, such as `port:`.
+    EmptyValue(String),
+    /// A `/pattern/` literal that does not compile.
+    InvalidRegex { pattern: String, message: String },
+}
+
+impl fmt::Display for FilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyValue(term) => write!(f, "\"{term}\" has no value after the colon"),
+            Self::InvalidRegex { pattern, message } => {
+                write!(f, "invalid regex /{pattern}/: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FilterError {}
+
+/// The pattern inside a `/pattern/` regex literal.
+fn regex_literal(value: &str) -> Option<&str> {
+    value
+        .strip_prefix('/')
+        .and_then(|rest| rest.strip_suffix('/'))
+        .filter(|pattern| !pattern.is_empty())
+}
+
 /// Parse a filter value string into a `PortMatch`.
 /// - `/pattern/`  → regex
 /// - all-digit    → exact u16 equality
 /// - anything else → substring contains
 fn parse_port_match(value: &str) -> PortMatch {
-    if value.starts_with('/') && value.ends_with('/') && value.len() > 2 {
-        let pattern = &value[1..value.len() - 1];
+    if let Some(pattern) = regex_literal(value) {
         match Regex::new(pattern) {
             Ok(re) => PortMatch::Regex(re),
             Err(_) => PortMatch::Partial(value.to_string()),
@@ -94,8 +126,7 @@ fn parse_port_match(value: &str) -> PortMatch {
 /// - `/pattern/`  → case-insensitive regex
 /// - anything else → case-insensitive literal contains
 fn parse_filter_value(value: &str) -> FilterValue {
-    if value.starts_with('/') && value.ends_with('/') && value.len() > 2 {
-        let pattern = &value[1..value.len() - 1];
+    if let Some(pattern) = regex_literal(value) {
         match Regex::new(&format!("(?i){pattern}")) {
             Ok(re) => FilterValue::Regex(re),
             Err(_) => FilterValue::Literal(value.to_string()),
@@ -103,6 +134,35 @@ fn parse_filter_value(value: &str) -> FilterValue {
     } else {
         FilterValue::Literal(value.to_string())
     }
+}
+
+/// The criterion for a lowercased `keyword:value` term, or `None` when the
+/// keyword is not one of the filter's (the term is then a general search,
+/// which keeps `10.0.0.1:443` and IPv6 literals usable).
+fn keyword_criterion(keyword: &str, value: &str) -> Option<FilterCriteria> {
+    let criterion = match keyword {
+        "port" => FilterCriteria::Port(parse_port_match(value)),
+        "sport" | "srcport" | "source-port" => FilterCriteria::SourcePort(parse_port_match(value)),
+        "dport" | "dstport" | "dest-port" | "destination-port" => {
+            FilterCriteria::DestinationPort(parse_port_match(value))
+        }
+        "src" | "source" => FilterCriteria::SourceIp(parse_filter_value(value)),
+        "dst" | "dest" | "destination" => FilterCriteria::DestinationIp(parse_filter_value(value)),
+        "proto" | "protocol" => FilterCriteria::Protocol(parse_filter_value(value)),
+        "process" | "proc" => FilterCriteria::Process(parse_filter_value(value)),
+        "service" | "svc" => FilterCriteria::Service(parse_filter_value(value)),
+        "sni" | "host" | "hostname" => FilterCriteria::Sni(parse_filter_value(value)),
+        "app" | "application" => FilterCriteria::Application(parse_filter_value(value)),
+        "state" => FilterCriteria::State(parse_filter_value(value)),
+        #[cfg(feature = "kubernetes")]
+        "pod" => FilterCriteria::Pod(parse_filter_value(value)),
+        #[cfg(feature = "kubernetes")]
+        "ns" | "namespace" => FilterCriteria::Namespace(parse_filter_value(value)),
+        #[cfg(feature = "kubernetes")]
+        "container" | "cont" => FilterCriteria::Container(parse_filter_value(value)),
+        _ => return None,
+    };
+    Some(criterion)
 }
 
 /// Match a port number against a `PortMatch`.
@@ -133,78 +193,48 @@ fn any_text_matches<'a>(
 
 impl ConnectionFilter {
     pub fn parse(query: &str) -> Self {
-        let mut criteria = Vec::new();
-
-        if query.trim().is_empty() {
-            return Self { criteria };
-        }
-
-        let parts: Vec<&str> = query.split_whitespace().collect();
-
-        for part in parts {
-            if let Some((keyword, value)) = part.split_once(':') {
-                let value = value.to_lowercase();
-                match keyword.to_lowercase().as_str() {
-                    "port" => {
-                        criteria.push(FilterCriteria::Port(parse_port_match(&value)));
-                    }
-                    "sport" | "srcport" | "source-port" => {
-                        criteria.push(FilterCriteria::SourcePort(parse_port_match(&value)));
-                    }
-                    "dport" | "dstport" | "dest-port" | "destination-port" => {
-                        criteria.push(FilterCriteria::DestinationPort(parse_port_match(&value)));
-                    }
-                    "src" | "source" => {
-                        criteria.push(FilterCriteria::SourceIp(parse_filter_value(&value)));
-                    }
-                    "dst" | "dest" | "destination" => {
-                        criteria.push(FilterCriteria::DestinationIp(parse_filter_value(&value)));
-                    }
-                    "proto" | "protocol" => {
-                        criteria.push(FilterCriteria::Protocol(parse_filter_value(&value)));
-                    }
-                    "process" | "proc" => {
-                        criteria.push(FilterCriteria::Process(parse_filter_value(&value)));
-                    }
-                    "service" | "svc" => {
-                        criteria.push(FilterCriteria::Service(parse_filter_value(&value)));
-                    }
-                    "sni" | "host" | "hostname" => {
-                        criteria.push(FilterCriteria::Sni(parse_filter_value(&value)));
-                    }
-                    "app" | "application" => {
-                        criteria.push(FilterCriteria::Application(parse_filter_value(&value)));
-                    }
-                    "state" => {
-                        criteria.push(FilterCriteria::State(parse_filter_value(&value)));
-                    }
-                    #[cfg(feature = "kubernetes")]
-                    "pod" => {
-                        criteria.push(FilterCriteria::Pod(parse_filter_value(&value)));
-                    }
-                    #[cfg(feature = "kubernetes")]
-                    "ns" | "namespace" => {
-                        criteria.push(FilterCriteria::Namespace(parse_filter_value(&value)));
-                    }
-                    #[cfg(feature = "kubernetes")]
-                    "container" | "cont" => {
-                        criteria.push(FilterCriteria::Container(parse_filter_value(&value)));
-                    }
-                    _ => {
-                        // Unknown keyword, treat as general search
-                        criteria.push(FilterCriteria::General(parse_filter_value(
-                            &part.to_lowercase(),
-                        )));
-                    }
-                }
-            } else {
-                criteria.push(FilterCriteria::General(parse_filter_value(
-                    &part.to_lowercase(),
-                )));
-            }
-        }
+        let criteria = query
+            .split_whitespace()
+            .map(|part| {
+                part.split_once(':')
+                    .and_then(|(keyword, value)| {
+                        keyword_criterion(&keyword.to_lowercase(), &value.to_lowercase())
+                    })
+                    .unwrap_or_else(|| {
+                        FilterCriteria::General(parse_filter_value(&part.to_lowercase()))
+                    })
+            })
+            .collect();
 
         Self { criteria }
+    }
+
+    /// Check a query for the mistakes [`parse`](Self::parse) papers over: a
+    /// known keyword with no value (`port:`) and an unparsable `/regex/`
+    /// literal.
+    pub fn validate(query: &str) -> Result<(), FilterError> {
+        for part in query.split_whitespace() {
+            let value = match part.split_once(':') {
+                Some((keyword, value))
+                    if keyword_criterion(&keyword.to_lowercase(), value).is_some() =>
+                {
+                    if value.is_empty() {
+                        return Err(FilterError::EmptyValue(part.to_string()));
+                    }
+                    value
+                }
+                _ => part,
+            };
+            if let Some(pattern) = regex_literal(value)
+                && let Err(e) = Regex::new(pattern)
+            {
+                return Err(FilterError::InvalidRegex {
+                    pattern: pattern.to_string(),
+                    message: e.to_string(),
+                });
+            }
+        }
+        Ok(())
     }
 
     pub fn matches(&self, connection: &Connection) -> bool {
@@ -633,6 +663,32 @@ mod tests {
             FilterCriteria::Port(PortMatch::Partial(_)) => {}
             _ => panic!("Expected fallback to Partial for invalid regex"),
         }
+    }
+
+    #[test]
+    fn validate_rejects_empty_keyword_values_and_bad_regexes() {
+        assert_eq!(ConnectionFilter::validate(""), Ok(()));
+        assert_eq!(ConnectionFilter::validate("port:443 proc:curl"), Ok(()));
+        assert_eq!(ConnectionFilter::validate("sni:/goo.*le/"), Ok(()));
+        // A term without a known keyword is a general search, colon included.
+        assert_eq!(ConnectionFilter::validate("10.0.0.1:443 ::1"), Ok(()));
+
+        assert_eq!(
+            ConnectionFilter::validate("port:"),
+            Err(FilterError::EmptyValue("port:".to_string()))
+        );
+        assert_eq!(
+            ConnectionFilter::validate("PROC:"),
+            Err(FilterError::EmptyValue("PROC:".to_string()))
+        );
+        assert!(matches!(
+            ConnectionFilter::validate("port:/[invalid/"),
+            Err(FilterError::InvalidRegex { pattern, .. }) if pattern == "[invalid"
+        ));
+        assert!(matches!(
+            ConnectionFilter::validate("/(unclosed/"),
+            Err(FilterError::InvalidRegex { .. })
+        ));
     }
 
     #[cfg(feature = "kubernetes")]

--- a/src/headless/events.rs
+++ b/src/headless/events.rs
@@ -1,0 +1,703 @@
+//! Serializable wire shapes for the JSONL connection events. The same
+//! [`ConnectionRecord`] backs the `new_connection` and `connection_closed`
+//! events of `--json-log` and any stream that reports connections, and the
+//! `snapshot` event of the headless stream; the PCAP sidecar has its own
+//! record with `local_`/`remote_` vocabulary.
+//!
+//! Optional fields are omitted rather than emitted as `null`, so a consumer
+//! of older logs sees the same keys it always did.
+
+use serde::Serialize;
+use std::borrow::Cow;
+use std::net::{IpAddr, SocketAddr};
+use std::time::{Duration, SystemTime};
+
+use crate::app::App;
+use crate::network::dns::DnsResolver;
+use crate::network::geoip::GeoIpInfo;
+#[cfg(feature = "kubernetes")]
+use crate::network::types::K8sInfo;
+use crate::network::types::{AddrKind, ApplicationProtocol, Connection, ProcessLineage, Protocol};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ConnectionEventKind {
+    NewConnection,
+    ConnectionClosed,
+}
+
+/// One line of the connection event stream: the envelope plus the
+/// connection record, with the traffic totals appended on close.
+#[derive(Debug, Serialize)]
+pub struct ConnectionEvent<'a> {
+    timestamp: String,
+    event: ConnectionEventKind,
+    #[serde(flatten)]
+    record: ConnectionRecord<'a>,
+    #[serde(flatten)]
+    close: Option<CloseRecord>,
+}
+
+#[derive(Debug, Serialize)]
+struct CloseRecord {
+    bytes_sent: u64,
+    bytes_received: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_secs: Option<u64>,
+}
+
+impl<'a> ConnectionEvent<'a> {
+    pub fn new_connection(conn: &'a Connection, dns_resolver: Option<&DnsResolver>) -> Self {
+        Self {
+            timestamp: rfc3339_now(),
+            event: ConnectionEventKind::NewConnection,
+            record: ConnectionRecord::from_connection(conn, dns_resolver),
+            close: None,
+        }
+    }
+
+    /// The close event for a connection archived or timed out at `now`; the
+    /// duration is measured from the connection's `created_at`.
+    pub fn connection_closed(
+        conn: &'a Connection,
+        now: SystemTime,
+        dns_resolver: Option<&DnsResolver>,
+    ) -> Self {
+        Self {
+            timestamp: rfc3339_now(),
+            event: ConnectionEventKind::ConnectionClosed,
+            record: ConnectionRecord::from_connection(conn, dns_resolver),
+            close: Some(CloseRecord {
+                bytes_sent: conn.bytes_sent,
+                bytes_received: conn.bytes_received,
+                duration_secs: now
+                    .duration_since(conn.created_at)
+                    .map(|duration| duration.as_secs())
+                    .ok(),
+            }),
+        }
+    }
+}
+
+/// The events the headless run loop itself emits, as opposed to the
+/// per-connection [`ConnectionEventKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RunEventKind {
+    Startup,
+    Snapshot,
+}
+
+/// The first line of a headless stream: what is being captured, how the
+/// process is protected, and the options the stream was started with.
+#[derive(Debug, Serialize)]
+pub struct StartupEvent {
+    timestamp: String,
+    event: RunEventKind,
+    version: &'static str,
+    pid: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interface: Option<String>,
+    link_type: String,
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "windows",
+        all(target_os = "macos", feature = "macos-sandbox")
+    ))]
+    sandbox: &'static str,
+    process_detection: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snapshot_interval_secs: Option<u64>,
+}
+
+impl StartupEvent {
+    /// Describe a launched `app`; read once the capture device is open and
+    /// the sandbox is applied, so the interface, link type, and sandbox
+    /// status are final.
+    pub fn from_app(app: &App, filter: Option<&str>, snapshot_interval: Option<Duration>) -> Self {
+        let (link_type, _is_tunnel) = app.get_link_layer_info();
+        Self {
+            timestamp: rfc3339_now(),
+            event: RunEventKind::Startup,
+            version: env!("CARGO_PKG_VERSION"),
+            pid: std::process::id(),
+            interface: app.get_current_interface(),
+            link_type,
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "windows",
+                all(target_os = "macos", feature = "macos-sandbox")
+            ))]
+            sandbox: app.get_sandbox_info().status.label(),
+            process_detection: app.get_process_detection_status().method,
+            filter: filter.map(str::to_owned),
+            snapshot_interval_secs: snapshot_interval.map(|interval| interval.as_secs()),
+        }
+    }
+}
+
+/// The full connection table at one instant, emitted by
+/// `--snapshot-interval`.
+#[derive(Debug, Serialize)]
+pub struct SnapshotEvent<'a> {
+    timestamp: String,
+    event: RunEventKind,
+    connections: Vec<ConnectionRecord<'a>>,
+}
+
+impl<'a> SnapshotEvent<'a> {
+    pub fn new(connections: &'a [Connection], dns_resolver: Option<&DnsResolver>) -> Self {
+        Self {
+            timestamp: rfc3339_now(),
+            event: RunEventKind::Snapshot,
+            connections: connections
+                .iter()
+                .map(|conn| ConnectionRecord::from_connection(conn, dns_resolver))
+                .collect(),
+        }
+    }
+}
+
+/// A connection as the event stream describes it, without an envelope.
+#[derive(Debug, Serialize)]
+pub struct ConnectionRecord<'a> {
+    protocol: &'static str,
+    source_ip: IpAddr,
+    source_port: u16,
+    destination_ip: IpAddr,
+    destination_port: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_addr_kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    destination_addr_kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    destination_is_gateway: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    destination_hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    process_name: Option<&'a str>,
+    #[serde(flatten)]
+    process: ProcessRecord<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    direction: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dpi_protocol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dpi_domain: Option<&'a str>,
+    #[serde(flatten)]
+    geoip: Option<GeoIpRecord<'a>>,
+}
+
+impl<'a> ConnectionRecord<'a> {
+    /// Build the record, asking the resolver for the endpoint hostnames it
+    /// already knows (which also queues the reverse lookups it does not).
+    pub fn from_connection(conn: &'a Connection, dns_resolver: Option<&DnsResolver>) -> Self {
+        // ARP connections are skipped: DNS lookups generate ARP traffic, so
+        // resolving them would feed back on itself.
+        let (destination_hostname, source_hostname) =
+            match dns_resolver.filter(|_| conn.protocol != Protocol::Arp) {
+                Some(resolver) => (
+                    resolver.get_hostname(&conn.remote_addr.ip()),
+                    resolver.get_hostname(&conn.local_addr.ip()),
+                ),
+                None => (None, None),
+            };
+
+        let dpi = conn.dpi_info.as_ref().map(|dpi| &dpi.application);
+
+        Self {
+            protocol: conn.protocol.as_str(),
+            source_ip: conn.local_addr.ip(),
+            source_port: conn.local_addr.port(),
+            destination_ip: conn.remote_addr.ip(),
+            destination_port: conn.remote_addr.port(),
+            source_addr_kind: addr_kind_marker(conn.local_addr_kind),
+            destination_addr_kind: addr_kind_marker(conn.remote_addr_kind),
+            destination_is_gateway: conn.remote_is_gateway.then_some(true),
+            source_hostname,
+            destination_hostname,
+            pid: conn.pid,
+            process_name: conn.process_name.as_deref(),
+            process: ProcessRecord::from_connection(conn),
+            service_name: conn.service_name.as_deref(),
+            // Direction is only known for TCP when the handshake was observed.
+            direction: conn
+                .connection_direction
+                .map(|is_outgoing| if is_outgoing { "outgoing" } else { "incoming" }),
+            dpi_protocol: dpi.map(ToString::to_string),
+            dpi_domain: dpi.and_then(dpi_domain),
+            geoip: conn.geoip_info.as_ref().map(GeoIpRecord::from_info),
+        }
+    }
+}
+
+/// A connection as the PCAP sidecar describes it, written when the
+/// connection closes and for every connection still open at shutdown.
+#[derive(Debug, Serialize)]
+pub struct PcapSidecarRecord<'a> {
+    timestamp: String,
+    protocol: &'static str,
+    local_addr: SocketAddr,
+    remote_addr: SocketAddr,
+    pid: Option<u32>,
+    process_name: Option<&'a str>,
+    first_seen: SystemTime,
+    last_seen: SystemTime,
+    bytes_sent: u64,
+    bytes_received: u64,
+    state: Cow<'a, str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_addr_kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_addr_kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_is_gateway: Option<bool>,
+    #[serde(flatten)]
+    process: ProcessRecord<'a>,
+    #[serde(flatten)]
+    geoip: Option<GeoIpRecord<'a>>,
+}
+
+impl<'a> PcapSidecarRecord<'a> {
+    pub fn from_connection(conn: &'a Connection) -> Self {
+        Self {
+            timestamp: rfc3339_now(),
+            protocol: conn.protocol.as_str(),
+            local_addr: conn.local_addr,
+            remote_addr: conn.remote_addr,
+            pid: conn.pid,
+            process_name: conn.process_name.as_deref(),
+            first_seen: conn.created_at,
+            last_seen: conn.last_activity,
+            bytes_sent: conn.bytes_sent,
+            bytes_received: conn.bytes_received,
+            state: conn.state(),
+            local_addr_kind: addr_kind_marker(conn.local_addr_kind),
+            remote_addr_kind: addr_kind_marker(conn.remote_addr_kind),
+            remote_is_gateway: conn.remote_is_gateway.then_some(true),
+            process: ProcessRecord::from_connection(conn),
+            geoip: conn.geoip_info.as_ref().map(GeoIpRecord::from_info),
+        }
+    }
+}
+
+/// Rich process attribution shared by the event stream and the sidecar:
+/// ppid, executable, uid/gid, match quality, lineage, the RTT estimate, and
+/// Kubernetes attribution. Both outputs are per connection, not per packet,
+/// so the verbose executable path costs nothing here (unlike a PCAPNG packet
+/// comment).
+#[derive(Debug, Serialize)]
+struct ProcessRecord<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    process_ppid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    process_executable: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    process_uid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    process_gid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    attribution_match: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    process_lineage: Option<ProcessLineageRecord<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rtt_ms: Option<f64>,
+    #[cfg(feature = "kubernetes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kubernetes: Option<KubernetesRecord<'a>>,
+}
+
+impl<'a> ProcessRecord<'a> {
+    fn from_connection(conn: &'a Connection) -> Self {
+        Self {
+            process_ppid: conn.process_ppid,
+            process_executable: conn
+                .executable
+                .as_ref()
+                .map(|executable| executable.display().to_string()),
+            process_uid: conn.process_uid,
+            process_gid: conn.process_gid,
+            attribution_match: conn.attribution_quality.map(|quality| quality.as_token()),
+            process_lineage: conn
+                .process_lineage
+                .as_deref()
+                .map(ProcessLineageRecord::from),
+            // Smoothed TCP data RTT, a handshake RTT, or the latest ICMP echo
+            // RTT, with one decimal of milliseconds.
+            rtt_ms: conn
+                .current_rtt()
+                .map(|rtt| (rtt.as_secs_f64() * 10_000.0).round() / 10.0),
+            #[cfg(feature = "kubernetes")]
+            kubernetes: conn.k8s_info.as_ref().and_then(KubernetesRecord::from_info),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProcessLineageRecord<'a> {
+    ancestors: Vec<ProcessAncestorRecord<'a>>,
+    truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ProcessAncestorRecord<'a> {
+    pid: u32,
+    name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    executable: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at_unix_ms: Option<u64>,
+}
+
+impl<'a> From<&'a ProcessLineage> for ProcessLineageRecord<'a> {
+    fn from(lineage: &'a ProcessLineage) -> Self {
+        Self {
+            ancestors: lineage
+                .ancestors
+                .iter()
+                .map(|ancestor| ProcessAncestorRecord {
+                    pid: ancestor.pid,
+                    name: &ancestor.name,
+                    executable: ancestor
+                        .executable
+                        .as_ref()
+                        .map(|executable| executable.display().to_string()),
+                    started_at_unix_ms: ancestor.started_at_unix_ms,
+                })
+                .collect(),
+            truncated: lineage.truncated,
+        }
+    }
+}
+
+/// The Kubernetes attribution block; absent when no field is populated.
+#[cfg(feature = "kubernetes")]
+#[derive(Debug, Serialize)]
+pub struct KubernetesRecord<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pod_uid: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pod_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pod_namespace: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    container_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    container_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cgroup_path: Option<&'a str>,
+}
+
+#[cfg(feature = "kubernetes")]
+impl<'a> KubernetesRecord<'a> {
+    pub fn from_info(k8s: &'a K8sInfo) -> Option<Self> {
+        let record = Self {
+            pod_uid: k8s.pod_uid.as_deref(),
+            pod_name: k8s.pod_name.as_deref(),
+            pod_namespace: k8s.pod_namespace.as_deref(),
+            container_id: k8s.container_id.as_deref(),
+            container_name: k8s.container_name.as_deref(),
+            cgroup_path: k8s.cgroup_path.as_deref(),
+        };
+        let populated = [
+            record.pod_uid,
+            record.pod_name,
+            record.pod_namespace,
+            record.container_id,
+            record.container_name,
+            record.cgroup_path,
+        ]
+        .iter()
+        .any(Option::is_some);
+        populated.then_some(record)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct GeoIpRecord<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    geoip_country_code: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    geoip_country_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    geoip_asn: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    geoip_as_org: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    geoip_city: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    geoip_postal_code: Option<&'a str>,
+}
+
+impl<'a> GeoIpRecord<'a> {
+    fn from_info(geoip: &'a GeoIpInfo) -> Self {
+        Self {
+            geoip_country_code: geoip.country_code.as_deref(),
+            geoip_country_name: geoip.country_name.as_deref(),
+            geoip_asn: geoip.asn,
+            geoip_as_org: geoip.as_org.as_deref(),
+            geoip_city: geoip.city.as_deref(),
+            geoip_postal_code: geoip.postal_code.as_deref(),
+        }
+    }
+}
+
+/// Address-kind markers are only emitted for broadcast/multicast endpoints,
+/// keeping unicast records (and consumers of older logs) unchanged.
+fn addr_kind_marker(kind: AddrKind) -> Option<&'static str> {
+    (kind != AddrKind::Unicast).then(|| kind.as_token())
+}
+
+fn rfc3339_now() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// Domain reported for a connection: DNS query name, or the hostname from
+/// the payload (SNI or HTTP Host) for other protocols.
+pub fn dpi_domain(application: &ApplicationProtocol) -> Option<&str> {
+    match application {
+        ApplicationProtocol::Dns(info) => info.query_name.as_deref(),
+        _ => application.hostname(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::types::{
+        DpiInfo, HttpsInfo, MatchQuality, ProcessAncestor, ProtocolState, TcpState, TlsInfo,
+    };
+    use serde_json::{Value, json};
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    /// The two example lines from the "JSON Logging" section of USAGE.md.
+    const USAGE_NEW_CONNECTION: &str = r#"{"timestamp":"2025-01-15T10:30:00Z","event":"new_connection","protocol":"TCP","source_ip":"192.168.1.100","source_port":54321,"destination_ip":"93.184.216.34","destination_port":443,"pid":1234,"process_name":"curl","service_name":"https","direction":"outgoing","dpi_protocol":"HTTPS (example.com)","dpi_domain":"example.com"}"#;
+    const USAGE_CONNECTION_CLOSED: &str = r#"{"timestamp":"2025-01-15T10:30:05Z","event":"connection_closed","protocol":"TCP","source_ip":"192.168.1.100","source_port":54321,"destination_ip":"93.184.216.34","destination_port":443,"pid":1234,"process_name":"curl","service_name":"https","direction":"outgoing","bytes_sent":1024,"bytes_received":4096,"duration_secs":5}"#;
+
+    /// The connection behind the USAGE.md examples: curl talking HTTPS to
+    /// example.com, with the handshake observed.
+    fn usage_connection() -> Connection {
+        let mut conn = Connection::new(
+            Protocol::Tcp,
+            "192.168.1.100:54321".parse().unwrap(),
+            "93.184.216.34:443".parse().unwrap(),
+            ProtocolState::Tcp(TcpState::Established),
+        );
+        conn.pid = Some(1234);
+        conn.process_name = Some("curl".to_string());
+        conn.service_name = Some("https".to_string());
+        conn.connection_direction = Some(true);
+        conn.dpi_info = Some(DpiInfo {
+            application: ApplicationProtocol::Https(HttpsInfo {
+                tls_info: Some(TlsInfo::with_sni("example.com".to_string())),
+            }),
+        });
+        conn.bytes_sent = 1024;
+        conn.bytes_received = 4096;
+        conn
+    }
+
+    fn keys(value: &Value) -> BTreeSet<String> {
+        value
+            .as_object()
+            .expect("event is a JSON object")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    fn to_value(event: &ConnectionEvent<'_>) -> Value {
+        serde_json::from_str(&serde_json::to_string(event).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn new_connection_matches_the_documented_example() {
+        let conn = usage_connection();
+        let event = to_value(&ConnectionEvent::new_connection(&conn, None));
+        let expected: Value = serde_json::from_str(USAGE_NEW_CONNECTION).unwrap();
+
+        assert_eq!(keys(&event), keys(&expected));
+        for (key, expected_value) in expected.as_object().unwrap() {
+            match key.as_str() {
+                "timestamp" => assert!(event[key].as_str().unwrap().ends_with("+00:00")),
+                _ => assert_eq!(&event[key], expected_value, "field {key}"),
+            }
+        }
+    }
+
+    #[test]
+    fn connection_closed_matches_the_documented_example() {
+        let conn = usage_connection();
+        let closed_at = conn.created_at + Duration::from_secs(5);
+        let event = to_value(&ConnectionEvent::connection_closed(&conn, closed_at, None));
+        let expected: Value = serde_json::from_str(USAGE_CONNECTION_CLOSED).unwrap();
+
+        // The example omits the DPI fields the fixture carries.
+        let mut expected_keys = keys(&expected);
+        expected_keys.extend(["dpi_protocol".to_string(), "dpi_domain".to_string()]);
+        assert_eq!(keys(&event), expected_keys);
+        for (key, expected_value) in expected.as_object().unwrap() {
+            if key != "timestamp" {
+                assert_eq!(&event[key], expected_value, "field {key}");
+            }
+        }
+    }
+
+    #[test]
+    fn unattributed_connection_omits_optional_keys() {
+        let mut conn = Connection::new(
+            Protocol::Udp,
+            "10.0.0.2:5353".parse().unwrap(),
+            "10.0.0.1:53".parse().unwrap(),
+            ProtocolState::Udp,
+        );
+        conn.pid = None;
+        conn.process_name = None;
+        let event = to_value(&ConnectionEvent::new_connection(&conn, None));
+
+        let expected: BTreeSet<String> = [
+            "timestamp",
+            "event",
+            "protocol",
+            "source_ip",
+            "source_port",
+            "destination_ip",
+            "destination_port",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+        assert_eq!(keys(&event), expected);
+        assert_eq!(event["protocol"], json!("UDP"));
+    }
+
+    #[test]
+    fn enrichment_fields_keep_their_value_types() {
+        let mut conn = usage_connection();
+        conn.local_addr_kind = AddrKind::Multicast;
+        conn.remote_is_gateway = true;
+        conn.process_ppid = Some(1);
+        conn.executable = Some(PathBuf::from("/usr/bin/curl").into());
+        conn.process_uid = Some(501);
+        conn.process_gid = Some(20);
+        conn.attribution_quality = Some(MatchQuality::ExactTuple);
+        conn.initial_rtt = Some(Duration::from_micros(12_345));
+        conn.geoip_info = Some(GeoIpInfo {
+            country_code: Some("US".to_string()),
+            asn: Some(15169),
+            ..GeoIpInfo::default()
+        });
+        let event = to_value(&ConnectionEvent::new_connection(&conn, None));
+
+        assert_eq!(event["source_addr_kind"], json!("multicast"));
+        assert_eq!(event.get("destination_addr_kind"), None);
+        assert_eq!(event["destination_is_gateway"], json!(true));
+        assert_eq!(event["process_ppid"], json!(1));
+        assert_eq!(event["process_executable"], json!("/usr/bin/curl"));
+        assert_eq!(event["process_uid"], json!(501));
+        assert_eq!(event["process_gid"], json!(20));
+        assert_eq!(event["attribution_match"], json!("exact-tuple"));
+        assert_eq!(event["rtt_ms"], json!(12.3));
+        assert_eq!(event["geoip_country_code"], json!("US"));
+        assert_eq!(event["geoip_asn"], json!(15169));
+        assert_eq!(event.get("geoip_city"), None);
+    }
+
+    #[test]
+    fn lineage_json_preserves_process_identity_fields() {
+        let lineage = ProcessLineage {
+            ancestors: vec![ProcessAncestor {
+                pid: 1,
+                name: "systemd".to_string(),
+                executable: Some(PathBuf::from("/usr/lib/systemd/systemd")),
+                started_at_unix_ms: Some(1_700_000_000_000),
+            }],
+            truncated: true,
+        };
+
+        assert_eq!(
+            serde_json::to_value(ProcessLineageRecord::from(&lineage)).unwrap(),
+            json!({
+                "ancestors": [{
+                    "pid": 1,
+                    "name": "systemd",
+                    "executable": "/usr/lib/systemd/systemd",
+                    "started_at_unix_ms": 1_700_000_000_000_u64,
+                }],
+                "truncated": true,
+            })
+        );
+    }
+
+    #[test]
+    fn startup_event_describes_the_app_and_its_options() {
+        let app = App::new(crate::app::Config::default()).unwrap();
+        app.set_current_interface_for_test(Some("en0".to_string()));
+        let event: Value = serde_json::to_value(StartupEvent::from_app(
+            &app,
+            Some("port:443"),
+            Some(Duration::from_secs(5)),
+        ))
+        .unwrap();
+
+        assert_eq!(event["event"], json!("startup"));
+        assert_eq!(event["version"], json!(env!("CARGO_PKG_VERSION")));
+        assert_eq!(event["pid"], json!(std::process::id()));
+        assert_eq!(event["interface"], json!("en0"));
+        assert!(event["link_type"].is_string());
+        assert!(event["process_detection"].is_string());
+        assert_eq!(event["filter"], json!("port:443"));
+        assert_eq!(event["snapshot_interval_secs"], json!(5));
+        assert!(event["timestamp"].as_str().unwrap().ends_with("+00:00"));
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "windows",
+            all(target_os = "macos", feature = "macos-sandbox")
+        ))]
+        assert_eq!(event["sandbox"], json!("Not applied"));
+
+        let bare: Value = serde_json::to_value(StartupEvent::from_app(&app, None, None)).unwrap();
+        assert_eq!(bare.get("filter"), None);
+        assert_eq!(bare.get("snapshot_interval_secs"), None);
+    }
+
+    #[test]
+    fn snapshot_event_wraps_connection_records() {
+        let connections = [usage_connection()];
+        let event: Value = serde_json::to_value(SnapshotEvent::new(&connections, None)).unwrap();
+
+        assert_eq!(event["event"], json!("snapshot"));
+        assert_eq!(event["connections"].as_array().unwrap().len(), 1);
+        assert_eq!(event["connections"][0]["process_name"], json!("curl"));
+        assert_eq!(event["connections"][0]["destination_port"], json!(443));
+        assert_eq!(event["connections"][0].get("bytes_sent"), None);
+    }
+
+    #[test]
+    fn sidecar_record_keeps_nullable_process_identity() {
+        let mut conn = usage_connection();
+        conn.pid = None;
+        conn.process_name = None;
+        let record: Value =
+            serde_json::to_value(PcapSidecarRecord::from_connection(&conn)).unwrap();
+
+        assert_eq!(record["protocol"], json!("TCP"));
+        assert_eq!(record["local_addr"], json!("192.168.1.100:54321"));
+        assert_eq!(record["remote_addr"], json!("93.184.216.34:443"));
+        assert_eq!(record["pid"], Value::Null);
+        assert_eq!(record["process_name"], Value::Null);
+        assert_eq!(record["state"], json!("ESTABLISHED"));
+        assert!(record["first_seen"]["secs_since_epoch"].is_u64());
+        assert_eq!(record.get("local_addr_kind"), None);
+    }
+}

--- a/src/headless/mod.rs
+++ b/src/headless/mod.rs
@@ -1,0 +1,168 @@
+//! Headless front-end: the full capture pipeline with no terminal, streaming
+//! connection events as JSON lines to stdout. The serializable event shapes
+//! and the line sinks (also used by `--json-log` and the PCAP sidecar) live
+//! in the submodules.
+
+pub mod events;
+pub mod sink;
+
+use anyhow::{Result, anyhow};
+use clap::ArgMatches;
+use log::{error, info};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use crate::app::{App, sleep_unless_stopped};
+use crate::bootstrap::{self, Frontend, shutdown_requested};
+use crate::filter::ConnectionFilter;
+use events::{SnapshotEvent, StartupEvent};
+use sink::{EventSink, FilteredSink, StdoutSink, json_line};
+
+/// Maximum queued event lines before the stdout stream drops events. A slow
+/// or paused consumer must never stall the packet-processing threads.
+const MAX_EVENT_QUEUE: usize = 10_000;
+
+/// How often the run loop checks for a shutdown signal, a closed stdout,
+/// or a dead capture thread.
+const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Run the pipeline until a shutdown signal arrives or stdout is closed
+/// (both a normal exit), or the capture thread fails (an error).
+pub fn run(matches: &ArgMatches) -> Result<()> {
+    // The query is checked before the privilege check and capture open so
+    // a typo costs nothing and the error lands on a plain stderr.
+    let filter_query = matches.get_one::<String>("filter").map(String::as_str);
+    if let Some(query) = filter_query {
+        ConnectionFilter::validate(query)
+            .map_err(|e| anyhow!("Invalid --filter query {query:?}: {e}"))?;
+    }
+    let snapshot_interval = matches
+        .get_one::<u64>("snapshot-interval")
+        .map(|secs| Duration::from_secs(*secs));
+
+    let mut prepared = bootstrap::prepare(matches, Frontend::Headless)?;
+
+    let stdout = Arc::new(StdoutSink::new());
+    let live_sink: Arc<dyn EventSink> = match filter_query {
+        Some(query) => Arc::new(FilteredSink::new(
+            ConnectionFilter::parse(query),
+            stdout.clone(),
+        )),
+        None => stdout.clone(),
+    };
+    prepared.add_event_sink(live_sink);
+
+    let app = prepared.launch_with(|app| {
+        if let Some(line) = json_line(&StartupEvent::from_app(
+            app,
+            filter_query,
+            snapshot_interval,
+        )) {
+            stdout.write_line(&line);
+        }
+    })?;
+    info!("Headless event stream started");
+
+    let exit = run_until_exit(&app, &stdout, filter_query, snapshot_interval);
+    app.stop();
+
+    match exit {
+        Exit::Signal => {
+            info!("Termination signal received, shutting down");
+            Ok(())
+        }
+        Exit::OutputClosed => {
+            info!("Event output closed, shutting down");
+            Ok(())
+        }
+        Exit::CaptureFailed(message) => {
+            error!("Packet capture failed: {message}");
+            Err(anyhow!("Packet capture failed: {message}"))
+        }
+    }
+}
+
+/// Block until the run should end, with the snapshot ticker (if any)
+/// running alongside and stopped before returning: it writes into the
+/// stdout sink, which `App::stop` drains and joins afterwards.
+fn run_until_exit(
+    app: &App,
+    stdout: &StdoutSink,
+    filter_query: Option<&str>,
+    snapshot_interval: Option<Duration>,
+) -> Exit {
+    let stop_snapshots = AtomicBool::new(false);
+    let stop_snapshots = &stop_snapshots;
+    thread::scope(|scope| {
+        let snapshot_thread = snapshot_interval.map(|interval| {
+            thread::Builder::new()
+                .name("headless-snapshot".to_string())
+                .spawn_scoped(scope, move || {
+                    emit_snapshots(
+                        app,
+                        stdout,
+                        filter_query.unwrap_or_default(),
+                        interval,
+                        stop_snapshots,
+                    )
+                })
+                .expect("Failed to spawn headless-snapshot thread")
+        });
+
+        let exit = wait_for_exit(app, stdout);
+
+        stop_snapshots.store(true, Ordering::Relaxed);
+        if let Some(handle) = snapshot_thread
+            && handle.join().is_err()
+        {
+            error!("headless-snapshot thread panicked");
+        }
+        exit
+    })
+}
+
+enum Exit {
+    Signal,
+    OutputClosed,
+    CaptureFailed(String),
+}
+
+fn wait_for_exit(app: &App, stdout: &StdoutSink) -> Exit {
+    loop {
+        if shutdown_requested() {
+            return Exit::Signal;
+        }
+        if stdout.output_failed() {
+            return Exit::OutputClosed;
+        }
+        if let Some(message) = app.get_capture_error() {
+            return Exit::CaptureFailed(message);
+        }
+        thread::sleep(EXIT_POLL_INTERVAL);
+    }
+}
+
+/// Write the (filtered) connection table every `interval` until told to
+/// stop. The first snapshot waits one full interval so it reflects real
+/// traffic rather than an empty table.
+fn emit_snapshots(
+    app: &App,
+    stdout: &StdoutSink,
+    filter_query: &str,
+    interval: Duration,
+    stop: &AtomicBool,
+) {
+    let dns_resolver = app.get_dns_resolver();
+    loop {
+        sleep_unless_stopped(stop, interval);
+        if stop.load(Ordering::Relaxed) {
+            return;
+        }
+        let connections = app.get_filtered_connections(filter_query);
+        if let Some(line) = json_line(&SnapshotEvent::new(&connections, dns_resolver.as_deref())) {
+            stdout.write_line(&line);
+        }
+    }
+}

--- a/src/headless/sink.rs
+++ b/src/headless/sink.rs
@@ -1,0 +1,441 @@
+//! Line sinks for the JSONL event stream: a synchronous writer for the
+//! `--json-log` file and the PCAP sidecar, and a queued stdout writer whose
+//! producers never block on a slow terminal or pipe.
+
+use crossbeam::channel::{self, Receiver, RecvTimeoutError, Sender, TrySendError};
+use log::warn;
+use serde::Serialize;
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use super::MAX_EVENT_QUEUE;
+use crate::filter::ConnectionFilter;
+use crate::network::types::Connection;
+
+/// How long the stdout writer waits for a line before re-checking its stop
+/// flag.
+const WRITER_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// A destination for JSONL lines, shared by every thread that emits events.
+pub trait EventSink: Send + Sync {
+    /// Append one line; the sink adds the newline.
+    fn write_line(&self, line: &str);
+
+    /// Whether this sink wants the events of `conn`. A sink that declines
+    /// every connection of an event still costs nothing: the event is not
+    /// even serialized.
+    fn accepts(&self, _conn: &Connection) -> bool {
+        true
+    }
+
+    /// Spawn the sink's writer thread, if it has one. The app calls this
+    /// after the sandbox is applied so the thread inherits it.
+    fn start(&self) {}
+
+    /// Ask the writer thread to exit once its queue is drained and hand back
+    /// its handle for a bounded join.
+    fn shutdown(&self) -> Option<JoinHandle<()>> {
+        None
+    }
+}
+
+/// One JSON document as a JSONL line. Serialization of the wire structs
+/// cannot fail in practice; a failure is logged rather than propagated so an
+/// emitting thread never stops over its own output.
+pub fn json_line(value: &impl Serialize) -> Option<String> {
+    match serde_json::to_string(value) {
+        Ok(line) => Some(line),
+        Err(e) => {
+            warn!("Failed to serialize JSON event: {e}");
+            None
+        }
+    }
+}
+
+/// Hand one event about `conn` to every sink that accepts it, building and
+/// serializing the event only when at least one does. The event is built
+/// lazily because building a record can queue reverse DNS lookups, which a
+/// connection nobody wants to hear about should not trigger.
+pub fn write_connection_event<E: Serialize>(
+    sinks: &[Arc<dyn EventSink>],
+    conn: &Connection,
+    event: impl FnOnce() -> E,
+) {
+    let accepting: Vec<&Arc<dyn EventSink>> =
+        sinks.iter().filter(|sink| sink.accepts(conn)).collect();
+    if accepting.is_empty() {
+        return;
+    }
+    if let Some(line) = json_line(&event()) {
+        for sink in accepting {
+            sink.write_line(&line);
+        }
+    }
+}
+
+/// A sink that forwards to another one only the connections matching a
+/// [`ConnectionFilter`]. Lines written directly to the inner sink (the
+/// startup and snapshot events) are unaffected.
+pub struct FilteredSink {
+    filter: ConnectionFilter,
+    inner: Arc<dyn EventSink>,
+}
+
+impl FilteredSink {
+    pub fn new(filter: ConnectionFilter, inner: Arc<dyn EventSink>) -> Self {
+        Self { filter, inner }
+    }
+}
+
+impl EventSink for FilteredSink {
+    fn write_line(&self, line: &str) {
+        self.inner.write_line(line);
+    }
+
+    fn accepts(&self, conn: &Connection) -> bool {
+        self.filter.matches(conn)
+    }
+
+    fn start(&self) {
+        self.inner.start();
+    }
+
+    fn shutdown(&self) -> Option<JoinHandle<()>> {
+        self.inner.shutdown()
+    }
+}
+
+/// A synchronous JSONL writer over a descriptor opened before sandboxing
+/// and uid drop.
+///
+/// Keeping the descriptor open is required for paths such as `/root`: after
+/// dropping to the invoking user or `nobody`, the process may no longer be
+/// able to traverse the parent directory even when the file itself was
+/// chowned.
+pub struct FileSink<W: Write + Send = File> {
+    writer: Mutex<W>,
+    path: String,
+    failure_reported: AtomicBool,
+}
+
+impl<W: Write + Send> FileSink<W> {
+    pub fn new(writer: W, path: impl Into<String>) -> Self {
+        Self {
+            writer: Mutex::new(writer),
+            path: path.into(),
+            failure_reported: AtomicBool::new(false),
+        }
+    }
+}
+
+impl<W: Write + Send> EventSink for FileSink<W> {
+    fn write_line(&self, line: &str) {
+        // One write call per line so concurrent appenders to the same file
+        // cannot interleave inside a record.
+        let mut record = String::with_capacity(line.len() + 1);
+        record.push_str(line);
+        record.push('\n');
+        let result = self
+            .writer
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .write_all(record.as_bytes());
+
+        if let Err(e) = result
+            && !self.failure_reported.swap(true, Ordering::Relaxed)
+        {
+            warn!(
+                "Failed to write JSONL output '{}': {}. Further write errors will be suppressed.",
+                self.path, e
+            );
+        }
+    }
+}
+
+/// A queued line writer for stdout. Producers enqueue without blocking and
+/// a dedicated thread writes the queue out in batches; when the consumer
+/// falls behind, lines are dropped and counted rather than stalling packet
+/// processing. A write failure (a closed pipe, typically) is latched in
+/// [`StdoutSink::output_failed`] so the run loop can shut down.
+pub struct StdoutSink {
+    tx: Sender<String>,
+    pending: Mutex<Option<PendingWriter>>,
+    writer_thread: Mutex<Option<JoinHandle<()>>>,
+    stop: Arc<AtomicBool>,
+    output_failed: Arc<AtomicBool>,
+    dropped: AtomicU64,
+    drop_warned: AtomicBool,
+}
+
+/// The receiving half and the output, held until [`EventSink::start`].
+struct PendingWriter {
+    rx: Receiver<String>,
+    output: Box<dyn Write + Send>,
+}
+
+impl Default for StdoutSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StdoutSink {
+    pub fn new() -> Self {
+        Self::with_output(Box::new(io::stdout()), MAX_EVENT_QUEUE)
+    }
+
+    fn with_output(output: Box<dyn Write + Send>, capacity: usize) -> Self {
+        let (tx, rx) = channel::bounded(capacity);
+        Self {
+            tx,
+            pending: Mutex::new(Some(PendingWriter { rx, output })),
+            writer_thread: Mutex::new(None),
+            stop: Arc::new(AtomicBool::new(false)),
+            output_failed: Arc::new(AtomicBool::new(false)),
+            dropped: AtomicU64::new(0),
+            drop_warned: AtomicBool::new(false),
+        }
+    }
+
+    /// Whether the writer thread gave up on the output after a write error.
+    pub fn output_failed(&self) -> bool {
+        self.output_failed.load(Ordering::Relaxed)
+    }
+
+    /// Lines dropped because the queue was full.
+    pub fn dropped_lines(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+}
+
+impl EventSink for StdoutSink {
+    fn write_line(&self, line: &str) {
+        match self.tx.try_send(line.to_owned()) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+                if !self.drop_warned.swap(true, Ordering::Relaxed) {
+                    warn!("Event output queue full; dropping events under load");
+                }
+            }
+            // The writer thread has exited; its failure is already latched.
+            Err(TrySendError::Disconnected(_)) => {}
+        }
+    }
+
+    fn start(&self) {
+        let Some(PendingWriter { rx, output }) = self
+            .pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take()
+        else {
+            return;
+        };
+        let stop = Arc::clone(&self.stop);
+        let output_failed = Arc::clone(&self.output_failed);
+        let handle = thread::Builder::new()
+            .name("headless-events".to_string())
+            .spawn(move || {
+                if let Err(e) = run_writer(&rx, BufWriter::new(output), &stop) {
+                    warn!("Event output failed: {e}. Stopping the event stream.");
+                    output_failed.store(true, Ordering::Relaxed);
+                }
+            })
+            .expect("Failed to spawn headless-events thread");
+        *self
+            .writer_thread
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = Some(handle);
+    }
+
+    fn shutdown(&self) -> Option<JoinHandle<()>> {
+        self.stop.store(true, Ordering::Relaxed);
+        let dropped = self.dropped_lines();
+        if dropped > 0 {
+            warn!("Event output dropped {dropped} events under backpressure");
+        }
+        self.writer_thread
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take()
+    }
+}
+
+/// Write queued lines until the stop flag is set, then drain what is left.
+/// Every batch ends with one flush so a consumer sees complete lines
+/// promptly; the first error ends the stream.
+fn run_writer<W: Write>(
+    rx: &Receiver<String>,
+    mut out: BufWriter<W>,
+    stop: &AtomicBool,
+) -> io::Result<()> {
+    while !stop.load(Ordering::Relaxed) {
+        match rx.recv_timeout(WRITER_POLL_INTERVAL) {
+            Ok(line) => {
+                writeln!(out, "{line}")?;
+                write_queued(rx, &mut out)?;
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    write_queued(rx, &mut out)
+}
+
+fn write_queued<W: Write>(rx: &Receiver<String>, out: &mut BufWriter<W>) -> io::Result<()> {
+    while let Ok(line) = rx.try_recv() {
+        writeln!(out, "{line}")?;
+    }
+    out.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::types::{Protocol, ProtocolState};
+    use serde_json::json;
+
+    /// A writer whose contents the test can read back after the sink has
+    /// taken ownership of it.
+    #[derive(Clone, Default)]
+    struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
+
+    impl SharedBuffer {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    impl Write for SharedBuffer {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct BrokenPipe;
+
+    impl Write for BrokenPipe {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+    }
+
+    #[test]
+    fn file_sink_appends_one_line_per_record() {
+        let buffer = SharedBuffer::default();
+        let sink = FileSink::new(buffer.clone(), "events.jsonl");
+
+        sink.write_line(r#"{"event":"new_connection"}"#);
+        sink.write_line(r#"{"event":"connection_closed"}"#);
+
+        assert_eq!(
+            buffer.contents(),
+            "{\"event\":\"new_connection\"}\n{\"event\":\"connection_closed\"}\n"
+        );
+    }
+
+    #[test]
+    fn stdout_sink_counts_drops_and_writes_what_it_kept() {
+        let buffer = SharedBuffer::default();
+        let sink = StdoutSink::with_output(Box::new(buffer.clone()), 2);
+
+        sink.write_line("one");
+        sink.write_line("two");
+        sink.write_line("three");
+        assert_eq!(sink.dropped_lines(), 1);
+
+        sink.start();
+        sink.shutdown().unwrap().join().unwrap();
+
+        assert_eq!(buffer.contents(), "one\ntwo\n");
+        assert!(!sink.output_failed());
+    }
+
+    #[test]
+    fn stdout_sink_latches_a_broken_pipe() {
+        let sink = StdoutSink::with_output(Box::new(BrokenPipe), 8);
+        sink.start();
+        sink.write_line("one");
+        sink.shutdown().unwrap().join().unwrap();
+
+        assert!(sink.output_failed());
+    }
+
+    #[test]
+    fn stdout_sink_shutdown_without_start_has_no_thread() {
+        let sink = StdoutSink::with_output(Box::new(BrokenPipe), 8);
+        assert!(sink.shutdown().is_none());
+    }
+
+    fn udp_connection(remote: &str) -> Connection {
+        Connection::new(
+            Protocol::Udp,
+            "10.0.0.2:40000".parse().unwrap(),
+            remote.parse().unwrap(),
+            ProtocolState::Udp,
+        )
+    }
+
+    #[test]
+    fn filtered_sink_drops_non_matching_connections_and_forwards_the_rest() {
+        let buffer = SharedBuffer::default();
+        let stdout = Arc::new(StdoutSink::with_output(Box::new(buffer.clone()), 8));
+        let unfiltered: Arc<dyn EventSink> = Arc::new(FileSink::new(buffer.clone(), "log"));
+        let filtered: Arc<dyn EventSink> = Arc::new(FilteredSink::new(
+            ConnectionFilter::parse("dport:53"),
+            stdout.clone(),
+        ));
+        let sinks = vec![filtered, unfiltered];
+
+        let dns = udp_connection("10.0.0.1:53");
+        let ntp = udp_connection("10.0.0.1:123");
+        let mut built = 0;
+        let mut emit = |conn: &Connection, port: u16| {
+            write_connection_event(&sinks, conn, || {
+                built += 1;
+                json!({ "port": port })
+            })
+        };
+        emit(&dns, 53);
+        emit(&ntp, 123);
+        assert_eq!(built, 2, "the unfiltered sink still wants every event");
+
+        // The file sink is synchronous: both lines are already there. The
+        // stdout sink only forwards the DNS line, after its thread drains.
+        assert_eq!(buffer.contents(), "{\"port\":53}\n{\"port\":123}\n");
+        stdout.start();
+        stdout.shutdown().unwrap().join().unwrap();
+        assert_eq!(
+            buffer.contents(),
+            "{\"port\":53}\n{\"port\":123}\n{\"port\":53}\n"
+        );
+    }
+
+    #[test]
+    fn event_is_not_built_when_no_sink_accepts_it() {
+        let sinks: Vec<Arc<dyn EventSink>> = vec![Arc::new(FilteredSink::new(
+            ConnectionFilter::parse("dport:53"),
+            Arc::new(FileSink::new(SharedBuffer::default(), "log")),
+        ))];
+        let mut built = false;
+        write_connection_event(&sinks, &udp_connection("10.0.0.1:123"), || {
+            built = true;
+            json!({})
+        });
+        assert!(!built);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@
 //! [`network`] holds capture, parsers, DPI, DNS, GeoIP, interface stats, and
 //! platform process lookup; [`ui`] holds the ratatui rendering and keyboard
 //! handling. [`bootstrap`] runs the front-end independent startup sequence
-//! (logging, privileges, output files, sandboxing) and [`tui`] drives the
-//! terminal front-end on top of it.
+//! (logging, privileges, output files, sandboxing); [`tui`] drives the
+//! terminal front-end on top of it and [`headless`] the JSONL event stream.
 //!
 //! The library surface is unstable and intended for internal use; the
 //! supported product is the `rustnet` binary.
@@ -23,6 +23,7 @@ pub mod cli;
 pub mod config;
 pub(crate) mod export;
 pub(crate) mod filter;
+pub mod headless;
 pub mod network;
 pub mod tui;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,15 @@
 use anyhow::Result;
 use log::info;
-use rustnet_monitor::{bootstrap, cli, tui};
+use rustnet_monitor::{cli, headless, tui};
 
 fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();
 
-    let prepared = bootstrap::prepare(&matches, true)?;
-    tui::run(&matches, prepared)?;
+    if matches.get_flag("headless") {
+        headless::run(&matches)?;
+    } else {
+        tui::run(&matches)?;
+    }
 
     info!("RustNet Monitor shutting down");
     Ok(())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -9,7 +9,7 @@ use std::io;
 use std::time::Duration;
 
 use crate::app::App;
-use crate::bootstrap::{Prepared, shutdown_requested};
+use crate::bootstrap::{self, Frontend, shutdown_requested};
 use crate::config;
 use crate::network::types::Connection;
 use crate::ui::{self, clear_all_with_confirmation, copy_to_clipboard, sort_connections};
@@ -18,7 +18,8 @@ use crate::ui::{self, clear_all_with_confirmation, copy_to_clipboard, sort_conne
 /// failures propagate; a failure inside the draw/input loop is reported
 /// after the terminal has been restored so the message lands on a usable
 /// screen, and the process still exits normally.
-pub fn run(matches: &ArgMatches, prepared: Prepared) -> Result<()> {
+pub fn run(matches: &ArgMatches) -> Result<()> {
+    let prepared = bootstrap::prepare(matches, Frontend::Tui)?;
     apply_theme(matches);
 
     let backend = CrosstermBackend::new(io::stdout());

--- a/tests/headless_cli.rs
+++ b/tests/headless_cli.rs
@@ -1,0 +1,49 @@
+//! `rustnet --headless` argument handling that must fail before any capture
+//! is attempted, so these pass without capture privileges.
+
+use std::process::{Command, Output};
+
+fn rustnet(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rustnet"))
+        .args(args)
+        .output()
+        .expect("rustnet binary should run")
+}
+
+#[test]
+fn snapshot_interval_without_headless_is_rejected_by_clap() {
+    let output = rustnet(&["--snapshot-interval", "5"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("--headless"), "stderr: {stderr}");
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn invalid_filter_fails_before_capture() {
+    let output = rustnet(&["--headless", "--filter", "port:"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("Invalid --filter"), "stderr: {stderr}");
+    assert!(stderr.contains("port:"), "stderr: {stderr}");
+    assert!(output.stdout.is_empty());
+    // The privilege banner is printed by the step this must fail before.
+    assert!(
+        !stderr.contains("INSUFFICIENT PRIVILEGES"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn version_is_printed_in_headless_mode() {
+    let output = rustnet(&["--headless", "--version"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "stdout: {stdout}"
+    );
+}


### PR DESCRIPTION
Headless front-end (PR 2 of 3, stacked on #598; retarget to main once that merges).

- `rustnet --headless` runs the full pipeline (capture, DPI, attribution, GeoIP, DNS, sandbox, uid drop) without a terminal and streams `startup`, `new_connection`, `connection_closed`, and optional `snapshot` events as JSON lines to stdout. `--log-level` goes to stderr.
- `--snapshot-interval SECONDS` emits the whole connection table periodically; `--filter QUERY` restricts the stream using the interactive filter syntax and is validated before any privileged work.
- Connection events are serde structs in `src/headless/events.rs`, shared by stdout, `--json-log`, and the PCAP sidecar (same keys and value types as before; key order is now struct order). Stdout writes go through a bounded queue and a dedicated writer thread, so a slow consumer drops events instead of stalling capture; a closed pipe ends the run cleanly.
- Exit is 0 on SIGINT/SIGTERM/SIGHUP or a closed stdout, 1 on capture failure.
- Docs: USAGE (en, zh-CN) with a Headless Mode section, README (en, zh-CN, ja), ARCHITECTURE, INSTALL Docker example, ROADMAP, CHANGELOG. Closes #9.

Verified: fmt, clippy, `cargo test --workspace` (default and no-default-features), real headless runs on macOS (Seatbelt) and Linux (OrbStack, Landlock ABI 8, eBPF attribution), including `--json-log` parity, `--filter`, the EPIPE path, and the new spawn tests in `tests/headless_cli.rs`.

Known: `new_connection` fires on the first packet, so attribution and DPI usually land in `connection_closed` and `snapshot` events instead (documented). No Windows console control handler yet, so Ctrl+C there exits without draining the queue (documented, follow-up).