### PR TITLE
feat: add opt-in headless services

### DIFF
--- a/.github/actions/package-archive/action.yml
+++ b/.github/actions/package-archive/action.yml
@@ -1,11 +1,12 @@
 name: 'Package Release Archive'
 description: >-
-  Stage a built rustnet binary with the services asset, README and LICENSE in
-  the release-archive layout and pack it as tar.gz or zip.
+  Stage a built rustnet binary with runtime assets, service examples,
+  documentation and LICENSE, then pack it as tar.gz or zip.
 
 # The staging layout is a cross-job contract: package-installers, package-macos
 # and package-windows in release.yml (and the Homebrew formula) unpack
-# rustnet-<version>-<target>/{rustnet[.exe],assets/services,README.md,LICENSE},
+# rustnet-<version>-<target>/{rustnet[.exe],assets/services,
+# resources/packaging/<platform>,README.md,SERVICE*.md,LICENSE},
 # so every release build must produce it through this action.
 
 inputs:
@@ -44,6 +45,28 @@ runs:
           mkdir -p "$staging/assets"
           cp "crates/rustnet-core/assets/services" "$staging/assets/"
         fi
+
+        cp SERVICE.md SERVICE.zh-CN.md SERVICE.ja.md "$staging/"
+        case "${{ inputs.target }}" in
+          *-unknown-linux-*)
+            mkdir -p "$staging/resources/packaging/linux"
+            cp -R resources/packaging/linux/systemd "$staging/resources/packaging/linux/"
+            cp -R resources/packaging/linux/logrotate "$staging/resources/packaging/linux/"
+            cp compose.headless.yml "$staging/"
+            ;;
+          *-apple-darwin)
+            mkdir -p "$staging/resources/packaging/macos"
+            cp -R resources/packaging/macos/launchd "$staging/resources/packaging/macos/"
+            ;;
+          *-freebsd*)
+            mkdir -p "$staging/resources/packaging/freebsd"
+            cp -R resources/packaging/freebsd/rc.d "$staging/resources/packaging/freebsd/"
+            ;;
+          *-windows-*)
+            # The MSI installs the native SCM definition. Raw archives include
+            # the service guide but do not mutate the host.
+            ;;
+        esac
 
         cp README.md "$staging/"
         cp LICENSE "$staging/" 2>/dev/null || true

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -92,6 +92,39 @@ jobs:
           default-features: ${{ (contains(matrix.target, 'linux') || contains(matrix.target, 'apple')) && 'true' || 'false' }}
           strip-symbols: ${{ inputs.strip-symbols && 'true' || 'false' }}
 
+      - name: Validate Windows MSI authoring
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: powershell
+        run: |
+          $wixZip = "$env:RUNNER_TEMP\wix-binaries.zip"
+          $wixDir = "$env:RUNNER_TEMP\wix"
+          Invoke-WebRequest `
+            -Uri "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip" `
+            -OutFile $wixZip
+          $expected = "2c1888d5d1dba377fc7fa14444cf556963747ff9a0a289a3599cf09da03b9e2e"
+          $actual = (Get-FileHash $wixZip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $expected) {
+            throw "WiX zip checksum mismatch: expected $expected, got $actual"
+          }
+          Expand-Archive -LiteralPath $wixZip -DestinationPath $wixDir -Force
+
+          New-Item -ItemType Directory -Path assets -Force | Out-Null
+          Copy-Item crates\rustnet-core\assets\services assets\services -Force
+          $outputDir = "target\wix-validation"
+          New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+          $binDir = "target\${{ matrix.target }}\release"
+          & "$wixDir\candle.exe" -nologo -arch x64 `
+            "-dCargoTargetBinDir=$binDir" `
+            "-dVersion=1.6.0" `
+            "-dPlatform=x64" `
+            -out "$outputDir\main.wixobj" `
+            resources\packaging\windows\wix\main.wxs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & "$wixDir\light.exe" -nologo `
+            -out "$outputDir\Rustnet.msi" `
+            "$outputDir\main.wixobj"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Run tests
         if: matrix.run-tests
         run: cargo test --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,13 +359,16 @@ jobs:
           sed -i'.bak' -e "s/0\.0\.0/${VERSION}/g" -e "s/fffffff/${GITHUB_SHA:0:7}/g" resources/packaging/macos/Info.plist
 
           # Create app bundle
-          mkdir -p "Rustnet.app/Contents/"{MacOS,Resources/assets}
+          mkdir -p "Rustnet.app/Contents/"{MacOS,Resources/assets,Resources/service/launchd}
           cp resources/packaging/macos/Info.plist "Rustnet.app/Contents/"
           cp resources/packaging/macos/graphics/rustnet.icns "Rustnet.app/Contents/Resources/"
           cp "rustnet-${RELEASE_TAG}-${{ matrix.target }}/rustnet" "Rustnet.app/Contents/MacOS/"
           cp resources/packaging/macos/wrapper.sh "Rustnet.app/Contents/MacOS/"
           cp "rustnet-${RELEASE_TAG}-${{ matrix.target }}/assets/services" "Rustnet.app/Contents/Resources/assets/"
+          cp resources/packaging/macos/launchd/* "Rustnet.app/Contents/Resources/service/launchd/"
+          cp SERVICE.md SERVICE.zh-CN.md SERVICE.ja.md "Rustnet.app/Contents/Resources/service/"
           chmod +x "Rustnet.app/Contents/MacOS/"{rustnet,wrapper.sh}
+          chmod +x "Rustnet.app/Contents/Resources/service/launchd/install-rustnet-headless.sh"
 
       - name: Code sign and notarize app bundle
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,9 @@ on:
       - 'build.rs'
       - 'benches/**'
       - 'Dockerfile'
+      - 'compose.headless.yml'
+      - 'resources/packaging/**'
+      - 'scripts/check-service-packaging.sh'
       - '.cargo/audit.toml'
       - '.github/workflows/rust.yml'
   pull_request:
@@ -23,6 +26,9 @@ on:
       - 'build.rs'
       - 'benches/**'
       - 'Dockerfile'
+      - 'compose.headless.yml'
+      - 'resources/packaging/**'
+      - 'scripts/check-service-packaging.sh'
       - '.cargo/audit.toml'
       - '.github/workflows/rust.yml'
   workflow_dispatch:
@@ -43,6 +49,8 @@ jobs:
       uses: ./.github/actions/setup-linux-deps
     - name: Check formatting
       run: cargo fmt --check
+    - name: Validate service packaging
+      run: scripts/check-service-packaging.sh
     - name: Validate dependency lockfile
       run: cargo check --locked --workspace --all-targets --all-features
     - name: Check without default features
@@ -81,3 +89,8 @@ jobs:
         tags: rustnet:ci-test
     - name: Verify Docker image
       run: docker run --rm rustnet:ci-test --version
+    - name: Verify headless Docker startup
+      run: |
+        docker run --rm --network host --cap-add NET_RAW \
+          rustnet:ci-test --headless --duration 1 --output json >/tmp/rustnet-headless.json
+        test -s /tmp/rustnet-headless.json

--- a/.github/workflows/test-platform-builds.yml
+++ b/.github/workflows/test-platform-builds.yml
@@ -19,6 +19,10 @@ on:
       - 'Cross.toml'
       - 'src/**'
       - 'crates/**'
+      - 'Dockerfile'
+      - 'compose.headless.yml'
+      - 'resources/packaging/**'
+      - 'scripts/check-service-packaging.sh'
       - '.github/workflows/test-platform-builds.yml'
       - '.github/workflows/build-platforms.yml'
       - '.github/actions/**'
@@ -30,7 +34,7 @@ jobs:
   build:
     uses: ./.github/workflows/build-platforms.yml
     with:
-      create-archives: ${{ inputs.create-archives || false }}
+      create-archives: ${{ github.event_name == 'pull_request' || inputs.create-archives || false }}
       strip-symbols: false
       version: test-${{ github.run_id }}
 
@@ -48,7 +52,10 @@ jobs:
           release: '14.2'
           usesh: true
           prepare: pkg install -y curl libpcap rust
-          run: cargo build --locked --verbose --release --no-default-features
+          run: |
+            sh -n resources/packaging/freebsd/rc.d/rustnet_headless
+            sh -n resources/packaging/freebsd/rc.d/install-rustnet-headless.sh
+            cargo build --locked --verbose --release --no-default-features
 
   trigger-freebsd-build:
     name: trigger-freebsd-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Opt-in Headless Services**: inactive service definitions for systemd,
+  launchd, Windows SCM, FreeBSD rc.d, and Docker Compose use explicit headless
+  commands and a 5000 ms refresh interval. `--output-file` securely writes
+  JSONL by appending or one final JSON snapshot by replacement
 - **Headless Mode**: `--headless` runs without the TUI, with optional
   `--duration` and shared `--filter` syntax. Versioned snapshots stream as
   JSONL by default, while `--output json` emits one final snapshot. Stdout is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ windows = { workspace = true, features = [
     "Win32_System_Console",
     "Win32_System_JobObjects",
     "Win32_System_LibraryLoader",
+    "Win32_System_Services",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
 ] }
@@ -188,6 +189,7 @@ Features:
 depends = "libpcap0.8, libelf1"
 section = "net"
 priority = "optional"
+maintainer-scripts = "debian"
 assets = [
     [
         "target/release/rustnet",
@@ -214,16 +216,42 @@ assets = [
         "usr/share/applications/",
         "644",
     ],
+    [
+        "resources/packaging/linux/systemd/rustnet-headless.service",
+        "usr/lib/systemd/system/rustnet-headless.service",
+        "644",
+    ],
+    [
+        "resources/packaging/linux/systemd/rustnet-headless.env",
+        "etc/default/rustnet-headless",
+        "644",
+    ],
+    [
+        "resources/packaging/linux/logrotate/rustnet-headless",
+        "etc/logrotate.d/rustnet-headless",
+        "644",
+    ],
+    [
+        "SERVICE.md",
+        "usr/share/doc/rustnet-monitor/",
+        "644",
+    ],
 ]
-conf-files = []
 
 [package.metadata.generate-rpm]
+post_install_script = "resources/packaging/linux/rpm/post_install.sh"
+pre_uninstall_script = "resources/packaging/linux/rpm/pre_uninstall.sh"
+post_uninstall_script = "resources/packaging/linux/rpm/post_uninstall.sh"
 assets = [
     { source = "target/release/rustnet", dest = "/usr/bin/rustnet", mode = "755" },
     { source = "README.md", dest = "/usr/share/doc/rustnet-monitor/README.md", mode = "644" },
     { source = "crates/rustnet-core/assets/services", dest = "/usr/share/rustnet-monitor/services", mode = "644" },
     { source = "resources/packaging/linux/graphics/rustnet.png", dest = "/usr/share/icons/hicolor/256x256/apps/rustnet.png", mode = "644" },
     { source = "resources/packaging/linux/rustnet.desktop", dest = "/usr/share/applications/rustnet.desktop", mode = "644" },
+    { source = "resources/packaging/linux/systemd/rustnet-headless.service", dest = "/usr/lib/systemd/system/rustnet-headless.service", mode = "644" },
+    { source = "resources/packaging/linux/systemd/rustnet-headless.env", dest = "/etc/default/rustnet-headless", mode = "644", config = "noreplace" },
+    { source = "resources/packaging/linux/logrotate/rustnet-headless", dest = "/etc/logrotate.d/rustnet-headless", mode = "644", config = "noreplace" },
+    { source = "SERVICE.md", dest = "/usr/share/doc/rustnet-monitor/SERVICE.md", mode = "644", doc = true },
 ]
 [package.metadata.generate-rpm.requires]
 libpcap = "*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,4 +108,5 @@ LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"
 # /proc-based process detection.
 # CAP_NET_ADMIN is NOT required (read-only, non-promiscuous capture).
 USER rustnet
+STOPSIGNAL SIGTERM
 ENTRYPOINT ["rustnet"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -106,9 +106,10 @@ rustnet --pcapng-export capture.pcapng  # 注釈付き PCAPNG を出力
 rustnet --headless                                      # JSONL スナップショットをストリーミング出力
 rustnet --headless --duration 30 --output json         # 最終スナップショットを 1 件出力
 rustnet --headless --filter 'process:curl app:https'   # 接続フィルターを適用
+rustnet --headless --output-file snapshots.jsonl       # 非公開ファイルへ JSONL を追記
 ```
 
-ヘッドレスモードの既定は `--output jsonl` で、設定された更新間隔ごとにバージョン付きスナップショットを出力します。`--output json` は監視終了時にバージョン付きの最終スナップショットを 1 件出力します。`--duration` は指定した秒数後にキャプチャを停止し、`--filter` は TUI と同じ構文を受け付けます。ヘッドレスモードでは stdout に機械可読の出力だけを書き込みます。キャプチャの起動に失敗した場合は、ゼロ以外の終了ステータスを返します。
+ヘッドレスモードの既定は `--output jsonl` で、設定された更新間隔ごとにバージョン付きスナップショットを出力します。`--output json` は監視終了時にバージョン付きの最終スナップショットを 1 件出力します。`--duration` は指定した秒数後にキャプチャを停止し、`--filter` は TUI と同じ構文を受け付けます。`--output-file` は stdout の代わりに非公開ファイルへ直接書き込み、JSONL は追記、JSON は置換します。ヘッドレスモードでは stdout に機械可読の出力だけを書き込みます。キャプチャの起動に失敗した場合は、ゼロ以外の終了ステータスを返します。systemd、launchd、Windows、FreeBSD、Docker Compose での明示的な有効化方法は [SERVICE.ja.md](SERVICE.ja.md) を参照してください。
 
 テーマと各色の上書きは `~/.config/rustnet/config.toml` でも設定できます（`--theme` が優先）。詳細は [USAGE.md](USAGE.md#--theme-preset) を参照してください。
 
@@ -152,6 +153,7 @@ RustNet は非プロミスキャスな読み取り専用キャプチャを行い
 
 - [INSTALL.md](INSTALL.md): 詳細なインストール、権限設定、トラブルシューティング
 - [USAGE.md](USAGE.md): 詳細な使用方法
+- [SERVICE.ja.md](SERVICE.ja.md): ヘッドレスサービスの有効化、運用、セキュリティ、出力保持
 - [ARCHITECTURE.md](ARCHITECTURE.md): 設計とプラットフォーム別実装
 - [CONTRIBUTING.md](CONTRIBUTING.md): コントリビューションガイド
 

--- a/README.md
+++ b/README.md
@@ -201,9 +201,10 @@ The TUI remains the default. For scripts and services, use headless mode:
 rustnet --headless                                      # Stream JSONL snapshots
 rustnet --headless --duration 30 --output json         # Emit one final snapshot
 rustnet --headless --filter 'process:curl app:https'   # Apply a connection filter
+rustnet --headless --output-file snapshots.jsonl       # Append JSONL to a private file
 ```
 
-`--output jsonl` is the headless default and streams versioned snapshots at the configured refresh interval. `--output json` emits one final versioned snapshot when monitoring stops. `--duration` stops capture after the requested number of seconds, and `--filter` accepts the same syntax as the TUI. In headless mode, stdout contains machine-readable output only. Capture startup failures exit with a nonzero status.
+`--output jsonl` is the headless default and streams versioned snapshots at the configured refresh interval. `--output json` emits one final versioned snapshot when monitoring stops. `--duration` stops capture after the requested number of seconds, and `--filter` accepts the same syntax as the TUI. `--output-file` writes directly to a private file instead of stdout, appending JSONL or replacing JSON. In headless mode, stdout contains machine-readable output only. Capture startup failures exit with a nonzero status. See [SERVICE.md](SERVICE.md) for opt-in systemd, launchd, Windows, FreeBSD, and Docker Compose operation.
 
 The theme and per-color overrides can also be set in `~/.config/rustnet/config.toml`; `--theme` takes precedence. See [USAGE.md](USAGE.md#--theme-preset) for the schema.
 
@@ -322,6 +323,7 @@ See [USAGE.md](USAGE.md) for complete timeout details.
 
 - **[INSTALL.md](INSTALL.md)** - Detailed installation instructions for all platforms, permission setup, and troubleshooting
 - **[USAGE.md](USAGE.md)** - Complete usage guide including command-line options, filtering, sorting, and logging
+- **[SERVICE.md](SERVICE.md)** - Opt-in headless service setup, operation, security, and output retention
 - **[SECURITY.md](SECURITY.md)** - Security features including Landlock sandboxing and privilege management
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - Technical architecture, platform implementations, and performance details
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - Contribution workflow, quality requirements, and project guidelines

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,9 +201,10 @@ rustnet --pcapng-export capture.pcapng  # 导出带注释的 PCAPNG
 rustnet --headless                                      # 流式输出 JSONL 快照
 rustnet --headless --duration 30 --output json         # 输出一份最终快照
 rustnet --headless --filter 'process:curl app:https'   # 应用连接过滤器
+rustnet --headless --output-file snapshots.jsonl       # 将 JSONL 追加到私有文件
 ```
 
-无界面模式默认使用 `--output jsonl`，按配置的刷新间隔流式输出带版本号的快照。`--output json` 会在监控停止时输出一份带版本号的最终快照。`--duration` 会在指定秒数后停止抓包，`--filter` 接受与 TUI 相同的语法。无界面模式的 stdout 仅包含机器可读输出。抓包启动失败时，程序会以非零状态退出。
+无界面模式默认使用 `--output jsonl`，按配置的刷新间隔流式输出带版本号的快照。`--output json` 会在监控停止时输出一份带版本号的最终快照。`--duration` 会在指定秒数后停止抓包，`--filter` 接受与 TUI 相同的语法。`--output-file` 会直接写入私有文件而不是 stdout，JSONL 会追加，JSON 会替换。无界面模式的 stdout 仅包含机器可读输出。抓包启动失败时，程序会以非零状态退出。systemd、launchd、Windows、FreeBSD 与 Docker Compose 的显式启用方法见 [SERVICE.zh-CN.md](SERVICE.zh-CN.md)。
 
 主题及各颜色的覆盖也可在 `~/.config/rustnet/config.toml` 中设置；`--theme` 优先。配置格式见 [USAGE.zh-CN.md](USAGE.zh-CN.md#--theme-preset)。
 
@@ -320,6 +321,7 @@ RustNet 在移除连接前会先通过智能超时机制与视觉提示给出预
 
 - **[INSTALL.zh-CN.md](INSTALL.zh-CN.md)** —— 各平台的详细安装说明、权限配置与排障
 - **[USAGE.zh-CN.md](USAGE.zh-CN.md)** —— 完整使用手册，涵盖命令行参数、过滤、排序与日志
+- **[SERVICE.zh-CN.md](SERVICE.zh-CN.md)**：无界面服务的显式启用、运行、安全与输出保留
 - **[SECURITY.zh-CN.md](SECURITY.zh-CN.md)** —— 安全特性，包括 Landlock 沙箱与权限管理
 - **[ARCHITECTURE.zh-CN.md](ARCHITECTURE.zh-CN.md)** —— 技术架构、各平台实现与性能细节
 - **[CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)** —— 贡献指南，包括工作流、质量要求与 AI 辅助贡献规范

--- a/SERVICE.ja.md
+++ b/SERVICE.ja.md
@@ -1,0 +1,282 @@
+<p align="center"><a href="SERVICE.md">English</a> | <a href="SERVICE.zh-CN.md">简体中文</a> | <strong>日本語</strong></p>
+
+# ヘッドレスサービスガイド
+
+RustNet は Linux、macOS、Windows、FreeBSD のネイティブなサービスマネージャー、
+または Docker Compose で継続的に実行できます。RustNet や付属のサービス定義を
+インストールしても、監視は有効化も開始もされません。コマンドとデータ保持方針を
+確認してから、明示的にサービスを有効化してください。
+
+オプションなしの `rustnet` は常に対話型 TUI を起動します。このリポジトリの各
+サービス定義は `--headless` を明示的に渡し、長期実行時の CPU とストレージ使用量を
+抑えるため更新間隔を 5000 ms に設定します。CLI の既定値は引き続き 500 ms です。
+
+## セキュリティ、出力、保持
+
+ほとんどのシステムではパケットキャプチャに昇格権限が必要です。systemd、launchd、
+rc.d の定義は root で起動し、RustNet がキャプチャを初期化した後、通常どおり
+サンドボックスと権限縮小を適用します。Windows サービスは LocalSystem で動作し、
+Npcap に依存します。Docker は `NET_RAW` だけを追加し、その他の Linux capability を
+すべて削除してホストネットワークを使用します。
+
+接続スナップショットには、プロセス名、アドレス、ホスト名、トラフィックメタデータが
+含まれる場合があります。親ディレクトリを非公開にし、この情報を参照すべき運用者だけに
+アクセスを許可してください。
+
+サービスの既定値は次のとおりです。
+
+| プラットフォーム | スナップショット出力 | 診断 | 付属の保持設定 |
+|---|---|---|---|
+| Linux systemd | `/var/lib/rustnet/headless.jsonl` | systemd journal | 日次ローテーション、7 ファイル、圧縮 |
+| macOS launchd | `/var/db/rustnet/headless.jsonl` | `/var/db/rustnet/headless.err.log` | なし |
+| Windows SCM | `%ProgramData%\Rustnet\rustnet.jsonl` | SCM でサービス状態を確認 | なし |
+| FreeBSD rc.d | `/var/db/rustnet/headless.jsonl` | `/var/db/rustnet/headless.err.log` | なし |
+| Docker Compose | コンテナの stdout | コンテナの stderr | Docker `json-file`、10 MB × 7 ファイル |
+
+Linux では `copytruncate` を使うため、ローテーション中も RustNet は出力ディスクリプタを
+保持できます。macOS、Windows、FreeBSD で長期運用する前にローカルのローテーションを
+設定してください。使用中の出力ファイルを移動または置換する前にはサービスを停止します。
+サービス定義を削除してもキャプチャ済みデータは削除されません。不要になった保持ファイル
+だけを別途削除してください。
+
+独自のヘッドレスコマンドでは、`--output-file FILE` により stdout の代わりに安全に
+開いた通常ファイルへスナップショットを直接書き込めます。`--output jsonl` では新しい
+実行がファイルへ追記されます。`--output json` では新しい実行が 1 件の最終スナップショット
+でファイルを置換します。`--output-file`、`--output`、`--duration`、`--filter` はすべて
+`--headless` が必要です。
+
+```bash
+# バージョン付きスナップショットストリームを追記
+sudo rustnet --headless --output jsonl --output-file /var/lib/rustnet/custom.jsonl
+
+# 60 秒後に 1 件の最終スナップショットでファイルを置換
+sudo rustnet --headless --duration 60 --output json --output-file /var/lib/rustnet/final.json
+```
+
+## Linux の systemd
+
+unit は RustNet が `/usr/bin/rustnet` にあることを前提とします。ディストリビューション
+パッケージでは付属ファイルが自動配置される場合があります。このソースツリーから手動で
+インストールする場合は次のようにします。
+
+```bash
+sudo install -m 0755 target/release/rustnet /usr/bin/rustnet
+sudo install -Dm0644 resources/packaging/linux/systemd/rustnet-headless.service \
+  /etc/systemd/system/rustnet-headless.service
+sudo install -Dm0644 resources/packaging/linux/systemd/rustnet-headless.env \
+  /etc/default/rustnet-headless
+sudo install -Dm0644 resources/packaging/linux/logrotate/rustnet-headless \
+  /etc/logrotate.d/rustnet-headless
+sudo systemctl daemon-reload
+```
+
+バイナリリリースアーカイブでは、展開したディレクトリから実行し、
+`target/release/rustnet` を `./rustnet` に置き換えてください。
+
+これらのコマンドは非アクティブな unit をインストールするだけです。任意のフィルターや
+追加引数は `/etc/default/rustnet-headless` で設定します。このファイルから固定の
+`--headless`、`--interface any`、`--refresh-interval 5000`、`--output jsonl` を
+削除することはできません。
+
+```bash
+# ブート時に有効化し、今すぐ開始
+sudo systemctl enable rustnet-headless.service
+sudo systemctl start rustnet-headless.service
+
+# 状態、診断、スナップショットを確認
+systemctl status rustnet-headless.service
+sudo journalctl -u rustnet-headless.service -f
+sudo tail -F /var/lib/rustnet/headless.jsonl
+
+# 停止して無効化
+sudo systemctl stop rustnet-headless.service
+sudo systemctl disable rustnet-headless.service
+```
+
+手動インストールした定義を削除する場合は、先に停止して無効化し、配置した定義ファイル
+だけを削除します。
+
+```bash
+sudo rm /etc/systemd/system/rustnet-headless.service
+sudo rm /etc/default/rustnet-headless
+sudo rm /etc/logrotate.d/rustnet-headless
+sudo systemctl daemon-reload
+```
+
+非公開の `/var/lib/rustnet` 状態ディレクトリとスナップショットは残ります。パッケージから
+配置されたファイルには、そのパッケージマネージャーを使用してください。
+
+## macOS の launchd
+
+launchd の property list はリリースアプリが `/Applications/Rustnet.app` にあることを
+前提とし、`/Applications/Rustnet.app/Contents/MacOS/rustnet` を実行します。app bundle を
+その場所へ配置してから、付属インストーラーを実行します。
+
+```bash
+sudo /Applications/Rustnet.app/Contents/Resources/service/launchd/install-rustnet-headless.sh
+```
+
+CLI またはバイナリアーカイブ版では、`rustnet` を安定した絶対パスにインストールし、
+そのパスを `resources/packaging/macos/launchd` 内のスクリプトへ明示的に渡します。
+
+```bash
+sudo install -m 0755 rustnet /usr/local/bin/rustnet
+sudo env RUSTNET_BIN=/usr/local/bin/rustnet \
+  resources/packaging/macos/launchd/install-rustnet-headless.sh
+```
+
+インストーラーはモード `0700` で `/var/db/rustnet` を作成し、
+`com.domcyrus.rustnet-headless.plist` を配置してジョブを無効化します。bootstrap や起動は
+行いません。準備ができてから有効化してロードしてください。property list に
+`RunAtLoad` があるため、bootstrap によって監視も開始されます。
+
+```bash
+# 有効化して開始
+sudo launchctl enable system/com.domcyrus.rustnet-headless
+sudo launchctl bootstrap system \
+  /Library/LaunchDaemons/com.domcyrus.rustnet-headless.plist
+
+# 状態、診断、スナップショットを確認
+sudo launchctl print system/com.domcyrus.rustnet-headless
+sudo tail -F /var/db/rustnet/headless.err.log
+sudo tail -F /var/db/rustnet/headless.jsonl
+
+# ロード済みジョブを再起動
+sudo launchctl kickstart -k system/com.domcyrus.rustnet-headless
+
+# 停止、アンロード、無効化
+sudo launchctl bootout system/com.domcyrus.rustnet-headless
+sudo launchctl disable system/com.domcyrus.rustnet-headless
+```
+
+bootout の後で定義をアンインストールします。
+
+```bash
+sudo rm /Library/LaunchDaemons/com.domcyrus.rustnet-headless.plist
+```
+
+app bundle と `/var/db/rustnet` のデータは、別途削除するまで残ります。
+
+## Windows の Service Control Manager
+
+最初に標準オプションで Npcap をインストールし、管理者 PowerShell から RustNet MSI を
+インストールします。
+
+```powershell
+msiexec.exe /i .\rustnet-<version>.msi
+```
+
+MSI は `Rustnet` サービスを手動スタートとして登録します。サービスの起動や自動スタートの
+設定は行いません。コマンドには `--windows-service --headless --output jsonl
+--output-file "%ProgramData%\Rustnet\rustnet.jsonl" --refresh-interval 5000` が含まれます。
+内部オプション `--windows-service` は SCM による起動専用です。TUI には引き続き通常の
+`rustnet` を使用してください。
+
+```powershell
+# 必要に応じて自動スタートを有効化し、今すぐ開始
+Set-Service -Name Rustnet -StartupType Automatic
+Start-Service -Name Rustnet
+
+# 状態を確認し、スナップショットを追跡
+Get-Service -Name Rustnet
+sc.exe queryex Rustnet
+Get-Content "$env:ProgramData\Rustnet\rustnet.jsonl" -Wait
+
+# System イベントログで SCM のライフサイクルエラーを確認
+Get-WinEvent -LogName System |
+  Where-Object ProviderName -eq 'Service Control Manager' |
+  Where-Object Message -Match 'Rustnet' |
+  Select-Object -First 20
+
+# 停止して無効化
+Stop-Service -Name Rustnet
+Set-Service -Name Rustnet -StartupType Disabled
+```
+
+Windows の設定画面からアンインストールするか、管理者 PowerShell で同じ MSI を使います。
+
+```powershell
+msiexec.exe /x .\rustnet-<version>.msi
+```
+
+インストーラーはサービスを停止して削除します。`%ProgramData%\Rustnet` の保持ファイルは
+残る場合があるため、必要に応じて別途削除してください。
+
+## FreeBSD の rc.d
+
+rc.d スクリプトは RustNet が `/usr/local/bin/rustnet` にあることを前提とします。
+バイナリを配置してから、付属の定義インストーラーを実行します。
+
+```sh
+sudo install -m 0555 target/release/rustnet /usr/local/bin/rustnet
+sudo resources/packaging/freebsd/rc.d/install-rustnet-headless.sh
+```
+
+バイナリリリースアーカイブでは、`target/release/rustnet` を `./rustnet` に
+置き換えてください。
+
+インストーラーはモード `0700` で `/var/db/rustnet` を作成し、`rustnet_headless` を配置して
+`rustnet_headless_enable=NO` を維持します。
+
+```sh
+# ブート時に有効化し、今すぐ開始
+sudo sysrc rustnet_headless_enable=YES
+sudo service rustnet_headless start
+
+# 状態、診断、スナップショットを確認
+sudo service rustnet_headless status
+sudo tail -F /var/db/rustnet/headless.err.log
+sudo tail -F /var/db/rustnet/headless.jsonl
+
+# 停止して無効化
+sudo service rustnet_headless stop
+sudo sysrc rustnet_headless_enable=NO
+```
+
+追加の CLI 引数は `/etc/rc.conf` の `rustnet_headless_extra_args` で設定できます。スクリプトは
+明示的な `--headless --refresh-interval 5000 --output jsonl` を常に維持します。
+
+手動インストールした定義を削除します。
+
+```sh
+sudo rm /usr/local/etc/rc.d/rustnet_headless
+sudo sysrc -x rustnet_headless_enable
+sudo sysrc -x rustnet_headless_extra_args
+```
+
+バイナリと `/var/db/rustnet` のデータは、別途削除するまで残ります。
+
+## Docker Compose
+
+付属の Compose ファイルは既存のイメージをビルドし、そのコマンドを明示的なヘッドレス
+引数で上書きします。イメージのビルドや pull だけでは監視は開始されません。
+
+```bash
+# 起動せずにビルド
+docker compose -f compose.headless.yml build
+
+# 明示的に開始
+docker compose -f compose.headless.yml up -d
+
+# バイナリリリースアーカイブでは、VERSION を先頭の v なしのバージョンに置換
+RUSTNET_IMAGE_TAG=VERSION docker compose -f compose.headless.yml pull
+RUSTNET_IMAGE_TAG=VERSION docker compose -f compose.headless.yml up -d --no-build
+
+# 状態と出力を確認
+docker compose -f compose.headless.yml ps
+docker compose -f compose.headless.yml logs -f rustnet
+
+# コンテナを残して停止し、その後デプロイをアンインストール
+docker compose -f compose.headless.yml stop
+docker compose -f compose.headless.yml down
+```
+
+Compose には個別の install や enable 手順はありません。イメージのビルドでデプロイを
+準備し、`down` でコンテナとネットワークを削除します。最初に明示的に起動した後は、運用者が停止
+しない限り、`restart: unless-stopped` によって障害時や Docker daemon 再起動後にコンテナが
+再起動します。スナップショットストリームはコンテナの stdout に残り、Docker が付属の
+上限付きログポリシーを適用します。
+
+スナップショットをファイルとして永続化する場合は、非公開のホスト volume を追加し、
+`command` に `--output-file` を渡してホスト側のローテーションを設定します。read-only
+コンテナ内では出力パスだけを書き込み可能にし、より広い capability は追加しないでください。

--- a/SERVICE.md
+++ b/SERVICE.md
@@ -1,0 +1,288 @@
+<p align="center"><strong>English</strong> | <a href="SERVICE.zh-CN.md">简体中文</a> | <a href="SERVICE.ja.md">日本語</a></p>
+
+# Headless Service Guide
+
+RustNet can run continuously under the native service manager on Linux, macOS,
+Windows, and FreeBSD, or under Docker Compose. Installing RustNet or one of the
+included service definitions does not enable or start monitoring. Review the
+command and retention policy, then activate the service explicitly.
+
+Running `rustnet` without options always starts the interactive TUI. Every
+service definition in this repository passes `--headless` explicitly and uses
+a 5000 ms refresh interval to limit long-running CPU and storage use. The CLI
+default remains 500 ms.
+
+## Security, output, and retention
+
+Packet capture needs elevated privileges on most systems. The systemd,
+launchd, and rc.d definitions start as root so RustNet can initialize capture,
+then RustNet applies its normal sandbox and privilege reduction. The Windows
+service runs as LocalSystem and depends on Npcap. Docker adds only `NET_RAW`,
+drops all other Linux capabilities, and uses host networking.
+
+Connection snapshots can contain process names, addresses, hostnames, and
+traffic metadata. Keep their parent directory private and grant access only to
+operators who should see that information.
+
+The service defaults are:
+
+| Platform | Snapshot output | Diagnostics | Included retention |
+|---|---|---|---|
+| Linux systemd | `/var/lib/rustnet/headless.jsonl` | systemd journal | Daily rotation, 7 files, compression |
+| macOS launchd | `/var/db/rustnet/headless.jsonl` | `/var/db/rustnet/headless.err.log` | None |
+| Windows SCM | `%ProgramData%\Rustnet\rustnet.jsonl` | Service status through SCM | None |
+| FreeBSD rc.d | `/var/db/rustnet/headless.jsonl` | `/var/db/rustnet/headless.err.log` | None |
+| Docker Compose | Container stdout | Container stderr | Docker `json-file`, 10 MB times 7 files |
+
+Linux uses `copytruncate` so RustNet can keep its output descriptor open during
+rotation. Configure local rotation before long-running macOS, Windows, or
+FreeBSD use. Stop the service before moving or replacing an active output file.
+Removing a service definition does not remove captured data. Delete retained
+files separately only when they are no longer needed.
+
+For a custom headless command, `--output-file FILE` writes snapshots directly
+to a securely opened regular file instead of stdout. With `--output jsonl`, a
+new run appends to the file. With `--output json`, a new run replaces the file
+with its single final snapshot. `--output-file`, `--output`, `--duration`, and
+`--filter` all require `--headless`.
+
+```bash
+# Append a versioned snapshot stream
+sudo rustnet --headless --output jsonl --output-file /var/lib/rustnet/custom.jsonl
+
+# Replace the file with one final snapshot after 60 seconds
+sudo rustnet --headless --duration 60 --output json --output-file /var/lib/rustnet/final.json
+```
+
+## Linux with systemd
+
+The unit expects RustNet at `/usr/bin/rustnet`. Distribution packages can place
+the included files automatically. For a manual installation from this source
+tree:
+
+```bash
+sudo install -m 0755 target/release/rustnet /usr/bin/rustnet
+sudo install -Dm0644 resources/packaging/linux/systemd/rustnet-headless.service \
+  /etc/systemd/system/rustnet-headless.service
+sudo install -Dm0644 resources/packaging/linux/systemd/rustnet-headless.env \
+  /etc/default/rustnet-headless
+sudo install -Dm0644 resources/packaging/linux/logrotate/rustnet-headless \
+  /etc/logrotate.d/rustnet-headless
+sudo systemctl daemon-reload
+```
+
+In a binary release archive, run these commands from the extracted directory
+and replace `target/release/rustnet` with `./rustnet`.
+
+These commands install an inactive unit. Configure optional filters or other
+arguments in `/etc/default/rustnet-headless`. The fixed `--headless`,
+`--interface any`, `--refresh-interval 5000`, and `--output jsonl` arguments
+cannot be removed through that file.
+
+```bash
+# Enable at boot, then start now
+sudo systemctl enable rustnet-headless.service
+sudo systemctl start rustnet-headless.service
+
+# Inspect status, diagnostics, and snapshots
+systemctl status rustnet-headless.service
+sudo journalctl -u rustnet-headless.service -f
+sudo tail -F /var/lib/rustnet/headless.jsonl
+
+# Stop and disable
+sudo systemctl stop rustnet-headless.service
+sudo systemctl disable rustnet-headless.service
+```
+
+To uninstall a manual definition, stop and disable it first, then remove only
+the installed definition files:
+
+```bash
+sudo rm /etc/systemd/system/rustnet-headless.service
+sudo rm /etc/default/rustnet-headless
+sudo rm /etc/logrotate.d/rustnet-headless
+sudo systemctl daemon-reload
+```
+
+The private `/var/lib/rustnet` state directory and its snapshots remain in
+place. Use the package manager instead when the files came from a package.
+
+## macOS with launchd
+
+The launchd property list expects the release app at `/Applications/Rustnet.app`
+and runs `/Applications/Rustnet.app/Contents/MacOS/rustnet`. Install the app
+bundle there, then run the included installer:
+
+```bash
+sudo /Applications/Rustnet.app/Contents/Resources/service/launchd/install-rustnet-headless.sh
+```
+
+For a CLI or binary-archive installation, install `rustnet` at a stable
+absolute path and pass it explicitly to the copy under
+`resources/packaging/macos/launchd`:
+
+```bash
+sudo install -m 0755 rustnet /usr/local/bin/rustnet
+sudo env RUSTNET_BIN=/usr/local/bin/rustnet \
+  resources/packaging/macos/launchd/install-rustnet-headless.sh
+```
+
+The installer creates `/var/db/rustnet` with mode `0700`, installs
+`com.domcyrus.rustnet-headless.plist`, disables the job, and does not bootstrap
+or start it. Enable and load it only when ready. Because the property list uses
+`RunAtLoad`, bootstrapping also starts monitoring.
+
+```bash
+# Enable and start
+sudo launchctl enable system/com.domcyrus.rustnet-headless
+sudo launchctl bootstrap system \
+  /Library/LaunchDaemons/com.domcyrus.rustnet-headless.plist
+
+# Inspect status, diagnostics, and snapshots
+sudo launchctl print system/com.domcyrus.rustnet-headless
+sudo tail -F /var/db/rustnet/headless.err.log
+sudo tail -F /var/db/rustnet/headless.jsonl
+
+# Restart an already loaded job
+sudo launchctl kickstart -k system/com.domcyrus.rustnet-headless
+
+# Stop, unload, and disable
+sudo launchctl bootout system/com.domcyrus.rustnet-headless
+sudo launchctl disable system/com.domcyrus.rustnet-headless
+```
+
+To uninstall the definition after booting it out:
+
+```bash
+sudo rm /Library/LaunchDaemons/com.domcyrus.rustnet-headless.plist
+```
+
+The app bundle and `/var/db/rustnet` data remain until removed separately.
+
+## Windows with the Service Control Manager
+
+Install Npcap with its standard options first, then install the RustNet MSI from
+an Administrator PowerShell:
+
+```powershell
+msiexec.exe /i .\rustnet-<version>.msi
+```
+
+The MSI registers the `Rustnet` service with Manual startup. It does not start
+the service or configure automatic startup. Its command contains
+`--windows-service --headless --output jsonl --output-file
+"%ProgramData%\Rustnet\rustnet.jsonl" --refresh-interval 5000`. The internal
+`--windows-service` switch is for SCM activation only. Continue to use bare
+`rustnet` for the TUI.
+
+```powershell
+# Optionally enable automatic startup, then start now
+Set-Service -Name Rustnet -StartupType Automatic
+Start-Service -Name Rustnet
+
+# Inspect status and follow snapshots
+Get-Service -Name Rustnet
+sc.exe queryex Rustnet
+Get-Content "$env:ProgramData\Rustnet\rustnet.jsonl" -Wait
+
+# Inspect SCM lifecycle errors in the System event log
+Get-WinEvent -LogName System |
+  Where-Object ProviderName -eq 'Service Control Manager' |
+  Where-Object Message -Match 'Rustnet' |
+  Select-Object -First 20
+
+# Stop and disable
+Stop-Service -Name Rustnet
+Set-Service -Name Rustnet -StartupType Disabled
+```
+
+Uninstall through Windows Settings, or use the same MSI from an Administrator
+PowerShell:
+
+```powershell
+msiexec.exe /x .\rustnet-<version>.msi
+```
+
+The installer stops and removes the service. Retained files under
+`%ProgramData%\Rustnet` may remain and should be removed separately if desired.
+
+## FreeBSD with rc.d
+
+The rc.d script expects RustNet at `/usr/local/bin/rustnet`. Install the binary,
+then run the included definition installer:
+
+```sh
+sudo install -m 0555 target/release/rustnet /usr/local/bin/rustnet
+sudo resources/packaging/freebsd/rc.d/install-rustnet-headless.sh
+```
+
+In a binary release archive, replace `target/release/rustnet` with `./rustnet`.
+
+The installer creates `/var/db/rustnet` with mode `0700`, installs
+`rustnet_headless`, and keeps `rustnet_headless_enable=NO`.
+
+```sh
+# Enable at boot, then start now
+sudo sysrc rustnet_headless_enable=YES
+sudo service rustnet_headless start
+
+# Inspect status, diagnostics, and snapshots
+sudo service rustnet_headless status
+sudo tail -F /var/db/rustnet/headless.err.log
+sudo tail -F /var/db/rustnet/headless.jsonl
+
+# Stop and disable
+sudo service rustnet_headless stop
+sudo sysrc rustnet_headless_enable=NO
+```
+
+Set optional CLI arguments with `rustnet_headless_extra_args` in `/etc/rc.conf`.
+The script always retains its explicit `--headless --refresh-interval 5000
+--output jsonl` arguments.
+
+To uninstall the manual definition:
+
+```sh
+sudo rm /usr/local/etc/rc.d/rustnet_headless
+sudo sysrc -x rustnet_headless_enable
+sudo sysrc -x rustnet_headless_extra_args
+```
+
+The binary and `/var/db/rustnet` data remain until removed separately.
+
+## Docker Compose
+
+The included Compose file builds the existing image and overrides its command
+with explicit headless arguments. Building or pulling an image does not start
+monitoring.
+
+```bash
+# Build without starting
+docker compose -f compose.headless.yml build
+
+# Start explicitly
+docker compose -f compose.headless.yml up -d
+
+# From a binary release archive, use its semver without the leading v
+RUSTNET_IMAGE_TAG=VERSION docker compose -f compose.headless.yml pull
+RUSTNET_IMAGE_TAG=VERSION docker compose -f compose.headless.yml up -d --no-build
+
+# Inspect status and output
+docker compose -f compose.headless.yml ps
+docker compose -f compose.headless.yml logs -f rustnet
+
+# Stop without removing the container, then uninstall the deployment
+docker compose -f compose.headless.yml stop
+docker compose -f compose.headless.yml down
+```
+
+Compose has no separate install or enable step. Building the image prepares the
+deployment, and `down` removes its container and network. After the first explicit start, the
+`restart: unless-stopped` policy restarts the container after failures or a
+Docker daemon restart unless an operator stopped it. The snapshot stream stays
+on container stdout, and Docker applies the included bounded log policy.
+
+To persist snapshots as files instead, add a private host volume, pass
+`--output-file` in `command`, and configure host-side rotation. Keep the output
+path writable inside the read-only container without adding broader
+capabilities.

--- a/SERVICE.zh-CN.md
+++ b/SERVICE.zh-CN.md
@@ -1,0 +1,268 @@
+<p align="center"><a href="SERVICE.md">English</a> | <strong>简体中文</strong> | <a href="SERVICE.ja.md">日本語</a></p>
+
+# 无界面服务指南
+
+RustNet 可以由 Linux、macOS、Windows 和 FreeBSD 的原生服务管理器持续运行，也可以
+由 Docker Compose 管理。安装 RustNet 或仓库提供的服务定义不会启用或启动监控。请先
+检查命令与数据保留策略，再明确启用服务。
+
+不带参数运行 `rustnet` 始终会启动交互式 TUI。仓库中的每个服务定义都会显式传入
+`--headless`，并使用 5000 ms 的刷新间隔，以降低长期运行时的 CPU 与存储开销。
+命令行的默认刷新间隔仍为 500 ms。
+
+## 安全、输出与数据保留
+
+大多数系统上的数据包捕获都需要提升权限。systemd、launchd 和 rc.d 定义会以 root
+启动，让 RustNet 初始化捕获，随后 RustNet 会照常启用沙箱并降低权限。Windows 服务
+以 LocalSystem 身份运行，并依赖 Npcap。Docker 仅添加 `NET_RAW`，丢弃其他所有 Linux
+capability，并使用主机网络。
+
+连接快照可能包含进程名、地址、主机名和流量元数据。请确保父目录仅对需要查看这些
+信息的管理员开放。
+
+各服务的默认设置如下：
+
+| 平台 | 快照输出 | 诊断信息 | 内置保留策略 |
+|---|---|---|---|
+| Linux systemd | `/var/lib/rustnet/headless.jsonl` | systemd journal | 每日轮换，保留 7 份并压缩 |
+| macOS launchd | `/var/db/rustnet/headless.jsonl` | `/var/db/rustnet/headless.err.log` | 无 |
+| Windows SCM | `%ProgramData%\Rustnet\rustnet.jsonl` | 通过 SCM 查看服务状态 | 无 |
+| FreeBSD rc.d | `/var/db/rustnet/headless.jsonl` | `/var/db/rustnet/headless.err.log` | 无 |
+| Docker Compose | 容器 stdout | 容器 stderr | Docker `json-file`，10 MB × 7 份 |
+
+Linux 使用 `copytruncate`，轮换期间 RustNet 可以继续持有输出描述符。长期运行 macOS、
+Windows 或 FreeBSD 服务前，请配置本机轮换策略。移动或替换正在使用的输出文件前，
+应先停止服务。删除服务定义不会删除已捕获的数据，仅在不再需要时另行删除保留文件。
+
+对于自定义无界面命令，`--output-file FILE` 会把快照直接写入安全打开的普通文件，而
+不是 stdout。使用 `--output jsonl` 时，新一轮运行会追加到文件；使用 `--output json`
+时，新一轮运行会以唯一的最终快照替换文件。`--output-file`、`--output`、`--duration`
+和 `--filter` 都必须与 `--headless` 一起使用。
+
+```bash
+# 追加带版本号的快照流
+sudo rustnet --headless --output jsonl --output-file /var/lib/rustnet/custom.jsonl
+
+# 运行 60 秒后，以一份最终快照替换文件
+sudo rustnet --headless --duration 60 --output json --output-file /var/lib/rustnet/final.json
+```
+
+## Linux systemd
+
+unit 默认要求 RustNet 位于 `/usr/bin/rustnet`。发行版软件包可自动安装这些文件。若要
+从本源码树手动安装：
+
+```bash
+sudo install -m 0755 target/release/rustnet /usr/bin/rustnet
+sudo install -Dm0644 resources/packaging/linux/systemd/rustnet-headless.service \
+  /etc/systemd/system/rustnet-headless.service
+sudo install -Dm0644 resources/packaging/linux/systemd/rustnet-headless.env \
+  /etc/default/rustnet-headless
+sudo install -Dm0644 resources/packaging/linux/logrotate/rustnet-headless \
+  /etc/logrotate.d/rustnet-headless
+sudo systemctl daemon-reload
+```
+
+若使用二进制发行归档，请在解压后的目录中运行这些命令，并将
+`target/release/rustnet` 替换为 `./rustnet`。
+
+以上命令只会安装未激活的 unit。可在 `/etc/default/rustnet-headless` 中配置可选过滤器
+或其他参数。该文件不能移除固定的 `--headless`、`--interface any`、
+`--refresh-interval 5000` 与 `--output jsonl` 参数。
+
+```bash
+# 启用开机启动，然后立即启动
+sudo systemctl enable rustnet-headless.service
+sudo systemctl start rustnet-headless.service
+
+# 查看状态、诊断信息和快照
+systemctl status rustnet-headless.service
+sudo journalctl -u rustnet-headless.service -f
+sudo tail -F /var/lib/rustnet/headless.jsonl
+
+# 停止并禁用
+sudo systemctl stop rustnet-headless.service
+sudo systemctl disable rustnet-headless.service
+```
+
+卸载手动安装的定义时，请先停止并禁用服务，再仅删除已安装的定义文件：
+
+```bash
+sudo rm /etc/systemd/system/rustnet-headless.service
+sudo rm /etc/default/rustnet-headless
+sudo rm /etc/logrotate.d/rustnet-headless
+sudo systemctl daemon-reload
+```
+
+私有的 `/var/lib/rustnet` 状态目录及其中的快照会保留。若这些文件来自软件包，请改用
+对应的软件包管理器卸载。
+
+## macOS launchd
+
+launchd plist 默认要求发行版 app 位于 `/Applications/Rustnet.app`，并运行
+`/Applications/Rustnet.app/Contents/MacOS/rustnet`。先把 app bundle 安装到该路径，
+再运行仓库提供的安装脚本：
+
+```bash
+sudo /Applications/Rustnet.app/Contents/Resources/service/launchd/install-rustnet-headless.sh
+```
+
+若使用命令行或二进制归档版本，请把 `rustnet` 安装到稳定的绝对路径，并将该路径显式
+传给 `resources/packaging/macos/launchd` 中的脚本：
+
+```bash
+sudo install -m 0755 rustnet /usr/local/bin/rustnet
+sudo env RUSTNET_BIN=/usr/local/bin/rustnet \
+  resources/packaging/macos/launchd/install-rustnet-headless.sh
+```
+
+安装脚本会以 `0700` 权限创建 `/var/db/rustnet`，安装
+`com.domcyrus.rustnet-headless.plist`，禁用任务，并且不会 bootstrap 或启动。准备完成后
+再启用和加载。由于 plist 使用 `RunAtLoad`，bootstrap 也会启动监控。
+
+```bash
+# 启用并启动
+sudo launchctl enable system/com.domcyrus.rustnet-headless
+sudo launchctl bootstrap system \
+  /Library/LaunchDaemons/com.domcyrus.rustnet-headless.plist
+
+# 查看状态、诊断信息和快照
+sudo launchctl print system/com.domcyrus.rustnet-headless
+sudo tail -F /var/db/rustnet/headless.err.log
+sudo tail -F /var/db/rustnet/headless.jsonl
+
+# 重启已加载的任务
+sudo launchctl kickstart -k system/com.domcyrus.rustnet-headless
+
+# 停止、卸载并禁用
+sudo launchctl bootout system/com.domcyrus.rustnet-headless
+sudo launchctl disable system/com.domcyrus.rustnet-headless
+```
+
+bootout 完成后，可卸载服务定义：
+
+```bash
+sudo rm /Library/LaunchDaemons/com.domcyrus.rustnet-headless.plist
+```
+
+app bundle 和 `/var/db/rustnet` 数据会继续保留，需另行删除。
+
+## Windows Service Control Manager
+
+先按默认选项安装 Npcap，再在管理员 PowerShell 中安装 RustNet MSI：
+
+```powershell
+msiexec.exe /i .\rustnet-<version>.msi
+```
+
+MSI 会以“手动”启动类型注册 `Rustnet` 服务，不会启动服务或配置自动启动。服务命令
+包含 `--windows-service --headless --output jsonl --output-file
+"%ProgramData%\Rustnet\rustnet.jsonl" --refresh-interval 5000`。内部参数
+`--windows-service` 仅供 SCM 激活使用。需要 TUI 时仍直接运行 `rustnet`。
+
+```powershell
+# 可选：启用自动启动，然后立即启动
+Set-Service -Name Rustnet -StartupType Automatic
+Start-Service -Name Rustnet
+
+# 查看状态并持续读取快照
+Get-Service -Name Rustnet
+sc.exe queryex Rustnet
+Get-Content "$env:ProgramData\Rustnet\rustnet.jsonl" -Wait
+
+# 在 System 事件日志中查看 SCM 生命周期错误
+Get-WinEvent -LogName System |
+  Where-Object ProviderName -eq 'Service Control Manager' |
+  Where-Object Message -Match 'Rustnet' |
+  Select-Object -First 20
+
+# 停止并禁用
+Stop-Service -Name Rustnet
+Set-Service -Name Rustnet -StartupType Disabled
+```
+
+可通过 Windows 设置卸载，也可以在管理员 PowerShell 中使用同一个 MSI：
+
+```powershell
+msiexec.exe /x .\rustnet-<version>.msi
+```
+
+安装程序会停止并移除服务。`%ProgramData%\Rustnet` 中的保留文件可能继续存在，如有
+需要请另行删除。
+
+## FreeBSD rc.d
+
+rc.d 脚本默认要求 RustNet 位于 `/usr/local/bin/rustnet`。先安装二进制文件，再运行
+仓库提供的定义安装脚本：
+
+```sh
+sudo install -m 0555 target/release/rustnet /usr/local/bin/rustnet
+sudo resources/packaging/freebsd/rc.d/install-rustnet-headless.sh
+```
+
+若使用二进制发行归档，请将 `target/release/rustnet` 替换为 `./rustnet`。
+
+安装脚本会以 `0700` 权限创建 `/var/db/rustnet`，安装 `rustnet_headless`，并保持
+`rustnet_headless_enable=NO`。
+
+```sh
+# 启用开机启动，然后立即启动
+sudo sysrc rustnet_headless_enable=YES
+sudo service rustnet_headless start
+
+# 查看状态、诊断信息和快照
+sudo service rustnet_headless status
+sudo tail -F /var/db/rustnet/headless.err.log
+sudo tail -F /var/db/rustnet/headless.jsonl
+
+# 停止并禁用
+sudo service rustnet_headless stop
+sudo sysrc rustnet_headless_enable=NO
+```
+
+可在 `/etc/rc.conf` 中通过 `rustnet_headless_extra_args` 设置可选 CLI 参数。脚本始终
+保留显式的 `--headless --refresh-interval 5000 --output jsonl` 参数。
+
+卸载手动安装的定义：
+
+```sh
+sudo rm /usr/local/etc/rc.d/rustnet_headless
+sudo sysrc -x rustnet_headless_enable
+sudo sysrc -x rustnet_headless_extra_args
+```
+
+二进制文件和 `/var/db/rustnet` 数据会继续保留，需另行删除。
+
+## Docker Compose
+
+仓库提供的 Compose 文件会构建现有镜像，并用显式无界面参数覆盖镜像命令。构建或
+拉取镜像不会启动监控。
+
+```bash
+# 仅构建，不启动
+docker compose -f compose.headless.yml build
+
+# 显式启动
+docker compose -f compose.headless.yml up -d
+
+# 使用二进制发行归档时，将 VERSION 替换为不带开头 v 的语义版本号
+RUSTNET_IMAGE_TAG=VERSION docker compose -f compose.headless.yml pull
+RUSTNET_IMAGE_TAG=VERSION docker compose -f compose.headless.yml up -d --no-build
+
+# 查看状态与输出
+docker compose -f compose.headless.yml ps
+docker compose -f compose.headless.yml logs -f rustnet
+
+# 停止但保留容器，然后卸载部署
+docker compose -f compose.headless.yml stop
+docker compose -f compose.headless.yml down
+```
+
+Compose 没有独立的安装或启用步骤。构建镜像会准备部署，`down` 会移除容器和网络。
+首次明确启动后，`restart: unless-stopped` 策略会在容器
+失败或 Docker daemon 重启后重新启动容器，除非管理员已停止它。快照流写入容器
+stdout，并由 Docker 执行内置的有界日志策略。
+
+若要把快照持久化到文件，请添加私有的主机 volume，在 `command` 中传入
+`--output-file`，并配置主机侧轮换。只需让输出路径在只读容器中可写，不要增加更广泛
+的 capability。

--- a/USAGE.md
+++ b/USAGE.md
@@ -92,6 +92,7 @@ Options:
       --duration <SECONDS>               Stop headless monitoring after this many seconds
       --output <FORMAT>                  Headless output format: jsonl (stream snapshots) or
                                          json (final snapshot)
+      --output-file <FILE>               Write headless output to FILE instead of stdout
       --filter <QUERY>                   Filter headless output using the shared connection filter syntax
   -r, --refresh-interval <MILLISECONDS>  UI and headless snapshot refresh interval in milliseconds
                                          [default: 500]
@@ -134,6 +135,9 @@ rustnet --headless --duration 60 --output json
 
 # Stream only matching connections
 rustnet --headless --filter 'process:curl app:https'
+
+# Append JSONL snapshots to a private regular file instead of stdout
+rustnet --headless --output jsonl --output-file snapshots.jsonl
 ```
 
 The headless controls are:
@@ -141,13 +145,14 @@ The headless controls are:
 - **`--headless`**: disables terminal setup and reserves stdout for machine-readable records only. Diagnostics go to stderr or configured log files.
 - **`--duration <SECONDS>`**: stops after a positive whole number of seconds. Without it, monitoring continues until a supported shutdown signal arrives. JSONL also stops when it discovers that its output pipe has closed. Headless shutdown signals are SIGINT, SIGTERM, and SIGHUP on Unix, and Ctrl+C and Ctrl+Break on Windows.
 - **`--output jsonl|json`**: selects the output shape. JSONL is the default and writes versioned latest-value snapshots, one JSON object per line. Under output backpressure, a stale queued snapshot is replaced by the newest one; consumers can detect skipped `runtime.snapshot_generation` values. After a duration or signal shutdown, JSONL also writes a final terminal record containing the termination reason and shutdown result. JSON waits for shutdown and writes exactly one final versioned record.
+- **`--output-file <FILE>`**: writes headless records to a securely opened regular file instead of stdout. JSONL appends so a stream can continue across runs. JSON truncates the file and replaces it with the current run's single final record. The parent directory must already exist and be writable during privileged startup.
 - **`--filter <QUERY>`**: applies the same connection-filter syntax as the TUI, including fields such as `port:`, `src:`, `dst:`, `sni:`, `process:`, `state:`, and `proto:`, plus `/pattern/` regular expressions.
 
 #### Schema contract
 
 The current wire schema is `schema_version = 1`. Every record is a snapshot object with these top-level fields: `schema_version`, `type`, `timestamp`, `runtime`, `sandbox`, `stats`, `filter`, `connection_count`, and `connections`. A terminal record sets `runtime.status` to `stopping`, `stopped`, or `stopped_with_errors`, and includes `runtime.termination_reason` and `runtime.shutdown`. Connection records cover endpoints, process attribution, traffic, protocol timing, GeoIP, and optional Kubernetes metadata. The `rtt` object includes current, initial, smoothed TCP, DNS, LLMNR, NetBIOS, ICMP echo, STUN, and NTP timings in milliseconds. Optional enrichment and timing fields remain null until discovered; connections drained during shutdown can appear before process, GeoIP, or Kubernetes enrichment completes. Consumers must branch on `schema_version` and tolerate unknown additive fields.
 
-Closing a JSONL pipeline early, for example with `head`, produces a broken pipe. RustNet treats that as a successful request to stop, shuts down its workers, and does not attempt a terminal record on the closed pipe. A packet-capture initialization failure or a later capture failure exits with a nonzero status. `--duration`, `--output`, and `--filter` require `--headless`.
+Closing a JSONL pipeline early, for example with `head`, produces a broken pipe. RustNet treats that as a successful request to stop, shuts down its workers, and does not attempt a terminal record on the closed pipe. A packet-capture initialization failure or a later capture failure exits with a nonzero status. `--duration`, `--output`, `--output-file`, and `--filter` require `--headless`. See [SERVICE.md](SERVICE.md) for long-running service definitions, private output paths, and retention.
 
 ### Option Details
 

--- a/USAGE.zh-CN.md
+++ b/USAGE.zh-CN.md
@@ -92,6 +92,7 @@ Options:
       --duration <SECONDS>               在指定秒数后停止无界面监控
       --output <FORMAT>                  无界面输出格式：jsonl（流式快照）或
                                          json（最终快照）
+      --output-file <FILE>               将无界面输出写入 FILE 而不是 stdout
       --filter <QUERY>                   使用共享的连接过滤语法筛选无界面输出
   -r, --refresh-interval <MILLISECONDS>  UI 和无界面快照的刷新间隔，单位为毫秒
                                          [默认：500]
@@ -134,6 +135,9 @@ rustnet --headless --duration 60 --output json
 
 # 仅流式输出匹配的连接
 rustnet --headless --filter 'process:curl app:https'
+
+# 将 JSONL 快照追加到私有普通文件，而不是 stdout
+rustnet --headless --output jsonl --output-file snapshots.jsonl
 ```
 
 无界面模式的参数如下：
@@ -141,13 +145,14 @@ rustnet --headless --filter 'process:curl app:https'
 - **`--headless`**：不设置终端，并确保 stdout 仅包含机器可读记录。诊断信息会写入 stderr 或已配置的日志文件。
 - **`--duration <SECONDS>`**：在指定的正整数秒数后停止。如果省略，监控会持续到收到支持的关闭信号。JSONL 在发现输出管道已关闭时也会停止。无界面模式在 Unix 上支持 SIGINT、SIGTERM 和 SIGHUP，在 Windows 上支持 Ctrl+C 和 Ctrl+Break。
 - **`--output jsonl|json`**：选择输出形式。JSONL 是默认格式，以每行一个 JSON 对象的方式写出带版本号的最新值快照。当输出产生背压时，队列中的旧快照会被最新快照替换；使用方可通过不连续的 `runtime.snapshot_generation` 值检测到跳过的快照。由时长或信号触发关闭后，JSONL 还会写出一条最终终止记录，其中包含终止原因和关闭结果。JSON 会等待监控停止，然后仅写出一条带版本号的最终记录。
+- **`--output-file <FILE>`**：将无界面记录写入安全打开的普通文件，而不是 stdout。JSONL 会追加，便于多轮运行延续同一数据流；JSON 会截断文件，并以本轮运行唯一的最终记录替换它。父目录必须已经存在，并且在特权初始化阶段可写。
 - **`--filter <QUERY>`**：使用与 TUI 相同的连接过滤语法，包括 `port:`、`src:`、`dst:`、`sni:`、`process:`、`state:` 和 `proto:` 等字段，以及 `/pattern/` 正则表达式。
 
 #### Schema 约定
 
 当前输出格式版本为 `schema_version = 1`。每条记录都是快照对象，顶层字段为 `schema_version`、`type`、`timestamp`、`runtime`、`sandbox`、`stats`、`filter`、`connection_count` 和 `connections`。最终终止记录会将 `runtime.status` 设为 `stopping`、`stopped` 或 `stopped_with_errors`，并包含 `runtime.termination_reason` 和 `runtime.shutdown`。连接记录涵盖端点、进程归属、流量、各协议计时、GeoIP，以及可选的 Kubernetes 元数据。`rtt` 对象以毫秒为单位提供当前值、初始值、平滑 TCP 值，以及 DNS、LLMNR、NetBIOS、ICMP echo、STUN 和 NTP 计时。可选的增强与计时字段在被发现前保持为 null；关闭期间排空的连接可能在进程、GeoIP 或 Kubernetes 增强完成前就出现在最终记录中。使用方必须根据 `schema_version` 选择解析逻辑，并允许出现新增的未知字段。
 
-如果 JSONL 管道的下游提前关闭，例如使用 `head`，会产生 broken pipe。RustNet 会将其视为成功的停止请求，关闭所有工作线程，并且不会尝试向已经关闭的管道写入最终终止记录。抓包初始化失败或之后发生抓包故障时，程序会以非零状态退出。`--duration`、`--output` 和 `--filter` 必须与 `--headless` 一起使用。
+如果 JSONL 管道的下游提前关闭，例如使用 `head`，会产生 broken pipe。RustNet 会将其视为成功的停止请求，关闭所有工作线程，并且不会尝试向已经关闭的管道写入最终终止记录。抓包初始化失败或之后发生抓包故障时，程序会以非零状态退出。`--duration`、`--output`、`--output-file` 和 `--filter` 必须与 `--headless` 一起使用。长期运行服务的定义、私有输出路径与保留策略见 [SERVICE.zh-CN.md](SERVICE.zh-CN.md)。
 
 ### 选项详情<a id="option-details"></a>
 

--- a/compose.headless.yml
+++ b/compose.headless.yml
@@ -1,0 +1,27 @@
+services:
+  rustnet:
+    build:
+      context: .
+    image: ghcr.io/domcyrus/rustnet:${RUSTNET_IMAGE_TAG:-local}
+    command:
+      - --headless
+      - --interface
+      - any
+      - --refresh-interval
+      - "5000"
+      - --output
+      - jsonl
+    network_mode: host
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_RAW
+    read_only: true
+    restart: unless-stopped
+    stop_grace_period: 10s
+    init: true
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "7"

--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,5 @@
 crates/rustnet-core/assets/services usr/share/rustnet-monitor/
 resources/packaging/linux/rustnet.desktop usr/share/applications/
 resources/packaging/linux/graphics/rustnet.png usr/share/icons/hicolor/256x256/apps/
+resources/packaging/linux/systemd/rustnet-headless.service usr/lib/systemd/system/
+resources/packaging/linux/logrotate/rustnet-headless etc/logrotate.d/

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,6 +5,11 @@ set -e
 
 case "$1" in
     configure)
+        # Make the opt-in unit visible without enabling or starting it.
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl daemon-reload >/dev/null 2>&1 || true
+        fi
+
         # Set narrow capabilities for packet capture and eBPF support without requiring root/sudo.
         # If eBPF capabilities are unavailable, fall back to packet capture only;
         # rustnet will degrade to procfs process detection rather than auto-grant CAP_SYS_ADMIN.
@@ -61,6 +66,9 @@ GEOIP (OPTIONAL):
 USAGE:
   rustnet              # Start network monitoring
   rustnet --help       # Show all options
+
+HEADLESS SERVICE (OPTIONAL, NOT ENABLED OR STARTED):
+  See the installed SERVICE.md guide.
 
 For more information, visit: https://github.com/domcyrus/rustnet
 ================================================================================

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+#DEBHELPER#
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "remove" ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl disable --now rustnet-headless.service >/dev/null 2>&1 || true
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -41,6 +41,11 @@ override_dh_auto_install:
 
 	# Install documentation
 	install -Dm644 README.md debian/rustnet/usr/share/doc/rustnet/README.md
+	install -Dm644 SERVICE.md debian/rustnet/usr/share/doc/rustnet/SERVICE.md
+
+	# Install the optional service configuration without enabling the unit.
+	install -Dm644 resources/packaging/linux/systemd/rustnet-headless.env \
+		debian/rustnet/etc/default/rustnet-headless
 
 	# Install shell completions if generated
 	if [ -d "$(RUSTNET_ASSET_DIR)" ]; then \
@@ -70,3 +75,7 @@ override_dh_auto_test:
 
 override_dh_installchangelogs:
 	dh_installchangelogs CHANGELOG.md
+
+# Ship the service definition but keep monitoring strictly opt-in.
+override_dh_installsystemd:
+	dh_installsystemd --no-enable --no-start

--- a/resources/packaging/freebsd/rc.d/install-rustnet-headless.sh
+++ b/resources/packaging/freebsd/rc.d/install-rustnet-headless.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "install-rustnet-headless.sh must run as root" >&2
+    exit 1
+fi
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+
+install -d -o root -g wheel -m 0700 /var/db/rustnet
+install -o root -g wheel -m 0555 \
+    "$script_dir/rustnet_headless" \
+    /usr/local/etc/rc.d/rustnet_headless
+
+echo "Installed with rustnet_headless_enable=NO."
+echo "Enable and start it explicitly when ready; this installer does neither."
+echo "Configure local retention for /var/db/rustnet before long-running use."

--- a/resources/packaging/freebsd/rc.d/rustnet_headless
+++ b/resources/packaging/freebsd/rc.d/rustnet_headless
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091,SC2034
+
+# PROVIDE: rustnet_headless
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="rustnet_headless"
+rcvar="rustnet_headless_enable"
+
+load_rc_config "$name"
+
+: "${rustnet_headless_enable:=NO}"
+: "${rustnet_headless_program:=/usr/local/bin/rustnet}"
+: "${rustnet_headless_extra_args:=}"
+
+pidfile="/var/run/${name}.pid"
+state_dir="/var/db/rustnet"
+output_file="${state_dir}/headless.jsonl"
+error_file="${state_dir}/headless.err.log"
+
+command="/usr/sbin/daemon"
+procname="$rustnet_headless_program"
+command_args="-p ${pidfile} -t ${name} -m 2 -o ${error_file} ${rustnet_headless_program} --headless --refresh-interval 5000 --output jsonl --output-file ${output_file} ${rustnet_headless_extra_args}"
+start_precmd="rustnet_headless_precmd"
+
+rustnet_headless_precmd()
+{
+    install -d -o root -g wheel -m 0700 "$state_dir"
+    touch "$output_file" "$error_file"
+    chown root:wheel "$output_file" "$error_file"
+    chmod 0600 "$output_file" "$error_file"
+}
+
+run_rc_command "$1"

--- a/resources/packaging/linux/logrotate/rustnet-headless
+++ b/resources/packaging/linux/logrotate/rustnet-headless
@@ -1,0 +1,10 @@
+/var/lib/rustnet/headless.jsonl {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+    su root root
+}

--- a/resources/packaging/linux/rpm/post_install.sh
+++ b/resources/packaging/linux/rpm/post_install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Make the opt-in unit visible without enabling or starting it.
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+fi

--- a/resources/packaging/linux/rpm/post_uninstall.sh
+++ b/resources/packaging/linux/rpm/post_uninstall.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+fi

--- a/resources/packaging/linux/rpm/pre_uninstall.sh
+++ b/resources/packaging/linux/rpm/pre_uninstall.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Stop and disable only when the package is being removed, not upgraded.
+if [ "${1:-0}" -eq 0 ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl disable --now rustnet-headless.service >/dev/null 2>&1 || :
+fi

--- a/resources/packaging/linux/systemd/rustnet-headless.env
+++ b/resources/packaging/linux/systemd/rustnet-headless.env
@@ -1,0 +1,8 @@
+# Optional arguments appended to the fixed headless service command.
+# Keep --headless, --interface any, --refresh-interval 5000, and --output jsonl
+# in the service unit so the safe operational defaults cannot be removed here.
+RUSTNET_EXTRA_ARGS=""
+
+# Examples:
+# RUSTNET_EXTRA_ARGS="--no-localhost --no-resolve-dns"
+# RUSTNET_EXTRA_ARGS="--filter app:https"

--- a/resources/packaging/linux/systemd/rustnet-headless.service
+++ b/resources/packaging/linux/systemd/rustnet-headless.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=RustNet headless network monitor
+Documentation=https://github.com/domcyrus/rustnet
+After=network.target
+
+[Service]
+Type=simple
+User=root
+EnvironmentFile=-/etc/default/rustnet-headless
+ExecStart=/usr/bin/rustnet --headless --interface any --refresh-interval 5000 --output jsonl $RUSTNET_EXTRA_ARGS
+Restart=on-failure
+RestartSec=5s
+KillSignal=SIGTERM
+TimeoutStopSec=10s
+
+# Keep captured network metadata private while allowing systemd to manage the
+# output path before RustNet drops privileges.
+UMask=0077
+StateDirectory=rustnet
+StateDirectoryMode=0700
+StandardOutput=append:/var/lib/rustnet/headless.jsonl
+StandardError=journal
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectHome=read-only
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/rustnet
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target

--- a/resources/packaging/macos/launchd/com.domcyrus.rustnet-headless.plist
+++ b/resources/packaging/macos/launchd/com.domcyrus.rustnet-headless.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.domcyrus.rustnet-headless</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Applications/Rustnet.app/Contents/MacOS/rustnet</string>
+        <string>--headless</string>
+        <string>--refresh-interval</string>
+        <string>5000</string>
+        <string>--output</string>
+        <string>jsonl</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <key>ProcessType</key>
+    <string>Adaptive</string>
+
+    <key>Umask</key>
+    <integer>63</integer>
+    <key>StandardOutPath</key>
+    <string>/var/db/rustnet/headless.jsonl</string>
+    <key>StandardErrorPath</key>
+    <string>/var/db/rustnet/headless.err.log</string>
+</dict>
+</plist>

--- a/resources/packaging/macos/launchd/install-rustnet-headless.sh
+++ b/resources/packaging/macos/launchd/install-rustnet-headless.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "install-rustnet-headless.sh must run as root" >&2
+    exit 1
+fi
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+rustnet_bin=${RUSTNET_BIN:-/Applications/Rustnet.app/Contents/MacOS/rustnet}
+
+if [ ! -x "$rustnet_bin" ]; then
+    echo "RustNet binary is not executable: $rustnet_bin" >&2
+    exit 1
+fi
+case "$rustnet_bin" in
+    /*) ;;
+    *)
+        echo "RUSTNET_BIN must be an absolute path" >&2
+        exit 1
+        ;;
+esac
+
+install -d -o root -g wheel -m 0700 /var/db/rustnet
+install -d -o root -g wheel -m 0755 /Library/LaunchDaemons
+launchctl disable system/com.domcyrus.rustnet-headless
+rendered_plist=$(mktemp -t rustnet-headless.plist)
+trap 'rm -f "$rendered_plist"' EXIT
+cp "$script_dir/com.domcyrus.rustnet-headless.plist" "$rendered_plist"
+plutil -replace ProgramArguments.0 -string "$rustnet_bin" "$rendered_plist"
+plutil -lint "$rendered_plist" >/dev/null
+install -o root -g wheel -m 0644 \
+    "$rendered_plist" \
+    /Library/LaunchDaemons/com.domcyrus.rustnet-headless.plist
+
+echo "Installed the disabled launchd definition."
+echo "Enable and bootstrap it explicitly when ready; this installer does neither."
+echo "Configure local retention for /var/db/rustnet before long-running use."

--- a/resources/packaging/windows/wix/main.wxs
+++ b/resources/packaging/windows/wix/main.wxs
@@ -58,6 +58,22 @@
                             KeyPath='yes'/>
                         <Environment Id='PATH' Name='PATH' Value='[APPLICATIONROOTDIRECTORY]'
                             Permanent='no' Part='last' Action='set' System='yes' />
+                        <ServiceInstall Id='RustnetServiceInstall'
+                            Name='Rustnet'
+                            DisplayName='Rustnet Network Monitor'
+                            Description='Collects per-process network connection telemetry.'
+                            Type='ownProcess'
+                            Start='demand'
+                            ErrorControl='normal'
+                            Account='LocalSystem'
+                            Arguments='--windows-service --headless --output jsonl --output-file &quot;[CommonAppDataFolder]Rustnet\rustnet.jsonl&quot; --refresh-interval 5000'>
+                            <ServiceDependency Id='npcap' />
+                        </ServiceInstall>
+                        <ServiceControl Id='RustnetServiceControl'
+                            Name='Rustnet'
+                            Stop='both'
+                            Remove='uninstall'
+                            Wait='yes' />
                     </Component>
                     <Component Id='AppIcon' Guid='*' Win64='$(var.Win64)'>
                         <File Id='RustnetIco'
@@ -71,6 +87,22 @@
                             DiskId='1'
                             Source='assets\services'
                             KeyPath='yes'/>
+                    </Component>
+                </Directory>
+            </Directory>
+
+            <Directory Id='CommonAppDataFolder'>
+                <Directory Id='RustnetDataDirectory' Name='Rustnet'>
+                    <Component Id='RustnetDataDirectoryComponent' Guid='*' Win64='$(var.Win64)'>
+                        <CreateFolder>
+                            <PermissionEx Sddl='D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)' />
+                        </CreateFolder>
+                        <RegistryValue Root='HKLM'
+                            Key='Software\domcyrus\Rustnet'
+                            Name='DataDirectory'
+                            Type='string'
+                            Value='[RustnetDataDirectory]'
+                            KeyPath='yes' />
                     </Component>
                 </Directory>
             </Directory>
@@ -103,6 +135,7 @@
             <ComponentRef Id='AppIcon' />
             <ComponentRef Id='AssetsDir' />
             <ComponentRef Id='ApplicationShortcut' />
+            <ComponentRef Id='RustnetDataDirectoryComponent' />
         </Feature>
 
         <!-- Note: VC++ Redistributable bundling via WiX Binary + CustomAction doesn't work -->

--- a/rpm/rustnet.spec
+++ b/rpm/rustnet.spec
@@ -90,10 +90,13 @@ install -Dpm 0755 target/release/rustnet -t %{buildroot}%{_bindir}/
 install -Dpm 0644 crates/rustnet-core/assets/services -t %{buildroot}%{_datadir}/%{name}/
 install -Dpm 0644 resources/packaging/linux/graphics/rustnet.png -t %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/
 install -Dpm 0644 resources/packaging/linux/rustnet.desktop -t %{buildroot}%{_datadir}/applications/
+install -Dpm 0644 resources/packaging/linux/systemd/rustnet-headless.service -t %{buildroot}%{_prefix}/lib/systemd/system/
+install -Dpm 0644 resources/packaging/linux/systemd/rustnet-headless.env %{buildroot}%{_sysconfdir}/default/rustnet-headless
+install -Dpm 0644 resources/packaging/linux/logrotate/rustnet-headless -t %{buildroot}%{_sysconfdir}/logrotate.d/
 
 %files
 %license LICENSE
-%doc README.md
+%doc README.md SERVICE.md
 %{_bindir}/rustnet
 %dir %{_datadir}/%{name}
 %{_datadir}/%{name}/services
@@ -102,6 +105,9 @@ install -Dpm 0644 resources/packaging/linux/rustnet.desktop -t %{buildroot}%{_da
 %dir %{_datadir}/icons/hicolor/256x256/apps
 %{_datadir}/icons/hicolor/256x256/apps/rustnet.png
 %{_datadir}/applications/rustnet.desktop
+%{_prefix}/lib/systemd/system/rustnet-headless.service
+%config(noreplace) %{_sysconfdir}/default/rustnet-headless
+%config(noreplace) %{_sysconfdir}/logrotate.d/rustnet-headless
 
 %post
 # Set narrow capabilities for packet capture and eBPF support without requiring root/sudo.
@@ -112,6 +118,19 @@ if command -v setcap >/dev/null 2>&1; then
     # CAP_BPF, CAP_PERFMON: eBPF support for enhanced process tracking
     setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip' %{_bindir}/rustnet 2>/dev/null || \
         setcap 'cap_net_raw+eip' %{_bindir}/rustnet || :
+fi
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+fi
+
+%preun
+if [ "$1" -eq 0 ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl disable --now rustnet-headless.service >/dev/null 2>&1 || :
+fi
+
+%postun
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
 fi
 
 %posttrans
@@ -164,6 +183,9 @@ GEOIP (OPTIONAL):
 USAGE:
   rustnet              # Start network monitoring
   rustnet --help       # Show all options
+
+HEADLESS SERVICE (OPTIONAL, NOT ENABLED OR STARTED):
+  See %{_docdir}/%{name}/SERVICE.md
 
 ================================================================================
 EOF

--- a/scripts/check-service-packaging.sh
+++ b/scripts/check-service-packaging.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+systemd_unit="resources/packaging/linux/systemd/rustnet-headless.service"
+systemd_env="resources/packaging/linux/systemd/rustnet-headless.env"
+logrotate_policy="resources/packaging/linux/logrotate/rustnet-headless"
+launchd_plist="resources/packaging/macos/launchd/com.domcyrus.rustnet-headless.plist"
+macos_installer="resources/packaging/macos/launchd/install-rustnet-headless.sh"
+freebsd_service="resources/packaging/freebsd/rc.d/rustnet_headless"
+freebsd_installer="resources/packaging/freebsd/rc.d/install-rustnet-headless.sh"
+compose_file="compose.headless.yml"
+windows_wix="resources/packaging/windows/wix/main.wxs"
+rpm_post_install="resources/packaging/linux/rpm/post_install.sh"
+rpm_pre_uninstall="resources/packaging/linux/rpm/pre_uninstall.sh"
+rpm_post_uninstall="resources/packaging/linux/rpm/post_uninstall.sh"
+
+required_files=(
+    "$systemd_unit"
+    "$systemd_env"
+    "$logrotate_policy"
+    "$launchd_plist"
+    "$macos_installer"
+    "$freebsd_service"
+    "$freebsd_installer"
+    "$compose_file"
+    "$windows_wix"
+    "$rpm_post_install"
+    "$rpm_pre_uninstall"
+    "$rpm_post_uninstall"
+    "Dockerfile"
+)
+
+fail()
+{
+    printf 'service packaging check failed: %s\n' "$1" >&2
+    exit 1
+}
+
+require_literal()
+{
+    file=$1
+    value=$2
+    grep -Fq -- "$value" "$file" || fail "$file is missing: $value"
+}
+
+for file in "${required_files[@]}"; do
+    [ -f "$file" ] || fail "missing $file"
+done
+
+executable_files=(
+    "$macos_installer"
+    "$freebsd_service"
+    "$freebsd_installer"
+    "$rpm_post_install"
+    "$rpm_pre_uninstall"
+    "$rpm_post_uninstall"
+    "debian/postinst"
+    "debian/prerm"
+    "debian/postrm"
+    "${BASH_SOURCE[0]}"
+)
+for file in "${executable_files[@]}"; do
+    [ -x "$file" ] || fail "$file must be executable"
+done
+
+# Every supervisor invokes a fixed headless command. Extra service arguments
+# may extend these defaults but cannot replace --headless.
+require_literal "$systemd_unit" "ExecStart=/usr/bin/rustnet --headless"
+require_literal "$launchd_plist" "<string>--headless</string>"
+require_literal "$launchd_plist" "<string>/Applications/Rustnet.app/Contents/MacOS/rustnet</string>"
+require_literal "$freebsd_service" "--headless --refresh-interval 5000 --output jsonl"
+require_literal "$compose_file" "- --headless"
+
+for file in "$systemd_unit" "$launchd_plist" "$freebsd_service" "$compose_file"; do
+    require_literal "$file" "5000"
+done
+
+require_literal "$systemd_unit" "--interface any"
+require_literal "$compose_file" "- any"
+require_literal "$compose_file" 'max-size: "10m"'
+require_literal "$compose_file" 'max-file: "7"'
+require_literal "$windows_wix" "Start='demand'"
+require_literal "$windows_wix" "--windows-service --headless"
+require_literal "$windows_wix" "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+require_literal "debian/rules" "dh_installsystemd --no-enable --no-start"
+require_literal "Cargo.toml" 'maintainer-scripts = "debian"'
+require_literal "debian/prerm" "systemctl disable --now rustnet-headless.service"
+require_literal "$rpm_pre_uninstall" "systemctl disable --now rustnet-headless.service"
+require_literal "$systemd_unit" "StateDirectoryMode=0700"
+require_literal "$systemd_unit" "UMask=0077"
+require_literal "$macos_installer" "-m 0700 /var/db/rustnet"
+require_literal "$macos_installer" "launchctl disable system/com.domcyrus.rustnet-headless"
+state_dir_install="-m 0700 \"\$state_dir\""
+require_literal "$freebsd_service" "$state_dir_install"
+require_literal "$freebsd_service" 'rustnet_headless_enable:=NO'
+require_literal "$freebsd_installer" "rustnet_headless_enable=NO"
+require_literal "Dockerfile" "STOPSIGNAL SIGTERM"
+
+if grep -Eq 'launchctl[[:space:]]+(bootstrap|enable|kickstart|load)' "$macos_installer"; then
+    fail "$macos_installer must not enable or start the service"
+fi
+
+if grep -Eq 'sysrc.*rustnet_headless_enable=.*YES|service[[:space:]]+rustnet_headless[[:space:]]+(start|onestart)' "$freebsd_installer"; then
+    fail "$freebsd_installer must not enable or start the service"
+fi
+
+if grep -Eq 'systemctl[[:space:]]+(enable|start|restart)|systemctl[[:space:]]+enable[[:space:]]+--now' "$rpm_post_install"; then
+    fail "$rpm_post_install must not enable or start the service"
+fi
+
+if grep -Eq 'systemctl[[:space:]]+(enable|start|restart)|systemctl[[:space:]]+enable[[:space:]]+--now' debian/postinst; then
+    fail "debian/postinst must not enable or start the service"
+fi
+
+if grep -Fq "Start='install'" "$windows_wix" || grep -Fq "Start='both'" "$windows_wix"; then
+    fail "$windows_wix must not start the service during installation"
+fi
+
+sh -n "$macos_installer"
+sh -n "$freebsd_service"
+sh -n "$freebsd_installer"
+sh -n "$rpm_post_install"
+sh -n "$rpm_pre_uninstall"
+sh -n "$rpm_post_uninstall"
+bash -n "${BASH_SOURCE[0]}"
+
+if command -v plutil >/dev/null 2>&1; then
+    plutil -lint "$launchd_plist" >/dev/null
+fi
+
+if command -v systemd-analyze >/dev/null 2>&1; then
+    verify_dir=$(mktemp -d)
+    trap 'rm -rf "$verify_dir"' EXIT
+    sed 's#ExecStart=/usr/bin/rustnet#ExecStart=/bin/true#' \
+        "$systemd_unit" >"$verify_dir/rustnet-headless.service"
+    systemd-analyze verify "$verify_dir/rustnet-headless.service" >/dev/null
+fi
+
+if command -v logrotate >/dev/null 2>&1; then
+    logrotate --debug "$logrotate_policy" >/dev/null
+fi
+
+if docker compose version >/dev/null 2>&1; then
+    docker compose -f "$compose_file" config --quiet
+fi
+
+if LC_ALL=C grep -n "$(printf '\342\200\224')" "${required_files[@]}" "${BASH_SOURCE[0]}"; then
+    fail "service assets contain an em dash"
+fi
+
+printf 'service packaging checks passed\n'

--- a/src/app/output.rs
+++ b/src/app/output.rs
@@ -65,7 +65,7 @@ fn open_private(path: impl AsRef<Path>, append: bool) -> io::Result<fs::File> {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::open_private_append_file;
+    use super::{open_private_append_file, precreate_private_file};
     use crate::app::scratch_dir::ScratchDir;
     use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
@@ -105,6 +105,20 @@ mod tests {
     }
 
     #[test]
+    fn rejects_hard_link_before_truncating_snapshot_output() {
+        let dir = scratch("hard_link_truncate");
+        let target = dir.join("target.json");
+        let link = dir.join("snapshot.json");
+        std::fs::write(&target, b"keep me").unwrap();
+        std::fs::hard_link(&target, &link).unwrap();
+
+        let error = precreate_private_file(&link).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(std::fs::read(target).unwrap(), b"keep me");
+    }
+
+    #[test]
     fn rejects_fifo_without_blocking() {
         use std::ffi::CString;
         use std::os::unix::ffi::OsStrExt;
@@ -124,6 +138,19 @@ mod tests {
         writeln!(open_private_append_file(&path).unwrap(), "line1").unwrap();
         writeln!(open_private_append_file(&path).unwrap(), "line2").unwrap();
         assert_eq!(std::fs::read_to_string(path).unwrap(), "line1\nline2\n");
+    }
+
+    #[test]
+    fn snapshot_output_truncates_existing_content() {
+        let dir = scratch("truncate");
+        let path = dir.join("snapshot.json");
+        std::fs::write(&path, b"stale content").unwrap();
+
+        let mut file = precreate_private_file(&path).unwrap();
+        write!(file, "fresh").unwrap();
+        file.sync_all().unwrap();
+
+        assert_eq!(std::fs::read(path).unwrap(), b"fresh");
     }
 
     #[test]

--- a/src/app/windows_output.rs
+++ b/src/app/windows_output.rs
@@ -1,10 +1,10 @@
 //! Secure Windows output-file opening.
 //!
 //! Windows has no mode-bit equivalent to Unix `0o600`. This module creates a
-//! protected DACL containing one full-control ACE for the current token user,
-//! supplies it to `CreateFileW`, and reapplies it through the opened handle so
-//! pre-existing files owned by the current user are hardened without a
-//! pathname race.
+//! protected DACL containing full control for the current token user and read
+//! access for the built-in Administrators group. It supplies that DACL to
+//! `CreateFileW` and reapplies it through the opened handle so pre-existing
+//! files owned by the current user are hardened without a pathname race.
 
 use std::fs::File;
 use std::io;
@@ -18,22 +18,23 @@ use windows::Win32::Foundation::{
 };
 use windows::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo};
 use windows::Win32::Security::{
-    ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, AddAccessAllowedAce, DACL_SECURITY_INFORMATION,
-    EqualSid, GetLengthSid, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor,
-    OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
-    SE_DACL_PROTECTED, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR, SetSecurityDescriptorControl,
-    SetSecurityDescriptorDacl, SetSecurityDescriptorOwner, TOKEN_QUERY, TOKEN_USER, TokenUser,
+    ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, AddAccessAllowedAce, CreateWellKnownSid,
+    DACL_SECURITY_INFORMATION, EqualSid, GetLengthSid, GetTokenInformation, InitializeAcl,
+    InitializeSecurityDescriptor, OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
+    PSECURITY_DESCRIPTOR, PSID, SE_DACL_PROTECTED, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR,
+    SECURITY_MAX_SID_SIZE, SetSecurityDescriptorControl, SetSecurityDescriptorDacl,
+    SetSecurityDescriptorOwner, TOKEN_QUERY, TOKEN_USER, TokenUser, WinBuiltinAdministratorsSid,
 };
 use windows::Win32::Storage::FileSystem::{
     BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_ALL_ACCESS, FILE_ATTRIBUTE_DIRECTORY,
     FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
-    FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_DATA,
-    GetFileInformationByHandle, OPEN_ALWAYS, READ_CONTROL, WRITE_DAC,
+    FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    FILE_WRITE_DATA, GetFileInformationByHandle, OPEN_ALWAYS, READ_CONTROL, WRITE_DAC,
 };
 use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 use windows::core::PCWSTR;
 
-/// Open an output file with access restricted to the current token user.
+/// Open an output file with writes restricted to the current token user.
 ///
 /// Existing files are not truncated until their type, link count, and owner
 /// have been validated and the protected DACL has been applied. Reparse points
@@ -152,8 +153,9 @@ fn validate_owner(file: &File, path: &Path, expected_owner: PSID) -> io::Result<
 
 struct PrivateSecurity {
     // The descriptor and ACL contain pointers into these heap allocations.
-    // Keep both allocations alive until CreateFileW and apply_to complete.
+    // Keep all allocations alive until CreateFileW and apply_to complete.
     sid_storage: Vec<usize>,
+    _administrator_sid_storage: Vec<usize>,
     _acl_storage: Vec<usize>,
     descriptor: SECURITY_DESCRIPTOR,
 }
@@ -196,9 +198,28 @@ impl PrivateSecurity {
             ));
         }
 
+        let administrator_sid_words = (SECURITY_MAX_SID_SIZE as usize).div_ceil(size_of::<usize>());
+        let mut administrator_sid_storage = vec![0usize; administrator_sid_words];
+        let administrator_sid = PSID(administrator_sid_storage.as_mut_ptr().cast());
+        let mut administrator_sid_size = SECURITY_MAX_SID_SIZE;
+        unsafe {
+            CreateWellKnownSid(
+                WinBuiltinAdministratorsSid,
+                None,
+                Some(administrator_sid),
+                &mut administrator_sid_size,
+            )
+            .map_err(|error| windows_error("CreateWellKnownSid", error))?;
+        }
+
         let sid_length = unsafe { GetLengthSid(sid) as usize };
-        let acl_bytes =
-            size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + sid_length;
+        let administrator_sid_length = unsafe { GetLengthSid(administrator_sid) as usize };
+        let ace_header_bytes = size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>();
+        let acl_bytes = size_of::<ACL>()
+            + ace_header_bytes
+            + sid_length
+            + ace_header_bytes
+            + administrator_sid_length;
         let acl_words = acl_bytes.div_ceil(size_of::<usize>());
         let mut acl_storage = vec![0usize; acl_words];
         let acl = acl_storage.as_mut_ptr().cast::<ACL>();
@@ -206,6 +227,8 @@ impl PrivateSecurity {
             InitializeAcl(acl, acl_bytes as u32, ACL_REVISION)
                 .map_err(|error| windows_error("InitializeAcl", error))?;
             AddAccessAllowedAce(acl, ACL_REVISION, FILE_ALL_ACCESS.0, sid)
+                .map_err(|error| windows_error("AddAccessAllowedAce", error))?;
+            AddAccessAllowedAce(acl, ACL_REVISION, FILE_GENERIC_READ.0, administrator_sid)
                 .map_err(|error| windows_error("AddAccessAllowedAce", error))?;
         }
 
@@ -225,6 +248,7 @@ impl PrivateSecurity {
 
         Ok(Self {
             sid_storage,
+            _administrator_sid_storage: administrator_sid_storage,
             _acl_storage: acl_storage,
             descriptor,
         })
@@ -342,6 +366,19 @@ mod tests {
         file.sync_all().unwrap();
 
         assert_eq!(fs::read(&path).unwrap(), b"first\nsecond\n");
+    }
+
+    #[test]
+    fn replaces_existing_content_in_truncate_mode() {
+        let scratch = ScratchDir::new("truncate");
+        let path = scratch.join("snapshot.json");
+        fs::write(&path, b"stale content").unwrap();
+
+        let mut file = open_private(&path, false).unwrap();
+        write!(file, "fresh").unwrap();
+        file.sync_all().unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), b"fresh");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,6 +78,14 @@ pub fn build_cli() -> Command {
                 .required(false),
         )
         .arg(
+            Arg::new("output-file")
+                .long("output-file")
+                .value_name("FILE")
+                .help("Write headless output to FILE instead of stdout")
+                .requires("headless")
+                .required(false),
+        )
+        .arg(
             Arg::new("filter")
                 .long("filter")
                 .value_name("QUERY")
@@ -200,6 +208,16 @@ pub fn build_cli() -> Command {
                 .action(clap::ArgAction::SetTrue),
         );
 
+    #[cfg(target_os = "windows")]
+    let cmd = cmd.arg(
+        Arg::new("windows-service")
+            .long("windows-service")
+            .help("Run under the Windows Service Control Manager")
+            .action(clap::ArgAction::SetTrue)
+            .requires("headless")
+            .hide(true),
+    );
+
     #[cfg(feature = "kubernetes")]
     let cmd = cmd.arg(
         Arg::new("kubernetes")
@@ -318,6 +336,7 @@ mod tests {
         assert!(!matches.get_flag("headless"));
         assert_eq!(matches.get_one::<u64>("duration"), None);
         assert_eq!(matches.get_one::<String>("output"), None);
+        assert_eq!(matches.get_one::<String>("output-file"), None);
         assert_eq!(matches.get_one::<String>("filter"), None);
     }
 
@@ -331,6 +350,8 @@ mod tests {
                 "30",
                 "--output",
                 "jsonl",
+                "--output-file",
+                "/var/log/rustnet/snapshots.jsonl",
                 "--filter",
                 "proto:tcp process:curl",
             ])
@@ -341,6 +362,10 @@ mod tests {
         assert_eq!(
             matches.get_one::<String>("output").map(String::as_str),
             Some("jsonl")
+        );
+        assert_eq!(
+            matches.get_one::<String>("output-file").map(String::as_str),
+            Some("/var/log/rustnet/snapshots.jsonl")
         );
         assert_eq!(
             matches.get_one::<String>("filter").map(String::as_str),
@@ -367,6 +392,7 @@ mod tests {
         for args in [
             ["rustnet", "--duration", "30"],
             ["rustnet", "--output", "json"],
+            ["rustnet", "--output-file", "snapshots.jsonl"],
             ["rustnet", "--filter", "port:443"],
         ] {
             let error = build_cli()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub(crate) mod export;
 pub(crate) mod filter;
 pub mod headless;
 pub mod network;
+#[cfg(any(target_os = "windows", test))]
+pub mod service;
 pub mod ui;
 
 /// Check if the current process is running with Administrator privileges (Windows only)

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,35 @@ use std::time::Duration;
 
 fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();
+
+    #[cfg(target_os = "windows")]
+    {
+        if matches.get_flag("windows-service") {
+            rustnet_monitor::service::run_dispatcher(move |service_context| {
+                run(matches, Some(service_context))
+            })
+        } else {
+            run(matches, None)
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        run(matches)
+    }
+}
+
+fn run(
+    matches: clap::ArgMatches,
+    #[cfg(target_os = "windows")] service_context: Option<rustnet_monitor::service::ServiceContext>,
+) -> Result<()> {
     let headless = matches.get_flag("headless");
+    let headless_format = matches
+        .get_one::<String>("output")
+        .map(|value| value.parse::<rustnet_monitor::headless::HeadlessFormat>())
+        .transpose()
+        .map_err(anyhow::Error::msg)?
+        .unwrap_or_default();
 
     // Never start terminal control or privileged capture accidentally from a
     // pipe, scheduler, or service. Machine consumers must opt in explicitly.
@@ -177,6 +205,19 @@ fn main() -> Result<()> {
     } else {
         rustnet_sandbox::privdrop::resolve_drop_target()
     };
+
+    // Retain the headless output descriptor across the sandbox and uid drop.
+    // JSONL is an event stream, so reopening it appends. A JSON snapshot
+    // represents one run and replaces any previous content.
+    let mut headless_output_file = None;
+    if let Some(path) = matches.get_one::<String>("output-file") {
+        let file = open_headless_output_file(path, headless_format).map_err(|error| {
+            anyhow::anyhow!("Failed to open headless output file '{}': {}", path, error)
+        })?;
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+        chown_to_uid_drop_target(&file, uid_drop_target, "headless output", path);
+        headless_output_file = Some(file);
+    }
 
     let mut output_handles = app::AppOutputHandles::default();
 
@@ -364,6 +405,11 @@ fn main() -> Result<()> {
 
     // Before this point the platform default remains in effect, so SIGTERM or
     // SIGHUP can still terminate a slow synchronous capture/process setup.
+    #[cfg(target_os = "windows")]
+    if service_context.is_none() {
+        install_signal_handlers()?;
+    }
+    #[cfg(not(target_os = "windows"))]
     install_signal_handlers()?;
 
     // Now that the sandbox has been applied on the main thread, start the worker
@@ -372,8 +418,26 @@ fn main() -> Result<()> {
     // a compromise in a DPI parser is contained even when running as root.
     app.start_workers(worker_startup_permit)?;
 
+    #[cfg(target_os = "windows")]
+    if let Some(context) = service_context.as_ref() {
+        context.mark_running()?;
+    }
+
     if headless {
-        return run_headless(&matches, &mut app);
+        #[cfg(target_os = "windows")]
+        let shutdown_requested = service_context
+            .as_ref()
+            .map_or(&SHUTDOWN_REQUESTED, |context| context.shutdown_requested());
+        #[cfg(not(target_os = "windows"))]
+        let shutdown_requested = &SHUTDOWN_REQUESTED;
+
+        return run_headless(
+            &matches,
+            &mut app,
+            headless_format,
+            headless_output_file,
+            shutdown_requested,
+        );
     }
 
     let backend = CrosstermBackend::new(io::stdout());
@@ -392,13 +456,13 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn run_headless(matches: &clap::ArgMatches, app: &mut app::App) -> Result<()> {
-    let format = matches
-        .get_one::<String>("output")
-        .map(|value| value.parse::<rustnet_monitor::headless::HeadlessFormat>())
-        .transpose()
-        .map_err(anyhow::Error::msg)?
-        .unwrap_or_default();
+fn run_headless(
+    matches: &clap::ArgMatches,
+    app: &mut app::App,
+    format: rustnet_monitor::headless::HeadlessFormat,
+    output_file: Option<fs::File>,
+    shutdown_requested: &std::sync::atomic::AtomicBool,
+) -> Result<()> {
     let options = rustnet_monitor::headless::HeadlessOptions {
         format,
         duration: matches
@@ -406,17 +470,20 @@ fn run_headless(matches: &clap::ArgMatches, app: &mut app::App) -> Result<()> {
             .map(|seconds| Duration::from_secs(*seconds)),
         filter_query: matches.get_one::<String>("filter").cloned(),
     };
-    let outcome =
-        match rustnet_monitor::headless::run(app, io::stdout(), &options, &SHUTDOWN_REQUESTED) {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                let stop_report = app.stop();
-                if let Err(shutdown_error) = ensure_clean_shutdown(stop_report) {
-                    return Err(anyhow::anyhow!("{error}; {shutdown_error}"));
-                }
-                return Err(error);
+    let writer: Box<dyn io::Write + Send> = match output_file {
+        Some(file) => Box::new(file),
+        None => Box::new(io::stdout()),
+    };
+    let outcome = match rustnet_monitor::headless::run(app, writer, &options, shutdown_requested) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let stop_report = app.stop();
+            if let Err(shutdown_error) = ensure_clean_shutdown(stop_report) {
+                return Err(anyhow::anyhow!("{error}; {shutdown_error}"));
             }
-        };
+            return Err(error);
+        }
+    };
     ensure_clean_shutdown(outcome.stop_report)
 }
 
@@ -489,6 +556,16 @@ fn setup_logging(level: LevelFilter) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn open_headless_output_file(
+    path: impl AsRef<Path>,
+    format: rustnet_monitor::headless::HeadlessFormat,
+) -> io::Result<fs::File> {
+    match format {
+        rustnet_monitor::headless::HeadlessFormat::JsonLines => app::open_private_append_file(path),
+        rustnet_monitor::headless::HeadlessFormat::Json => app::precreate_private_file(path),
+    }
 }
 
 /// Hand an output file over to the uid-drop target.
@@ -1102,4 +1179,43 @@ fn initialize_windows_npcap() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::open_headless_output_file;
+    use rustnet_monitor::headless::HeadlessFormat;
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn headless_file_mode_matches_output_format() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "rustnet-headless-output-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+
+        let jsonl_path = dir.join("snapshots.jsonl");
+        std::fs::write(&jsonl_path, b"old\n").unwrap();
+        let mut jsonl = open_headless_output_file(&jsonl_path, HeadlessFormat::JsonLines).unwrap();
+        writeln!(jsonl, "new").unwrap();
+        jsonl.sync_all().unwrap();
+        assert_eq!(std::fs::read(&jsonl_path).unwrap(), b"old\nnew\n");
+
+        let json_path = dir.join("snapshot.json");
+        std::fs::write(&json_path, b"stale").unwrap();
+        let mut json = open_headless_output_file(&json_path, HeadlessFormat::Json).unwrap();
+        write!(json, "fresh").unwrap();
+        json.sync_all().unwrap();
+        assert_eq!(std::fs::read(&json_path).unwrap(), b"fresh");
+
+        drop(jsonl);
+        drop(json);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,0 +1,363 @@
+//! Service-host lifecycle support.
+//!
+//! The Windows backend connects this state machine to the Service Control
+//! Manager. Keeping the transitions here makes readiness and shutdown behavior
+//! testable on every development platform.
+
+use anyhow::{Result, anyhow};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[cfg(target_os = "windows")]
+pub use windows::run_dispatcher;
+
+const START_WAIT_HINT: Duration = Duration::from_secs(30);
+const STOP_WAIT_HINT: Duration = Duration::from_secs(10);
+
+/// Handle passed to the application while it runs under a service manager.
+#[derive(Clone)]
+pub struct ServiceContext {
+    lifecycle: Arc<ServiceLifecycle>,
+}
+
+impl ServiceContext {
+    /// Report that privileged setup and worker startup completed successfully.
+    pub fn mark_running(&self) -> Result<()> {
+        self.lifecycle.mark_running()
+    }
+
+    /// Shared stop condition set by Windows service control requests.
+    pub fn shutdown_requested(&self) -> &AtomicBool {
+        &self.lifecycle.shutdown_requested
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ServiceStatus {
+    StartPending {
+        checkpoint: u32,
+        wait_hint: Duration,
+    },
+    Running,
+    StopPending {
+        checkpoint: u32,
+        wait_hint: Duration,
+    },
+    Stopped {
+        failed: bool,
+    },
+}
+
+pub(crate) trait StatusSink: Send + Sync {
+    fn report(&self, status: ServiceStatus) -> Result<()>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ServicePhase {
+    Created,
+    StartPending,
+    Running,
+    StopPending,
+    Stopped,
+}
+
+pub(crate) struct ServiceLifecycle {
+    shutdown_requested: AtomicBool,
+    phase: Mutex<ServicePhase>,
+    sink: Arc<dyn StatusSink>,
+}
+
+impl ServiceLifecycle {
+    pub(crate) fn new(sink: Arc<dyn StatusSink>) -> Self {
+        Self {
+            shutdown_requested: AtomicBool::new(false),
+            phase: Mutex::new(ServicePhase::Created),
+            sink,
+        }
+    }
+
+    fn begin(&self) -> Result<()> {
+        let mut phase = self
+            .phase
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if *phase != ServicePhase::Created {
+            return Err(anyhow!("service lifecycle has already started"));
+        }
+        self.sink.report(ServiceStatus::StartPending {
+            checkpoint: 1,
+            wait_hint: START_WAIT_HINT,
+        })?;
+        *phase = ServicePhase::StartPending;
+        Ok(())
+    }
+
+    fn mark_running(&self) -> Result<()> {
+        let mut phase = self
+            .phase
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match *phase {
+            ServicePhase::StartPending if !self.shutdown_requested.load(Ordering::Acquire) => {
+                self.sink.report(ServiceStatus::Running)?;
+                *phase = ServicePhase::Running;
+                Ok(())
+            }
+            ServicePhase::StopPending => Ok(()),
+            ServicePhase::StartPending => self.report_stop_pending_locked(&mut phase),
+            ServicePhase::Running => Ok(()),
+            ServicePhase::Created => Err(anyhow!("service lifecycle has not started")),
+            ServicePhase::Stopped => Err(anyhow!("service lifecycle has already stopped")),
+        }
+    }
+
+    pub(crate) fn request_shutdown(&self) -> Result<()> {
+        self.shutdown_requested.store(true, Ordering::Release);
+        let mut phase = self
+            .phase
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match *phase {
+            ServicePhase::StartPending | ServicePhase::Running => {
+                self.report_stop_pending_locked(&mut phase)
+            }
+            ServicePhase::Created | ServicePhase::StopPending | ServicePhase::Stopped => Ok(()),
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub(crate) fn report_current(&self) -> Result<()> {
+        let phase = *self
+            .phase
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let status = match phase {
+            ServicePhase::Created => return Ok(()),
+            ServicePhase::StartPending => ServiceStatus::StartPending {
+                checkpoint: 1,
+                wait_hint: START_WAIT_HINT,
+            },
+            ServicePhase::Running => ServiceStatus::Running,
+            ServicePhase::StopPending => ServiceStatus::StopPending {
+                checkpoint: 1,
+                wait_hint: STOP_WAIT_HINT,
+            },
+            ServicePhase::Stopped => ServiceStatus::Stopped { failed: false },
+        };
+        self.sink.report(status)
+    }
+
+    fn finish(&self, failed: bool) -> Result<()> {
+        let mut phase = self
+            .phase
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !matches!(*phase, ServicePhase::StopPending | ServicePhase::Stopped) {
+            self.report_stop_pending_locked(&mut phase)?;
+        }
+        if *phase != ServicePhase::Stopped {
+            self.sink.report(ServiceStatus::Stopped { failed })?;
+            *phase = ServicePhase::Stopped;
+        }
+        Ok(())
+    }
+
+    fn report_stop_pending_locked(&self, phase: &mut ServicePhase) -> Result<()> {
+        self.sink.report(ServiceStatus::StopPending {
+            checkpoint: 1,
+            wait_hint: STOP_WAIT_HINT,
+        })?;
+        *phase = ServicePhase::StopPending;
+        Ok(())
+    }
+}
+
+pub(crate) fn run_managed<F>(lifecycle: Arc<ServiceLifecycle>, runner: F) -> Result<()>
+where
+    F: FnOnce(ServiceContext) -> Result<()>,
+{
+    lifecycle.begin()?;
+    let run_result = catch_unwind(AssertUnwindSafe(|| {
+        runner(ServiceContext {
+            lifecycle: Arc::clone(&lifecycle),
+        })
+    }))
+    .unwrap_or_else(|_| Err(anyhow!("service runner panicked")));
+    let finish_result = lifecycle.finish(run_result.is_err());
+
+    match (run_result, finish_result) {
+        (Err(run_error), Err(status_error)) => Err(anyhow!(
+            "{run_error}; failed to report final service status: {status_error}"
+        )),
+        (Err(run_error), Ok(())) => Err(run_error),
+        (Ok(()), Err(status_error)) => Err(status_error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    #[derive(Default)]
+    struct RecordingSink {
+        statuses: Mutex<Vec<ServiceStatus>>,
+    }
+
+    impl RecordingSink {
+        fn statuses(&self) -> Vec<ServiceStatus> {
+            self.statuses
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+    }
+
+    impl StatusSink for RecordingSink {
+        fn report(&self, status: ServiceStatus) -> Result<()> {
+            self.statuses
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(status);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn successful_run_reports_full_lifecycle() {
+        let sink = Arc::new(RecordingSink::default());
+        let lifecycle = Arc::new(ServiceLifecycle::new(sink.clone()));
+
+        run_managed(lifecycle, |context| context.mark_running()).unwrap();
+
+        assert_eq!(
+            sink.statuses(),
+            vec![
+                ServiceStatus::StartPending {
+                    checkpoint: 1,
+                    wait_hint: START_WAIT_HINT,
+                },
+                ServiceStatus::Running,
+                ServiceStatus::StopPending {
+                    checkpoint: 1,
+                    wait_hint: STOP_WAIT_HINT,
+                },
+                ServiceStatus::Stopped { failed: false },
+            ]
+        );
+    }
+
+    #[test]
+    fn stop_during_startup_skips_running_state() {
+        let sink = Arc::new(RecordingSink::default());
+        let lifecycle = Arc::new(ServiceLifecycle::new(sink.clone()));
+
+        run_managed(lifecycle, |context| {
+            context.lifecycle.request_shutdown()?;
+            context.mark_running()?;
+            assert!(context.shutdown_requested().load(Ordering::Acquire));
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            sink.statuses(),
+            vec![
+                ServiceStatus::StartPending {
+                    checkpoint: 1,
+                    wait_hint: START_WAIT_HINT,
+                },
+                ServiceStatus::StopPending {
+                    checkpoint: 1,
+                    wait_hint: STOP_WAIT_HINT,
+                },
+                ServiceStatus::Stopped { failed: false },
+            ]
+        );
+    }
+
+    #[test]
+    fn runner_failure_is_reflected_in_stopped_status() {
+        let sink = Arc::new(RecordingSink::default());
+        let lifecycle = Arc::new(ServiceLifecycle::new(sink.clone()));
+
+        let error = run_managed(lifecycle, |context| {
+            context.mark_running()?;
+            Err(anyhow!("capture failed"))
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("capture failed"));
+        assert_eq!(
+            sink.statuses(),
+            vec![
+                ServiceStatus::StartPending {
+                    checkpoint: 1,
+                    wait_hint: START_WAIT_HINT,
+                },
+                ServiceStatus::Running,
+                ServiceStatus::StopPending {
+                    checkpoint: 1,
+                    wait_hint: STOP_WAIT_HINT,
+                },
+                ServiceStatus::Stopped { failed: true },
+            ]
+        );
+    }
+
+    #[test]
+    fn runner_panic_is_reflected_in_stopped_status() {
+        let sink = Arc::new(RecordingSink::default());
+        let lifecycle = Arc::new(ServiceLifecycle::new(sink.clone()));
+
+        let error = run_managed(lifecycle, |context| {
+            context.mark_running()?;
+            panic!("boom")
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("service runner panicked"));
+        assert_eq!(
+            sink.statuses(),
+            vec![
+                ServiceStatus::StartPending {
+                    checkpoint: 1,
+                    wait_hint: START_WAIT_HINT,
+                },
+                ServiceStatus::Running,
+                ServiceStatus::StopPending {
+                    checkpoint: 1,
+                    wait_hint: STOP_WAIT_HINT,
+                },
+                ServiceStatus::Stopped { failed: true },
+            ]
+        );
+    }
+
+    #[test]
+    fn duplicate_stop_requests_are_idempotent() {
+        let sink = Arc::new(RecordingSink::default());
+        let lifecycle = Arc::new(ServiceLifecycle::new(sink.clone()));
+
+        run_managed(lifecycle, |context| {
+            context.mark_running()?;
+            context.lifecycle.request_shutdown()?;
+            context.lifecycle.request_shutdown()
+        })
+        .unwrap();
+
+        assert_eq!(
+            sink.statuses()
+                .iter()
+                .filter(|status| matches!(status, ServiceStatus::StopPending { .. }))
+                .count(),
+            1
+        );
+    }
+}

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -1,0 +1,250 @@
+//! Windows Service Control Manager adapter.
+
+use super::{ServiceContext, ServiceLifecycle, ServiceStatus, StatusSink, run_managed};
+use anyhow::{Context, Result, anyhow};
+use std::ffi::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::mpsc::{SyncSender, sync_channel};
+use std::sync::{Arc, Mutex};
+use windows::Win32::Foundation::{
+    ERROR_CALL_NOT_IMPLEMENTED, ERROR_SERVICE_SPECIFIC_ERROR, NO_ERROR,
+};
+use windows::Win32::System::Services::{
+    RegisterServiceCtrlHandlerExW, SERVICE_ACCEPT_PRESHUTDOWN, SERVICE_ACCEPT_SHUTDOWN,
+    SERVICE_ACCEPT_STOP, SERVICE_CONTROL_INTERROGATE, SERVICE_CONTROL_PRESHUTDOWN,
+    SERVICE_CONTROL_SHUTDOWN, SERVICE_CONTROL_STOP, SERVICE_RUNNING, SERVICE_START_PENDING,
+    SERVICE_STATUS, SERVICE_STATUS_HANDLE, SERVICE_STOP_PENDING, SERVICE_STOPPED,
+    SERVICE_TABLE_ENTRYW, SERVICE_WIN32_OWN_PROCESS, SetServiceStatus, StartServiceCtrlDispatcherW,
+};
+use windows::core::{PWSTR, w};
+
+const SERVICE_NAME: &str = "Rustnet";
+
+type ServiceRunner = Box<dyn FnOnce(ServiceContext) -> Result<()> + Send + 'static>;
+
+#[derive(Default)]
+struct DispatchSlot {
+    runner: Option<ServiceRunner>,
+    result_sender: Option<SyncSender<Result<()>>>,
+}
+
+static DISPATCH_SLOT: Mutex<DispatchSlot> = Mutex::new(DispatchSlot {
+    runner: None,
+    result_sender: None,
+});
+
+/// Connect the current process to the Windows Service Control Manager.
+///
+/// The runner must call [`ServiceContext::mark_running`] after privileged
+/// setup and application worker startup complete. It should pass
+/// [`ServiceContext::shutdown_requested`] to the headless run loop.
+pub fn run_dispatcher<F>(runner: F) -> Result<()>
+where
+    F: FnOnce(ServiceContext) -> Result<()> + Send + 'static,
+{
+    let (result_sender, result_receiver) = sync_channel(1);
+    {
+        let mut slot = DISPATCH_SLOT
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if slot.runner.is_some() || slot.result_sender.is_some() {
+            return Err(anyhow!("Windows service dispatcher is already active"));
+        }
+        slot.runner = Some(Box::new(runner));
+        slot.result_sender = Some(result_sender);
+    }
+
+    let mut service_name: Vec<u16> = SERVICE_NAME.encode_utf16().chain(Some(0)).collect();
+    let dispatch_table = [
+        SERVICE_TABLE_ENTRYW {
+            lpServiceName: PWSTR(service_name.as_mut_ptr()),
+            lpServiceProc: Some(service_main),
+        },
+        SERVICE_TABLE_ENTRYW::default(),
+    ];
+
+    // SAFETY: the table and its UTF-16 service name remain alive until the
+    // dispatcher returns, and the second entry is the required null sentinel.
+    if let Err(error) = unsafe { StartServiceCtrlDispatcherW(dispatch_table.as_ptr()) } {
+        clear_dispatch_slot();
+        return Err(anyhow!(error)).context("failed to connect to the Windows service dispatcher");
+    }
+
+    result_receiver
+        .recv()
+        .context("Windows service entry point exited without a result")?
+}
+
+fn clear_dispatch_slot() {
+    let mut slot = DISPATCH_SLOT
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    slot.runner = None;
+    slot.result_sender = None;
+}
+
+unsafe extern "system" fn service_main(_argument_count: u32, _arguments: *mut PWSTR) {
+    let (runner, result_sender) = {
+        let mut slot = DISPATCH_SLOT
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (slot.runner.take(), slot.result_sender.take())
+    };
+
+    let Some(runner) = runner else {
+        return;
+    };
+    let result = catch_unwind(AssertUnwindSafe(|| run_service(runner)))
+        .unwrap_or_else(|_| Err(anyhow!("Windows service runner panicked")));
+    if let Some(result_sender) = result_sender {
+        let _ = result_sender.send(result);
+    }
+}
+
+fn run_service(runner: ServiceRunner) -> Result<()> {
+    let status_sink = Arc::new(WindowsStatusSink::default());
+    let lifecycle = Arc::new(ServiceLifecycle::new(status_sink.clone()));
+    // Keep one process-lifetime owner for the callback context. A control
+    // handler may still be returning while the main service thread reports
+    // STOPPED, so reclaiming this allocation here could race that callback.
+    let lifecycle_context = Arc::into_raw(Arc::clone(&lifecycle));
+    let context = lifecycle_context.cast::<c_void>();
+
+    // SAFETY: the callback context has a process-lifetime Arc owner and the
+    // service name is a statically allocated, null-terminated UTF-16 string.
+    let status_handle = unsafe {
+        RegisterServiceCtrlHandlerExW(w!("Rustnet"), Some(control_handler), Some(context))
+    };
+    let status_handle = match status_handle {
+        Ok(handle) => handle,
+        Err(error) => {
+            // SAFETY: registration failed, so the SCM cannot retain or use the
+            // callback context and this is still the sole raw Arc owner.
+            drop(unsafe { Arc::from_raw(lifecycle_context) });
+            return Err(anyhow!(error))
+                .context("failed to register the Windows service control handler");
+        }
+    };
+    status_sink.set_handle(status_handle);
+
+    run_managed(lifecycle, runner)
+}
+
+unsafe extern "system" fn control_handler(
+    control: u32,
+    _event_type: u32,
+    _event_data: *mut c_void,
+    context: *mut c_void,
+) -> u32 {
+    if context.is_null() {
+        return ERROR_CALL_NOT_IMPLEMENTED.0;
+    }
+    // SAFETY: `context` points to the process-lifetime `ServiceLifecycle` Arc
+    // owner created by `run_service`.
+    let lifecycle = unsafe { &*context.cast::<ServiceLifecycle>() };
+
+    let result = match control {
+        SERVICE_CONTROL_STOP | SERVICE_CONTROL_SHUTDOWN | SERVICE_CONTROL_PRESHUTDOWN => {
+            lifecycle.request_shutdown()
+        }
+        SERVICE_CONTROL_INTERROGATE => lifecycle.report_current(),
+        _ => return ERROR_CALL_NOT_IMPLEMENTED.0,
+    };
+    if result.is_ok() {
+        NO_ERROR.0
+    } else {
+        ERROR_SERVICE_SPECIFIC_ERROR.0
+    }
+}
+
+#[derive(Default)]
+struct WindowsStatusSink {
+    handle: Mutex<Option<usize>>,
+}
+
+impl WindowsStatusSink {
+    fn set_handle(&self, handle: SERVICE_STATUS_HANDLE) {
+        *self
+            .handle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(handle.0 as usize);
+    }
+}
+
+impl StatusSink for WindowsStatusSink {
+    fn report(&self, status: ServiceStatus) -> Result<()> {
+        let handle_value = self
+            .handle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .ok_or_else(|| anyhow!("Windows service status handle is unavailable"))?;
+        let handle = SERVICE_STATUS_HANDLE(handle_value as *mut c_void);
+        let status = windows_status(status);
+        // SAFETY: the status handle was returned by
+        // RegisterServiceCtrlHandlerExW and the status value lives for the call.
+        unsafe { SetServiceStatus(handle, &raw const status) }
+            .context("failed to report Windows service status")
+    }
+}
+
+fn windows_status(status: ServiceStatus) -> SERVICE_STATUS {
+    let (current_state, controls_accepted, exit_code, service_exit_code, checkpoint, wait_hint) =
+        match status {
+            ServiceStatus::StartPending {
+                checkpoint,
+                wait_hint,
+            } => (
+                SERVICE_START_PENDING,
+                0,
+                NO_ERROR.0,
+                0,
+                checkpoint,
+                wait_hint,
+            ),
+            ServiceStatus::Running => (
+                SERVICE_RUNNING,
+                SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN | SERVICE_ACCEPT_PRESHUTDOWN,
+                NO_ERROR.0,
+                0,
+                0,
+                std::time::Duration::ZERO,
+            ),
+            ServiceStatus::StopPending {
+                checkpoint,
+                wait_hint,
+            } => (
+                SERVICE_STOP_PENDING,
+                0,
+                NO_ERROR.0,
+                0,
+                checkpoint,
+                wait_hint,
+            ),
+            ServiceStatus::Stopped { failed: false } => (
+                SERVICE_STOPPED,
+                0,
+                NO_ERROR.0,
+                0,
+                0,
+                std::time::Duration::ZERO,
+            ),
+            ServiceStatus::Stopped { failed: true } => (
+                SERVICE_STOPPED,
+                0,
+                ERROR_SERVICE_SPECIFIC_ERROR.0,
+                1,
+                0,
+                std::time::Duration::ZERO,
+            ),
+        };
+
+    SERVICE_STATUS {
+        dwServiceType: SERVICE_WIN32_OWN_PROCESS,
+        dwCurrentState: current_state,
+        dwControlsAccepted: controls_accepted,
+        dwWin32ExitCode: exit_code,
+        dwServiceSpecificExitCode: service_exit_code,
+        dwCheckPoint: checkpoint,
+        dwWaitHint: wait_hint.as_millis().try_into().unwrap_or(u32::MAX),
+    }
+}

--- a/tests/non_tty_startup.rs
+++ b/tests/non_tty_startup.rs
@@ -36,12 +36,40 @@ fn help_remains_available_without_a_terminal() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--headless"));
     assert!(stdout.contains("--output <FORMAT>"));
+    assert!(stdout.contains("--output-file <FILE>"));
     // Existing interactive controls remain part of the default frontend after
     // adding headless mode. Help exits before privilege or capture setup.
     assert!(stdout.contains("--interface <INTERFACE>"));
     assert!(stdout.contains("--refresh-interval <MILLISECONDS>"));
     assert!(stdout.contains("--no-color"));
     assert!(stdout.contains("--theme <PRESET>"));
+}
+
+#[test]
+fn output_file_requires_explicit_headless_mode_before_startup() {
+    let path = std::env::temp_dir().join(format!(
+        "rustnet-output-file-cli-{}.jsonl",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rustnet"))
+        .arg("--output-file")
+        .arg(&path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("rustnet should reject output files outside headless mode");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        !path.exists(),
+        "argument validation must happen before file creation"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--headless"), "unexpected stderr: {stderr}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add secure `--output-file` support and Windows SCM lifecycle integration
- ship inactive systemd, launchd, Windows, FreeBSD, and Compose service packaging
- add package and CI validation plus service guides in all supported languages

## Validation
- `cargo test --locked --workspace --all-targets --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `scripts/check-service-packaging.sh`
- rebuilt DEB and RPM packages